### PR TITLE
[ADD] odoo_sh: Mention Python dependency behavior in FAQ

### DIFF
--- a/content/administration/odoo_sh/advanced/frequent_technical_questions.rst
+++ b/content/administration/odoo_sh/advanced/frequent_technical_questions.rst
@@ -30,3 +30,26 @@ We advise that:
   `idempotent <https://stackoverflow.com/a/1077421/3332416>`_: they must not
   cause side-effects if they are started more often than expected.
 
+Why are the installed Python libraries different from Odoo's own requirements.txt?
+----------------------------------------------------------------------------------
+
+On Odoo.sh, Odoo uses the Python libraries available in the Linux distribution
+to fulfill its dependencies. Odoo is compatible with the packages in Debian
+stable and Ubuntu LTS releases. The `requirements.txt <https://github.com/odoo/odoo/blob/master/requirements.txt>`_
+included with Odoo is intended for use on different distributions where the
+same library versions might not be available. As a result, Odoo.sh does not use
+Odoo's own requirements.txt file and there might be occasional differences
+between them.
+
+For example, reportlab 3.5.34 is the version available on Ubuntu 20.04 as a
+distribution package. That distribution uses Python 3.8, in which case
+requirements.txt in `Odoo 14.0 <https://github.com/odoo/odoo/blob/2097c75dc38b310c4d9ddecd79e2218448a51a4c/requirements.txt#L46>`_
+specifies reportlab 3.5.55. Normally speaking the pin in requirements.txt
+should reflect that and be 3.5.34, but it turns out that this version only
+works if Ubuntu's patches are applied to it. Ubuntu LTS releases have
+backporting of bug fixes, which means that the behavior of a Python package in
+the distribution might not be the same as that same version when installed with
+pip. This is the case with reportlab, which is why the pin is different.
+
+If a custom module requires a more recent version of a package than is
+installed on Odoo.sh, you can specify it in your own requirements.txt file.


### PR DESCRIPTION
Odoo.sh doesn't use the requirements.txt included in Odoo but Python
packages available in the Linux distribution instead. This is
non-obvious and can be confusing to users, especially in the cases where
the version available in the distribution and requirements.txt are
different.

Adding this section is intended to clarify that, and to provide a
reference for developers of custom modules on what to expect.

opw-2688205