### PR TITLE
[IMP] developer/views: document new kanban field attribute

### DIFF
--- a/content/developer/reference/views.rst
+++ b/content/developer/reference/views.rst
@@ -1505,6 +1505,12 @@ Possible children of the view element are:
   ``name`` (required)
     the name of the field to fetch
 
+  ``allow_group_range_value`` (optional)
+    whether a ``date`` or ``datetime`` field allows a value computed from a
+    group range (which consists of the first and last dates of the group).
+    Enables the 'quick create' and 'drag and drop' features when the kanban
+    view is grouped by that field. Default: false.
+
 ``progressbar``
   declares a progressbar element to put on top of kanban columns.
 


### PR DESCRIPTION
### [IMP] `developer`/`views`: document new kanban field attribute
This commit relates to a new community feature:
  A read_group on a date(time) field will also return a __range property with
  the date bounds of the group [from, to[

The community commit also introduces a new xml attribute
`allow_group_range_value` for `<kanban>` `<field>`, and this commit is the
documentation for that attribute.

allow_group_range_value (boolean):
  - to perform a drag&drop or a quickCreate, we must be able to get and use the
    value from the group containing the record. The last date of the group will
    be taken as the record's field value.

  - allows (or disallows) date(time) non-readonly fields to be:
    - draggable
    - quick created

  - defaults to false.

Task-ID: 2243913
Community PR odoo/odoo#69380  
> Commit: [IMP] core, web: add a range for date(time) read_group