### PR TITLE
[REM/ADD] account: remove none relevant module + re sequencing restriction

### DIFF
--- a/content/applications/finance/accounting/fiscal_localizations/localizations/france.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/france.rst
@@ -59,11 +59,9 @@ In case of non-conformity, your company risks a fine of €7,500.
 
 To get the certification just follow the following steps:
 
-* Install the anti-fraud module fitting your Odoo environment from the
-  *Apps* menu:
-
-  * if you use Odoo Point of Sale: *l10n_fr_pos_cert*: France - VAT Anti-Fraud Certification for Point of Sale (CGI 286 I-3 bis)
-  * in any other case: *l10n_fr_certification*: France - VAT Anti-Fraud Certification (CGI 286 I-3 bis)
+* If you use **Odoo Point of Sale**, install the **France - VAT Anti-Fraud Certification for Point
+  of Sale (CGI 286 I-3 bis)** module by going to :menuselection:`Apps`, removing the *Apps* filter,
+  then searching for *l10n_fr_pos_cert*, and installing the module.
 
 * Make sure a country is set on your company, otherwise your entries won’t be
   encrypted for the inalterability check. To edit your company’s data,

--- a/content/applications/finance/accounting/receivables/customer_invoices/overview.rst
+++ b/content/applications/finance/accounting/receivables/customer_invoices/overview.rst
@@ -135,3 +135,15 @@ Some specific modules are also able to generate draft invoices:
 -  **membership**: invoice your members every year
 
 -  **repairs**: invoice your after-sale services
+
+Resequencing of the invoices
+----------------------------
+
+It remains possible to resequence the invoices but with some restrictions:
+
+#. The feature does not work when entries are previous to a lock date.
+#. The feature does not work if the sequence is inconsistent with the month of the entry.
+#. It does not work if the sequence leads to a duplicate.
+#. The order of the invoice remains unchanged.
+#. It is useful for people who use a numbering from another software and who want to continue the 
+   current year without starting over from the beginning.


### PR DESCRIPTION
Rebase of 825

commit ef4209d2763de607bd44ae937ce7266677bd69f9
The module ' l10n_fr_certification ' has been integrate in the account module.
so this is not installable anymore. Removed this but kept the explanation
for the POS.

commit a98d026bf8cea20410b4a3f074ad25ab48e0e93e
The re sequencing feature done by WAN is perturbing our french customer
In order to explain the reason the feature is, let's state what has been
decided by the product owner (TSB)

opw-2389435