### PR TITLE
[FIX] conf: allow to build on python 3.6

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -74,6 +74,10 @@ if not odoo_dir.is_dir():
     )
 else:
     sys.path.insert(0, str(odoo_dir.absolute()))
+    if sys.version_info < (3, 7) and sys.version_info > (3, 6):
+        # running odoo needs python 3.7 min but monkey patch version_info to be
+        # able to build the doc in python 3.6
+        sys.version_info = (3, 7, 0)
     from odoo import release as odoo_release  # Don't collide with Sphinx's 'release' config option
     odoo_version = odoo_release.version.replace('~', '-') \
         if 'alpha' not in odoo_release.version else 'master'


### PR DESCRIPTION
Since odoo/odoo@794677fb6a3391379 Odoo requires python 3.7 min.
However, it still runs fine in 3.6 and this is the python version of
the build server.
Fake the version to be able to build the doc on the nightly server.

To be removed once the nightly server is migrated.