### PR TITLE
[IMP] manufacturing: scrap location warning-backport of #950

### DIFF
--- a/content/applications/inventory_and_mrp/manufacturing/management/bill_configuration.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/management/bill_configuration.rst
@@ -33,6 +33,10 @@ type, which is *Manufacture this Product*.
 .. image:: media/bills_of_materials_01.png
     :align: center
 
+.. warning::
+   The destination location should **not** be a scrap location. A scrap location is where you put
+   products that you don't need. 
+
 Using the same BoM to describe Variants
 ---------------------------------------
 


### PR DESCRIPTION
The destination location in manufacturing order shouldn't be a scrap location.
Otherwise, the user won't be able to complete manufacturing orders.

Backport of: #950 