### PR TITLE
[FIX] Indentation was inconsistent in nginx config

### DIFF
--- a/content/administration/deployment/deploy.rst
+++ b/content/administration/deployment/deploy.rst
@@ -296,59 +296,59 @@ in ``/etc/nginx/sites-enabled/odoo.conf`` set:
 
   #odoo server
   upstream odoo {
-   server 127.0.0.1:8069;
+    server 127.0.0.1:8069;
   }
   upstream odoochat {
-   server 127.0.0.1:8072;
+    server 127.0.0.1:8072;
   }
 
   # http -> https
   server {
-     listen 80;
-     server_name odoo.mycompany.com;
-     rewrite ^(.*) https://$host$1 permanent;
+    listen 80;
+    server_name odoo.mycompany.com;
+    rewrite ^(.*) https://$host$1 permanent;
   }
 
   server {
-   listen 443;
-   server_name odoo.mycompany.com;
-   proxy_read_timeout 720s;
-   proxy_connect_timeout 720s;
-   proxy_send_timeout 720s;
+    listen 443;
+    server_name odoo.mycompany.com;
+    proxy_read_timeout 720s;
+    proxy_connect_timeout 720s;
+    proxy_send_timeout 720s;
 
-   # Add Headers for odoo proxy mode
-   proxy_set_header X-Forwarded-Host $host;
-   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-   proxy_set_header X-Forwarded-Proto $scheme;
-   proxy_set_header X-Real-IP $remote_addr;
+    # Add Headers for odoo proxy mode
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
 
-   # SSL parameters
-   ssl on;
-   ssl_certificate /etc/ssl/nginx/server.crt;
-   ssl_certificate_key /etc/ssl/nginx/server.key;
-   ssl_session_timeout 30m;
-   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-   ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
-   ssl_prefer_server_ciphers on;
+    # SSL parameters
+    ssl on;
+    ssl_certificate /etc/ssl/nginx/server.crt;
+    ssl_certificate_key /etc/ssl/nginx/server.key;
+    ssl_session_timeout 30m;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+    ssl_prefer_server_ciphers on;
 
-   # log
-   access_log /var/log/nginx/odoo.access.log;
-   error_log /var/log/nginx/odoo.error.log;
+    # log
+    access_log /var/log/nginx/odoo.access.log;
+    error_log /var/log/nginx/odoo.error.log;
 
-   # Redirect longpoll requests to odoo longpolling port
-   location /longpolling {
-   proxy_pass http://odoochat;
-   }
+    # Redirect longpoll requests to odoo longpolling port
+    location /longpolling {
+      proxy_pass http://odoochat;
+    }
 
-   # Redirect requests to odoo backend server
-   location / {
-     proxy_redirect off;
-     proxy_pass http://odoo;
-   }
+    # Redirect requests to odoo backend server
+    location / {
+      proxy_redirect off;
+      proxy_pass http://odoo;
+    }
 
-   # common gzip
-   gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;
-   gzip on;
+    # common gzip
+    gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;
+    gzip on;
   }
 
 Odoo as a WSGI Application


### PR DESCRIPTION
All indentation is now consistent to two spaces.

This needs to be forward-ported to 13 and 14.

<table>
<th>Before
<th>After
<tr>
	<td><img width="950" alt="before" src="https://user-images.githubusercontent.com/75302079/120795879-5c2a8e80-c53a-11eb-8920-ed45968dbdcc.png">
	<td><img width="940" alt="after" src="https://user-images.githubusercontent.com/75302079/120795947-71072200-c53a-11eb-868e-0d20b6c3df64.png">

</table>


