### PR TITLE
[FIX] Makefile: call pysassc from python module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ gettext:
 $(HTML_BUILD_DIR)/_static/style.css: extensions/odoo_theme/static/style.scss extensions/odoo_theme/static/scss/*.scss
 	@echo "Compiling stylesheets..."
 	mkdir -p $(HTML_BUILD_DIR)/_static
-	pysassc extensions/odoo_theme/static/style.scss $(HTML_BUILD_DIR)/_static/style.css
+	python3 -m pysassc extensions/odoo_theme/static/style.scss $(HTML_BUILD_DIR)/_static/style.css
 	@echo "Compilation finished."
 
 #=== Development and debugging rules ===#

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+libsass==0.18.0
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
-pysass~=0.1.0
 sphinx~=3.0
 werkzeug==0.14.1


### PR DESCRIPTION
pysassc utility is called in the Makefile. On some system (e.g.: the latest
Dockerfile of the runbot) this utility cannot be found in the system's
paths.

As the pysassc utility is a wrapper for the python module, we can simply
call the python module by it's entrypoint.

Also, this commit fixes the requirements as the pysass package was
installed to incidentally install libsass.