### PR TITLE
No Project/Tasks for Helpdesk Tickets as of v14

### DIFF
--- a/helpdesk/timesheet_and_invoice/reinvoice_from_project.rst
+++ b/helpdesk/timesheet_and_invoice/reinvoice_from_project.rst
@@ -24,10 +24,6 @@ Create a sales order and an invoice
 Now, once you have recorded the time you spent on the helpdesk ticket, under the *Timesheets* tab,
 access the task clicking on its name.
 
-.. image:: media/reinvoice_time2.png
-   :align: center
-   :alt: Sales Order from a task in Odoo Helpdesk
-
 *Create Sales Order* and proceed to create the invoice.
 
 .. image:: media/reinvoice_time3.png


### PR DESCRIPTION
Ticket with github request saying not having Project/Tasks in Helpdesk tickets is now expected behavior as of v14: https://www.odoo.com/web#action=333&active_id=49&cids=3&id=2454453&menu_id=4720&model=project.task&view_type=form

Therefore, we should change the picture I took off, as it shows the task field and project field in it and is misleading customers.