### PR TITLE
[FIX] remove enterprise tag from Gantt documentation

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -956,10 +956,6 @@ Generic structure
 Gantt
 -----
 
-.. raw:: html
-
-   <span class="badge" style="background-color:#AD5E99">Enterprise feature</span>
-
 Gantt views appropriately display Gantt charts (for scheduling).
 
 The root element of gantt views is ``<gantt/>``, it has no children but can


### PR DESCRIPTION
Gantt view is implemented in community, see https://github.com/odoo/odoo/blob/c3673e63064c7f331754ef0e9d02cbbe7b1927f4/odoo/addons/base/models/ir_ui_view.py#L246