### PR TITLE
[FIX] requirements.txt: Let sphinx manage docutils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-docutils~=0.14
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 pysass~=0.1.0


### PR DESCRIPTION
As of sphinx 3.5.4, docutils >0.17 is no longer supported. To avoid
forcing the install of an unsupported version of docutils, we let
sphinx install the appropriate version through its dependencies.