### PR TITLE
[IMP] l10n_mx: Add extra paragraph in Warning (MXN currency)

### DIFF
--- a/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
@@ -119,9 +119,10 @@ In the resulting form, put your full address (including zip code), RFC (VAT numb
 the data.
 
 .. important::
-   From a legal point of view, a Mexican company must use the local currency (MXN). Therefore,
-   Odoo does not provide features to manage an alternative configuration. If you want
-   to manage another currency, let MXN be the default currency and use price list instead.
+   From a legal point of view, a Mexican company must use the local currency (MXN). Therefore, Odoo
+   does not provide features to manage an alternative configuration. If you want to manage another
+   currency, let MXN be the default currency and use a :doc:`pricelist
+   </applications/sales/sales/products_prices/prices/pricing>` instead.
 
 .. warning::
    Make sure that in the address, for the Country field, "Mexico" is chosen from the list of

--- a/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
@@ -119,6 +119,10 @@ In the resulting form, put your full address (including zip code), RFC (VAT numb
 the data.
 
 .. warning::
+   From a legal point of view, a Mexican company must use the local currency (MXN). Therefore, 
+   Odoo does not provide features to manage an alternative configuration. If you want to manage
+   another currency, let MXN be the default currency and use price list instead.
+   
    Make sure that in the address, for the Country field, "Mexico" is chosen from the list of
    countries that Odoo shows, because if it is entered manually there is a risk of creating a "new
    country" in the system, which it will result in errors later when the CFDIs are generated.

--- a/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
@@ -118,11 +118,12 @@ click on *Update information* under your company name.
 In the resulting form, put your full address (including zip code), RFC (VAT number), and the rest of
 the data.
 
+.. important::
+   From a legal point of view, a Mexican company must use the local currency (MXN). Therefore,
+   Odoo does not provide features to manage an alternative configuration. If you want
+   to manage another currency, let MXN be the default currency and use price list instead.
+
 .. warning::
-   From a legal point of view, a Mexican company must use the local currency (MXN). Therefore, 
-   Odoo does not provide features to manage an alternative configuration. If you want to manage
-   another currency, let MXN be the default currency and use price list instead.
-   
    Make sure that in the address, for the Country field, "Mexico" is chosen from the list of
    countries that Odoo shows, because if it is entered manually there is a risk of creating a "new
    country" in the system, which it will result in errors later when the CFDIs are generated.


### PR DESCRIPTION
This is a result of a feedback we've received, in previous MX DOC versions we were specifying that the company/main currency should be MXN.

This is good to have it as a warning, we have as a warning in previous DOV versions but now we add some extra info as well (ref: https://www.odoo.com/documentation/13.0/applications/finance/accounting/fiscal_localizations/localizations/mexico.html#set-your-legal-information-in-the-company)