### PR TITLE
[IMP] rdtraining: no need to add web to dependencies

### DIFF
--- a/content/developer/howtos/rdtraining/03_newapp.rst
+++ b/content/developer/howtos/rdtraining/03_newapp.rst
@@ -82,7 +82,7 @@ be uninstalled**. Think about your favorite Linux distribution package manager
     - ``/home/$USER/src/custom/estate/__manifest__.py``
 
     The ``__manifest__.py`` file should only define the name and the dependencies of our modules.
-    Two framework modules are necessary: ``base`` and ``web``.
+    The only necessary framework module for now is ``base``.
 
 
 Restart the Odoo server and add the ``custom`` folder to the ``addons-path``:


### PR DESCRIPTION
`web` is not used directly and is installed automatically anyway.
Having both `web` and `base` looks excessively, so coaches usually ask to delete
`base`. But more correct solution is adding `base` only. Completly skipping
dependencies is not good either -- see 76e05cc