### PR TITLE
[FIX] mail_plugins: fix outlook plugin url

### DIFF
--- a/content/applications/productivity/mail_plugins/outlook.rst
+++ b/content/applications/productivity/mail_plugins/outlook.rst
@@ -40,7 +40,7 @@ Install the Outlook Plugin
       :align: center
       :alt: Custom add-ins in Outlook
 
-#. Enter the following URL `https://download.odoo.com/plugins/outlook/manifest.xml` and press
+#. Enter the following URL `https://download.odoo.com/plugins/v15/outlook/manifest.xml` and press
    *OK*.
 
    .. image:: outlook/enter-add-in-url.png


### PR DESCRIPTION
The outlook plugin (v2.0.0) for v15 is not compatible with older databases, so we need both version to be hosted separately, and therefore a new URL.