### PR TITLE
[FIX] howtos: remove useless <group/> tag from training example

### DIFF
--- a/content/developer/howtos/rdtraining/12_sprinkles.rst
+++ b/content/developer/howtos/rdtraining/12_sprinkles.rst
@@ -426,7 +426,6 @@ used to search on both ``name`` and ``description`` fields.
     <search string="Test">
         <field name="description" string="Name and description"
                filter_domain="['|', ('name', 'ilike', self), ('description', 'ilike', self)]"/>
-        </group>
     </search>
 
 .. exercise:: Change the living area search.


### PR DESCRIPTION
</group> tag should be deleted