### PR TITLE
[IMP] point_of_sale: Configure https in the POS

### DIFF
--- a/content/applications/sales/point_of_sale/overview.rst
+++ b/content/applications/sales/point_of_sale/overview.rst
@@ -9,3 +9,4 @@ Overview
 
    overview/getting_started
    overview/register
+   overview/https

--- a/content/applications/sales/point_of_sale/overview/https.rst
+++ b/content/applications/sales/point_of_sale/overview/https.rst
@@ -1,0 +1,19 @@
+=========================
+Secure connection (HTTPS)
+=========================
+
+If **Direct Devices** is enabled in a Point of Sale settings (for example, if you use an ePos
+printer), HTTP becomes the default protocol.
+
+Force your Point of Sale to use a secure connection (HTTPS)
+===========================================================
+
+Add a new **key** in the **System Parameters** to force your Point of Sale to use a secure
+connection with the HTTPS protocol.
+
+To do so, activate the :ref:`developer mode <developer-mode>`, go to :menuselection:`Settings -->
+Technical --> Parameters --> System Parameters`, then create a new parameter, add the following
+values and click on *Save*.
+
+- **Key**: `point_of_sale.enforce_https`
+- **Value**: `True`


### PR DESCRIPTION
The default protocol int the POS with "other device"
is on HTTP.

This doc explain how to activate the HTTPS in the POS