### PR TITLE
[IMP] mail plugins: improve the naming consistency of plugins

### DIFF
--- a/content/applications/productivity/mail_plugins.rst
+++ b/content/applications/productivity/mail_plugins.rst
@@ -18,6 +18,9 @@ interact with your Odoo database directly from your mailbox by:
 - Creating tickets in the Helpdesk app.
 - Searching and storing insights on your contacts.
 
+Mail Plugins are available for :doc:`Outlook <mail_plugins/outlook>` and :doc:`Gmail
+<mail_plugins/gmail>`.
+
 .. _mail_plugins/pricing:
 
 Pricing

--- a/content/applications/productivity/mail_plugins/gmail.rst
+++ b/content/applications/productivity/mail_plugins/gmail.rst
@@ -5,7 +5,7 @@ Gmail Plugin
 Configuration
 =============
 
-The Odoo-Gmail :doc:`Mail Plugin <../mail_plugins>` needs to be configured both on Odoo and Gmail.
+The Gmail :doc:`Mail Plugin <../mail_plugins>` needs to be configured both on Odoo and Gmail.
 
 .. _mail-plugin/gmail/enable-mail-plugin:
 
@@ -17,8 +17,8 @@ First, you need to enable the *Mail Plugin* feature in your database. Go to :men
 
 .. _mail-plugin/gmail/install-plugin:
 
-Install the Odoo-Gmail Plugin
------------------------------
+Install the Gmail Plugin
+------------------------
 
 #. Open the `Gmail Plugin Apps Script project
    <https://script.google.com/d/1n7cxtaR4fGXKcP0RwinNQmL8S4FhVqpo-ZZ_cUAhYuuDpZAP_CnHE_7q/edit>`_.
@@ -32,7 +32,7 @@ Install the Odoo-Gmail Plugin
       :alt: Deploying from manifest the Gmail Plugin from the Apps Script project
 
    .. important::
-      Make sure you are using the legacy editor, otherwise the *Deploy from manifest* functionality
+      Make sure you are using the legacy editor; otherwise the *Deploy from manifest* functionality
       may not be available.
 
       .. image:: gmail/legacy-editor.png
@@ -88,7 +88,7 @@ Configure your Gmail mailbox
 
 #. If you aren't logged into your database, enter your credentials.
 
-#. Click on *Allow* to let the Odoo-Gmail Plugin connect to your database.
+#. Click on *Allow* to let the Gmail Plugin connect to your database.
 
    .. image:: gmail/odoo-permission.png
       :align: center

--- a/content/applications/productivity/mail_plugins/outlook.rst
+++ b/content/applications/productivity/mail_plugins/outlook.rst
@@ -5,8 +5,7 @@ Outlook Plugin
 Configuration
 =============
 
-The Odoo-Outlook :doc:`Mail Plugin <../mail_plugins>` needs to be configured both on Odoo and
-Outlook.
+The Outlook :doc:`Mail Plugin <../mail_plugins>` needs to be configured both on Odoo and Outlook.
 
 .. _mail-plugin/outlook/enable-mail-plugin:
 
@@ -116,7 +115,7 @@ time, it's possible to add it next to the other default actions.
       :align: center
       :alt: Odoo for Outlook customized action
 
-#. Open any email and the shortcut should be displayed.
+#. Open any email; the shortcut should be displayed.
 
    .. image:: outlook/odoo-outlook-shortcut.png
       :align: center


### PR DESCRIPTION
The plugins were named "Odoo-Gmail Plugin" / "Gmail Plugin" and "Odoo-Outlook Plugin" /
"Outlook Plugin". I chose the later version for both plugins consistently.
I also added a reference to both the Gmail and Outlook docs in the main Mail Plugins doc for easier access.