### PR TITLE
[FIX] orm: readonly is True for related fields.

### DIFF
--- a/content/developer/reference/orm.rst
+++ b/content/developer/reference/orm.rst
@@ -351,6 +351,17 @@ Add the attribute ``store=True`` to make it stored, just like computed
 fields. Related fields are automatically recomputed when their
 dependencies are modified.
 
+.. tip::
+
+    You can specify precise field dependencies if you don't want
+    the related field to be recomputed on any dependency change::
+
+        nickname = fields.Char(
+            related='partner_id.name', store=True,
+            depends=['partner_id'])
+        # The nickname will only be recomputed when the partner_id
+        # is modified, not when the name is modified on the partner.
+
 .. warning::
 
     You cannot chain :class:`~odoo.fields.Many2many` or :class:`~odoo.fields.One2many` fields in ``related`` fields dependencies.

--- a/content/developer/reference/orm.rst
+++ b/content/developer/reference/orm.rst
@@ -334,18 +334,22 @@ relational fields and reading a field on the reached model. The complete
 sequence of fields to traverse is specified by the ``related`` attribute.
 
 Some field attributes are automatically copied from the source field if
-they are not redefined: ``string``, ``help``, ``readonly``, ``required`` (only
+they are not redefined: ``string``, ``help``, ``required`` (only
 if all fields in the sequence are required), ``groups``, ``digits``, ``size``,
 ``translate``, ``sanitize``, ``selection``, ``comodel_name``, ``domain``,
 ``context``. All semantic-free attributes are copied from the source
 field.
 
-By default, the values of related fields are not stored to the database.
+By default, related fields are:
+
+* not stored
+* not copied
+* readonly
+* computed in superuser mode
+
 Add the attribute ``store=True`` to make it stored, just like computed
 fields. Related fields are automatically recomputed when their
 dependencies are modified.
-
-.. note:: The related fields are computed in sudo mode.
 
 .. warning::
 


### PR DESCRIPTION
Since Odoo 12: https://github.com/odoo/odoo/commit/52a8ed3c0c72b21baf589bc9b91a030d9da661a8

Also this adds a note about `copy` attribute.