### PR TITLE
[IMP] general/payment_acquirers: authorize support refund from odoo

### DIFF
--- a/content/applications/general/payment_acquirers.rst
+++ b/content/applications/general/payment_acquirers.rst
@@ -62,7 +62,7 @@ Online payment acquirers
 | :doc:`Alipay                  | Redirection to the   |            |                 |           |
 | <payment_acquirers/alipay>`   | acquirer website     |            |                 |           |
 +-------------------------------+----------------------+------------+-----------------+-----------+
-| :doc:`Authorize.Net           | Payment from Odoo    | |V|        | |V|             |           |
+| :doc:`Authorize.Net           | Payment from Odoo    | |V|        | |V|             | |V|       |
 | <payment_acquirers/authorize>`|                      |            |                 |           |
 +-------------------------------+----------------------+------------+-----------------+-----------+
 | :doc:`Buckaroo                | Redirection to the   |            |                 |           |


### PR DESCRIPTION
Add 'x' to make evident that Authorize.net supports
refunds directly from odoo.

Task - 2712287
Task (on payment) - 2678757