### PR TITLE
[FIX] Makefile: avoid confusing // in build dir path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ ifndef BUILD_DIR
   BUILD_DIR    = _build
 endif
 
+ifndef CURRENT_LANG
+  CURRENT_LANG = en
+endif
+
 SPHINX_BUILD   = sphinx-build
 CONFIG_DIR     = .
 SPHINXOPTS     = -D project_root=$(ROOT) -D canonical_version=$(CANONICAL_VERSION) \


### PR DESCRIPTION
When locally building the doc (aka make), CURRENT_LANG is not defined,
which results in HTML_BUILD_DIR = _build/html//, resulting in commands
& logs like the following

mkdir -p _build/html//_static
pysassc extensions/odoo_theme/static/style.scss _build/html//_static/style.css

This has no impact on linux builds, but could be unclear/confusing for some non tech
users (can it have any impact on other OS's/distros ?)