### PR TITLE
[FIX] theme: hide "Try Odoo" button on iOS

### DIFF
--- a/extensions/odoo_theme/layout_templates/homepage.html
+++ b/extensions/odoo_theme/layout_templates/homepage.html
@@ -4,7 +4,7 @@
             <h2 class="text-white">Odoo Documentation</h2>
             <p class="text-white">The comprehensive guide for Odoo users. Easily find the tutorial and helpful tips that suit your needs.</p>
             <div class="mt-3">
-                <a href="https://odoo.com/trial" class="btn btn-primary mb-2">Try Odoo for FREE</a>
+                <a href="https://odoo.com/trial" class="btn btn-primary mb-2 o-hidden-ios">Try Odoo for FREE</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
According to the app-store guidelines we are not allowed to sell from
the iOS app.

Our updates are currently blocked because of this.
In the rush, we have no choice but to hide "Try Odoo for FREE" buttons
that redirects the customer to the subscription page.
This is unfortunately not allowed by Apple who consider this
as "In-App Purchase".

Note that in the old documentation (https://www.odoo.com/documentation/user),
this button was located in the header which was hidden in the app
(see related PR).

Source: https://developer.apple.com/app-store/review/guidelines/#business

Related PR:
odoo/mobile-ios#102
odoo/mobile-ios#103

Task-id: 2483253