### PR TITLE
[REM] accounting: removing none existing module

### DIFF
--- a/accounting/fiscal_localizations/localizations/france.rst
+++ b/accounting/fiscal_localizations/localizations/france.rst
@@ -171,6 +171,18 @@ Odoo absolves itself of all and any responsibility in case of changes
 in the module’s functions caused by 3rd party applications not certified by Odoo.
 
 
+Re sequencing of the invoices
+-----------------------------
+
+It remains possible to re sequence the invoices but with some restrictions:
+
+1. The feature will not work when entries are previous to a lock date.
+2. The feature will not work if the sequence is inconsistent with the month of the entry.
+3. It will not work if the sequence leads to a duplicate.
+4. The order of the invoice will remain unchanged.
+5. It is useful for people who use a numbering from another software and who want to continue the current year without starting over from the beginning.
+
+
 More Information
 ----------------
 

--- a/accounting/fiscal_localizations/localizations/france.rst
+++ b/accounting/fiscal_localizations/localizations/france.rst
@@ -59,11 +59,8 @@ In case of non-conformity, your company risks a fine of €7,500.
 
 To get the certification just follow the following steps:
 
-* Install the anti-fraud module fitting your Odoo environment from the 
-  *Apps* menu:
-
-  * if you use Odoo Point of Sale: *l10n_fr_pos_cert*: France - VAT Anti-Fraud Certification for Point of Sale (CGI 286 I-3 bis)
-  * in any other case: *l10n_fr_certification*: France - VAT Anti-Fraud Certification (CGI 286 I-3 bis)
+* If you use Odoo Point of Sale, install the anti-fraud module *l10n_fr_pos_cert*: France - VAT Anti-Fraud Certification for Point of Sale (CGI 286 I-3 bis) 
+  fitting your Odoo environment from the *Apps* menu.
 
 * Make sure a country is set on your company, otherwise your entries won’t be 
   encrypted for the inalterability check. To edit your company’s data, 


### PR DESCRIPTION
The module ' l10n_fr_certification ' has been integrate in the account module.
so this is not installable anymore. Removed this but kept the explanation
for the POS.
opw-2389435