### PR TITLE
[FIX] developer/reference/javascript_reference

### DIFF
--- a/content/developer/reference/frontend/javascript_reference.rst
+++ b/content/developer/reference/frontend/javascript_reference.rst
@@ -311,8 +311,9 @@ Here is an example of a basic counter widget:
     });
 
 For this example, assume that the template *some.template* (and is properly
-loaded: the template is in a file, which is properly defined in the *qweb* key
-in the module manifest) is given by:
+loaded: the template is in a file, which is properly defined in the assets of
+the module manifest ``'assets': {'web.assets_qweb': [...]}``,  see
+:ref:`assets <reference/assets>`.) is given by:
 
 .. code-block:: xml
 


### PR DESCRIPTION
The "qweb key of the manifest" file was still mentionned even if it has
been replaced by the assets bundles.

See related task: 2352566

See also: odoo/odoo#80988