### PR TITLE
[IMP] qweb: mention the two possible syntaxes for `t-attf`

### DIFF
--- a/content/developer/reference/frontend/qweb.rst
+++ b/content/developer/reference/frontend/qweb.rst
@@ -223,6 +223,11 @@ exists in 3 different forms:
         <li class="row even">1</li>
         <li class="row odd">2</li>
         <li class="row even">3</li>
+
+    .. tip::
+       There are two equivalent syntaxes for format strings: ``"plain_text {{code}}"`` (aka
+       jinja-style) and ``"plain_text #{code}"`` (aka ruby-style).
+    
 :samp:`t-att=mapping`
     if the parameter is a mapping, each (key, value) pair generates a new
     attribute and its value::


### PR DESCRIPTION
I wasted time trying to insert a # character in my qweb before discovering this thread:
https://www.odoo.com/nl_NL/forum/help-1/what-is-the-utility-of-the-sign-in-qweb-t-attf-91382

I had this documentation page right under me the whole time, but it made no mention of the ruby-style pattern for format strings in qweb.

Could we change that ?