### PR TITLE
[FIX] extensions: support parallel read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Pass WORKERS=auto for parallel build
 ifndef WORKERS
-  WORKERS = 1
+  WORKERS = auto
 endif
 
 SPHINX_BUILD   = sphinx-build
@@ -67,7 +67,7 @@ extensions/odoo_theme/static/style.css: extensions/odoo_theme/static/style.scss 
 
 #=== Development and debugging rules ===#
 
-fast: SPHINXOPTS += -A collapse_menu=True -j auto
+fast: SPHINXOPTS += -A collapse_menu=True
 fast: html
 
 static: extensions/odoo_theme/static/style.css

--- a/extensions/autodoc_placeholder/__init__.py
+++ b/extensions/autodoc_placeholder/__init__.py
@@ -21,6 +21,6 @@ def setup(app):
     directives.register_directive('autoattribute', PlaceHolder)
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }

--- a/extensions/embedded_video/__init__.py
+++ b/extensions/embedded_video/__init__.py
@@ -66,6 +66,6 @@ def setup(app):
     directives.register_directive('vimeo', Vimeo)
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }

--- a/extensions/exercise_admonition/__init__.py
+++ b/extensions/exercise_admonition/__init__.py
@@ -21,7 +21,7 @@ def setup(app):
     ))
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }
 

--- a/extensions/github_link/__init__.py
+++ b/extensions/github_link/__init__.py
@@ -75,7 +75,7 @@ def setup(app):
     app.config.linkcode_resolve = linkcode_resolve
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }
 

--- a/extensions/html_domain/__init__.py
+++ b/extensions/html_domain/__init__.py
@@ -40,7 +40,7 @@ def setup(app):
         addnode(app, node, name)
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }
 
@@ -183,3 +183,11 @@ class HtmlDomain(Domain):
         'var': makerole(var),
         'samp': makerole(samp),
     }
+
+    def merge_domaindata(self, docnames, otherdata) -> None:
+        """Merge in data regarding *docnames* from a different domaindata
+        inventory (coming from a subprocess in parallel builds).
+        """
+        # This extension doesn't store any data on the env
+        # and therefore doesn't need to support this method.
+        pass

--- a/extensions/odoo_theme/__init__.py
+++ b/extensions/odoo_theme/__init__.py
@@ -16,7 +16,7 @@ def setup(app):
     app.add_js_file('js/page_toc.js')
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }
 

--- a/extensions/redirects/__init__.py
+++ b/extensions/redirects/__init__.py
@@ -64,6 +64,6 @@ def setup(app):
     app.connect('builder-inited', generate_redirects)
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }

--- a/extensions/switcher/__init__.py
+++ b/extensions/switcher/__init__.py
@@ -13,7 +13,7 @@ def setup(app):
     app.connect('env-updated', add_statics)
 
     return {
-        'parallel_read_safe': False,
+        'parallel_read_safe': True,
         'parallel_write_safe': True
     }
 


### PR DESCRIPTION
Now that patchqueue was removed, we can consider supporting the parallel 
read with our local extensions.

Since we only have basic extensions, not storing any data on the build 
environment, the change mainly consists of specifying the extensions as 
parallelizable.

The only specific case is the html domain, since the base html domain 
requires the support of the method merge_domaindata in parallel read 
mode.  Since we do not need to share anything between the envs for this 
extension, we can simply ignore the method.