### PR TITLE
[FIX] rdtraining: fix wrong suggested folder for views

### DIFF
--- a/content/developer/howtos/rdtraining/06_firstui.rst
+++ b/content/developer/howtos/rdtraining/06_firstui.rst
@@ -56,7 +56,7 @@ Actions
 
     .. code-block:: text
 
-        INFO rd-demo odoo.modules.loading: loading estate/data/estate_property_views.xml
+        INFO rd-demo odoo.modules.loading: loading estate/views/estate_property_views.xml
 
 Actions can be triggered in three ways:
 


### PR DESCRIPTION
The training suggests to put the views in the data/ folder instead of the views/ folder