### PR TITLE
[FIX] makefile: fix overridden css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 
 # Sphinx build files
 _build/
-extensions/odoo_theme/static/style.css
 
 # Dependencies
 odoo

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 	rm -rf $(BUILD_DIR)/*
 	@echo "Cleaning finished."
 
-html: $(HTML_BUILD_DIR)/html/_static/style.css
+html: $(HTML_BUILD_DIR)/_static/style.css
 	@echo "Starting build..."
 	$(SPHINX_BUILD) -c $(CONFIG_DIR) -b html $(SPHINXOPTS) $(SOURCE_DIR) $(HTML_BUILD_DIR)
 	@echo "Build finished."
@@ -62,7 +62,7 @@ gettext:
 	$(SPHINX_BUILD) -c $(CONFIG_DIR) -b gettext $(SOURCE_DIR) locale/sources
 	@echo "Generation finished."
 
-$(HTML_BUILD_DIR)/html/_static/style.css: extensions/odoo_theme/static/style.scss extensions/odoo_theme/static/scss/*.scss
+$(HTML_BUILD_DIR)/_static/style.css: extensions/odoo_theme/static/style.scss extensions/odoo_theme/static/scss/*.scss
 	@echo "Compiling stylesheets..."
 	mkdir -p $(HTML_BUILD_DIR)/_static
 	pysassc extensions/odoo_theme/static/style.scss $(HTML_BUILD_DIR)/_static/style.css
@@ -74,5 +74,5 @@ fast: SPHINXOPTS += -A collapse_menu=True
 fast: html
 
 static: $(HTML_BUILD_DIR)/static/style.css
-	cp -r extensions/odoo_theme/static/* $(HTML_BUILD_DIR)/html/_static/
-	cp -r static/* $(HTML_BUILD_DIR)/html/_static/
+	cp -r extensions/odoo_theme/static/* $(HTML_BUILD_DIR)/_static/
+	cp -r static/* $(HTML_BUILD_DIR)/_static/


### PR DESCRIPTION
The previous makefile was compiling css beside the style.scss and
the style.css was copied at the end.

The new makefile compile css directly in the build dir.

Since this file was still present in the source because of the .gitignore,
sphinx was using this old version of style.css, overriding the new compiled
css file at the end.

Removing it from gitignore should helpFix this problem.

This commit also fix some path in makefile.
(not critical but this should fix a potential error in static command)