### PR TITLE
Fix "Pull From" documentation -> Inconsistency of terms & operation

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/routes/concepts/use-routes.rst
+++ b/content/applications/inventory_and_mrp/inventory/routes/concepts/use-routes.rst
@@ -260,7 +260,7 @@ all of them:
    in a specific stock location. The need can come from a sale order
    which has been validated or for a manufacturing order which
    requires a specific component. When the need appears in the
-   source location, Odoo generates a picking to fulfill this need.
+   destination location, Odoo generates a picking to fulfill this need.
 -  **Push To**: this rule is triggered by the arrival of some
    products in the defined source location. In case you move
    products to the source location, Odoo generates a picking to move


### PR DESCRIPTION
Source -> Destination

Documentation says:"When the need appears in the source location
Odoo says: "When products are needed in [Destination Location]

![imagen](https://user-images.githubusercontent.com/8736623/132837193-86e906b5-0cbf-464b-b6d1-e8cafb7cf001.png)
