### PR TITLE
[FIX] redirects: odoo_sh documentation page

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -30,4 +30,5 @@ contributing/documentation/guidelines.rst contributing/documentation/rst_guideli
 
 # Redirections introduced in 12.0 :
 
+administration/odoo_sh/documentation.rst administration/odoo_sh.rst # moved during doc-apocalypse (#945)
 support/user_doc.rst contributing/documentation/introduction_guide.rst  # removed in forward-port of #544 (b109c3af)


### PR DESCRIPTION
This redirection was seemingly forgotten in the nginx redirections deployed online,
we will cover it through the redirects file then.