### PR TITLE
[FIX] app/accounting: Fix outdated Colombian test server url

### DIFF
--- a/content/applications/finance/accounting/fiscal_localizations/localizations/colombia.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/colombia.rst
@@ -19,7 +19,7 @@ requires the next modules:
    contains the default setup for: chart of accounts, taxes,
    retentions, identification document types
 #. **l10n_co_edi**: This module includes all the extra fields that are
-   required for the Integration with Carvajal T&S and generate the
+   required for the Integration with Carvajal and generate the
    electronic invoice, based on the DIAN legal requirements.
 
 
@@ -43,12 +43,12 @@ filter and search for "Colombia". Then click on *Install* for the first two modu
    :align: center
 
 
-Configure credentials for Carvajal T&S web service
---------------------------------------------------
+Configure credentials for Carvajal web service
+----------------------------------------------
 
 Once that the modules are installed, in order to be able to connect
-with Carvajal T&S Web Service, it's necessary to configure the user
-and credentials, this information will be provided by Carvajal T&S.
+with Carvajal Web Service, it's necessary to configure the user
+and credentials, this information will be provided by Carvajal.
 
 Go to :menuselection:`Accounting --> Configuration --> Settings` and
 look for the *Colombian Electronic Invoice* section.
@@ -56,12 +56,20 @@ look for the *Colombian Electronic Invoice* section.
 .. image:: media/colombia03.png
    :align: center
 
-Using the Testing mode it is possible to connect with a Carvajal T&S
+Using the Testing mode it is possible to connect with a Carvajal
 testing environment. This allows users to test the complete workflow
 and integration with the CEN Financiero portal, which is accessible
-here: https://cenfinancierolab.cen.biz
+here:
 
-Once that Odoo and Carvajal T&S is fully configured and ready for
+CTS (Carvajal T&S)
+  https://cenflab.cen.biz/site/
+
+CSC (Carvajal Servicios de Comunicación)
+  https://web-stage.facturacarvajal.com/
+
+CSC is the default for new databases.
+
+Once that Odoo and Carvajal are fully configured and ready for
 production the testing environment can be disabled.
 
 

--- a/content/applications/finance/accounting/fiscal_localizations/localizations/colombia_ES.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/colombia_ES.rst
@@ -18,7 +18,7 @@ requiere los siguientes Módulos:
    - Tipos de Documentos de Identificación
 
 #. **l10n_co_edi**: Este módulo incluye todos los campos adicionales que son
-   requeridos para la Integración entre Carvajal T&S y la generación de la
+   requeridos para la Integración entre Carvajal y la generación de la
    Factura Electrónica, basado en los requisitos legales de la DIAN.
 
 
@@ -42,12 +42,12 @@ Instalar a los primeros dos módulos:
    :align: center
 
 
-Configuración de las credenciales del Servicio Web de Carvajal T&S
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Configuración de las credenciales del Servicio Web de Carvajal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 | Una vez que los módulos están instalados, para poderte conectar con el
-  Servicio Web de Carvajal T&S, es necesario configurar el Usuario y las
-  Credenciales. Esta información será provista por Carvajal T&S.
+  Servicio Web de Carvajal, es necesario configurar el Usuario y las
+  Credenciales. Esta información será provista por Carvajal.
 | Ve a :menuselection:`Facturación --> Configuración --> Configuración` y busca la sección
   **Facturación Electrónica Colombiana**
 
@@ -55,14 +55,21 @@ Configuración de las credenciales del Servicio Web de Carvajal T&S
   :align: center
 
 La funcionalidad de pruebas le permite conectarse e interactuar con el
-ambiente piloto de Carvajal T&S, esto permite a los usuarios probar el
+ambiente piloto de Carvajal, esto permite a los usuarios probar el
 flujo completo y la integración con el Portal Financiero CEN, al cual
-se accede a través de la siguiente liga: `Cenfinanciero <https://cenfinancierolab.cen.biz>`_.
+se accede a través de la siguiente liga:
+
+CTS (Carvajal T&S)
+   https://cenflab.cen.biz/site/
+
+CSC (Carvajal Servicios de Comunicación)
+   https://web-stage.facturacarvajal.com/
+
+CSC es el predeterminado para nuevas bases de datos.
 
 Una vez que el ambiente de producción está listo en Odoo y en Carvajal
-T&S el ambiente de pruebas debe ser deshabilitado para poder enviar la
-información al ambiente de producción de Carvajal, para el cual es
-utilizada la siguiente URL: `Cenfinanciero <https://cenfinancierolab.cen.biz>`_.
+el ambiente de pruebas debe ser deshabilitado para poder enviar la
+información al ambiente de producción de Carvajal.
 
 
 Configuración de Información para PDF


### PR DESCRIPTION
This is the V14 followup of https://github.com/odoo/documentation/pull/1107 . V14 has two different services which can be used, because Carvajal split into 2 entities.