### PR TITLE
[IMP] dev/howtos: hide deprecated and outdated tutorial

### DIFF
--- a/content/developer/howtos.rst
+++ b/content/developer/howtos.rst
@@ -9,6 +9,5 @@ Tutorials
     howtos/themes
     howtos/website
     howtos/backend
-    howtos/web
     howtos/profilecode
     howtos/company

--- a/content/developer/howtos/web.rst
+++ b/content/developer/howtos/web.rst
@@ -1,11 +1,14 @@
+:orphan:
 
 =============================
 Customizing the web client
 =============================
 
-Note: this section is really really out of date. It will be updated someday,
-but meanwhile, this tutorial will probably be frustrating to follow, since it
-was written a long time ago.
+.. note::
+
+    this section is really really out of date. It will be updated someday,
+    but meanwhile, this tutorial will probably be frustrating to follow, since it
+    was written a long time ago.
 
 
 .. highlight:: javascript


### PR DESCRIPTION
Now that the new rd&training is deployed, we shouldn't highlight this page anymore

Fixes #1017