### PR TITLE
[FIX] app/accounting: Fix outdated Colombian test server url

### DIFF
--- a/content/applications/finance/accounting/localizations/colombia.rst
+++ b/content/applications/finance/accounting/localizations/colombia.rst
@@ -49,7 +49,7 @@ look for the *Colombian Electronic Invoice* section.
 Using the Testing mode it is possible to connect with a Carvajal T&S
 testing environment. This allows users to test the complete workflow
 and integration with the CEN Financiero portal, which is accessible
-here: https://cenfinancierolab.cen.biz
+here: https://cenflab.cen.biz/site/
 
 Once that Odoo and Carvajal T&S is fully configured and ready for
 production the testing environment can be disabled.


### PR DESCRIPTION
Replaced an old dead link with the correct one. Note that Carvajal's web service got split into two entities, which means there are two web services now. V12 and V13 use the old CST one. V14 uses the newer CSC service for new customers, with a configuration option to use the CST server for existing customers using that. So this PR is intended for V12 and V13, and after that I intend to do a new PR which mentions both services.