### PR TITLE
[IMP] mail: add documentation about the SSL SMTP authentication

### DIFF
--- a/content/developer/cli.rst
+++ b/content/developer/cli.rst
@@ -292,9 +292,11 @@ Emails
 
 .. option:: --from-filter <address or domain>
 
-    Email address or domain that the mail server is configured for. If the 
-    email of the sender does not match this value, it might be encapsulated 
-    into ``mail.default.from``.
+    Define which email address the SMTP configuration will apply to. The field can be a domain name
+    or an entire email address, or it can remain empty. If the sender's email address does not
+    match this set filter, then the email will be encapsulated using a combination of the two
+    system parameters: ``mail.default.from`` and ``mail.catchall.domain``. For example, "Admin"
+    <admin\@example.com> => "Admin" <notifications\@mycompany.com>.
 
 .. option:: --smtp <server>
 
@@ -316,11 +318,12 @@ Emails
 
 .. option:: --smtp-ssl-certificate-filename <path/to/cert.pem>
 
-    SSL certificate used for SMTP authentication
+    An SSL certificate is to be used for authentication. If set, then `smtp-ssl-private-key` is
+    required.
 
 .. option:: --smtp-ssl-private-key-filename <path/to/key.pem>
 
-    SSL private key used for SMTP authentication
+    An SSL private key is used for authentication. If set, then `smtp-ssl-certificate` is required.
 
 .. _reference/cmdline/server/internationalisation:
 


### PR DESCRIPTION
Purpose
=======
Add the documentation about the SSL SMTP authentication
(2 new binary arguments) and also about the new from
filter binary argument.

The goal of those new arguments is to improve the score
of the emails sent by Odoo.

Task 2367946
See odoo/odoo/pull/61853
See odoo/upgrade/pull/1903