### PR TITLE
[FIX] accounting/l10n_mx: Updated Mexican modules list

### DIFF
--- a/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
@@ -59,33 +59,20 @@ The following modules are necessary for all databases that require Mexican local
    | All the basic data to manage accounting, taxes and the chart of accounts. The installed chart
      of accounts is based on `the SAT account grouping code
      <https://www.gob.mx/cms/uploads/attachment/file/151586/codigo_agrupador.pdf>`_.
-#. | **EDI for Mexico (l10n_mx_edi)**
+#. | **EDI for Mexico (l10n_mx_edi & l10n_mx_edi_extended)**
    | Necessary for electronic transactions, CFDI 3.3, payment complement, and addenda on invoices.
-#. | **Odoo Mexican localization reports (l10n_mx_reports)**
+#. | **Odoo Mexican localization reports (l10n_mx_reports & l10n_mx_reports_closing)**
    | All mandatory reports for electronic accounting. (Requires the accounting application).
 
 The following modules are optional, and should be installed only if they meet a specific
 organization requirement. Installing these modules is not recommended unless you are sure they
 are needed as they add fields that can unnecessarily complicate form filling.
 
-#. | **EDI External Trade Complement for Mexico (l10n_mx_edi_external_trade)**
-   | For clients that export, add the foreign trade complement to the CFDI, and the logic for
-     filling it.
-#. | **Odoo Mexico Localization for Invoice with customs Number (l10n_mx_edi_customs)**
-   | For importing customers, this module allows adding to the CFDI the request number with which
-     the merchandise to be resold entered. When it is imported into Mexico, in the invoice that
-     comes from any foreign country it is necessary to specify which was the import document; This
-     is known as a "pedimento", and it is processed at customs.
 #. | **Odoo Mexico Localization for Stock / Landing (l10n_mx_edi_landing)**
-   | Related to the import module (*l10n_mx_edi_customs*), this module allows managing the requests
-     as part of the shipping costs.
-#. | **Bank account payment to Mexico (l10n_mx_edi_payment_bank)**
-   | Add optional attributes to the payment plugin, allowing the user to select the bank account
-     that was used to pay the bills.
-#. | **Odoo Mexico Localization for Sale Coupon (l10n_mx_edi_sale_coupon)**
-   | Complements the Odoo coupon module (*sale_coupon*) to avoid errors in the generation of CFDIs.
-#. | **Tax Cash Basis Entries at Payment Date (l10n_mx_tax_cash_basis)** Create journal entries for
-   | taxes on the payment date (instead of the issue date).
+   | This module allows managing the requests as part of the shipping costs.
+#. | **Odoo Mexican XML Polizas Export (l10n_mx_xml_polizas)**
+   | With this module, you will be able to export your Journal Entries in XML ready to be uploaded
+     to the SAT.
 
 Configuration
 =============


### PR DESCRIPTION
Most of the modules in the optional module list don't exist in V14,
except for l10n_mx_edi_landing. I've opted to remove the entire list
as a result.