### PR TITLE
[FIX] odoo_theme: unclickable :show-content: pages in global toctree

### DIFF
--- a/extensions/odoo_theme/__init__.py
+++ b/extensions/odoo_theme/__init__.py
@@ -59,16 +59,23 @@ def resolve(old_resolve, tree, docname, *args, **kwargs):
                 _update_toctree_nodes(_subnode)
 
     def _get_docname(_node):
-        """
-        docname = a/b/c/the_page_being_rendered
+        """ Return the docname of the targeted document.
+
+        docname = some_common_root/foo/bar/the_page_being_rendered
         _ref = ../../contributing/documentation
         _path_parts = ['..', '..', 'contributing', 'documentation']
-        _res = ['a', 'contributing', 'documentation']
-        _docname = a/contributing/documentation
+        _res = ['some_common_root', 'contributing', 'documentation']
+        _docname = some_common_root/contributing/documentation
+
+        :return: The docname of the document targeted by `_node`, i.e. the relative path from the
+                 documentation source directory (the `content/` directory)
+        :rtype: str
         """
         _ref = _node['refuri'].replace('.html', '')
         _parent_directory_occurrences = _ref.count('..')
-        if not _parent_directory_occurrences:  # The ref is already the docname
+        if not _parent_directory_occurrences and '/' not in docname:
+            # The current document is at the root of the documentation source directory
+            # (e.g. docname == 'index'|'applications'|...). i.e., the ref is already the docname.
             _docname = _ref
         else:
             _path_parts = _ref.split('/')


### PR DESCRIPTION
When navigating the themes tutorial (developer/howto/themes), the rdtraining page wasn't clickable
in the global toc, even though it was specified as :show-content: (note that the rdtraining was only added in 14+).

The current heuristic extracting the pagename from a toctree node wasn't considering the current depth
if the page referenced by the toctree node was in the same folder than the current page.

Explanation:

We are computing the toctree for the page developer/howtos/themes.
One of the toctree nodes references the rdtraining page, with a relative link,
i.e. `rdtraining.html`.

We were wrongfully looking for show_content in the metadata of the `rdtraining` page,
instead of `developer/howtos/rdtraining`, since we didn't consider the current document
depth when the reference didn't contain any `/`.

This commit ensures that if the current document has a depth > 1, this depth is
currently considered, even for links referencing documents in the same folder.

Task-Id: 2538297