### PR TITLE
[ADD] add link to "welcome" wiki at start of tuto

### DIFF
--- a/content/developer/howtos/rdtraining/02_setup.rst
+++ b/content/developer/howtos/rdtraining/02_setup.rst
@@ -460,5 +460,13 @@ Here is a list of commands:
         limit_time_cpu = 9999
         limit_time_real = 9999
 
+Additional reading
+------------------
+
+Feel free to read our `welcome <https://github.com/odoo/enterprise/wiki/Welcome>`__ page has extra info about
+working at Odoo as well as additional `tutorials <https://github.com/odoo/enterprise/wiki/Welcome#3-technical-training>`__ that are
+both language and Odoo specific. Note that the information contained therein might feel a bit overhwelming at this stage, so don't hesistate to skim, skip
+and come back to it later when you need it!
+
 Now that your server is running, it's time to start
 :ref:`writing your own application <howto/rdtraining/03_newapp>`!


### PR DESCRIPTION
Once I'd reached chapter 16 of the dev tutorial, I stumbled upon the "Welcome" page of the enterprise wiki, and I believe that particular piece of information would gain in being seen sooner, most especially the different links to tutorials about languages and technologies.

The sections about guidelines, security, commit hygiene, etc. are also of particular interest, as they would allow a new recruits to start "playing" with those principles during their functional training.

In this PR is a quick example of where & how I believe the link could be added at an earlier stage of the tutorial.

That being said, I have absolutely no insight as to the intent and purpose behind the current structure, so don't hesitate do dispose of this without further ceremony =)