### PR TITLE
[IMP] paypal: clarify steps to properly configure PayPal

### DIFF
--- a/content/applications/general/payment_acquirers/paypal.rst
+++ b/content/applications/general/payment_acquirers/paypal.rst
@@ -3,9 +3,9 @@ Paypal
 ======
 
 `Paypal <https://www.paypal.com/>`_ is available and popular worldwide. It doesn't charge any
-subscription fee and creating an account is very easy. That's why we definitely recommend it for
-starters in Odoo. It works as a seamless flow where the customer is routed to Paypal website to
-register the payment.
+subscription fee, and creating an account is very easy. That's why we recommend it for starters in
+Odoo. It works as a seamless flow where the customer is routed to the Paypal website to register the
+payment.
 
 Settings in Odoo
 ================
@@ -18,29 +18,34 @@ Credentials tab
 
 Odoo needs your **API Credentials** to connect with your PayPal account, which comprise:
 
-- **Email ID**: your login email address in Paypal.
-- **Merchant ID**: the code of the merchant account used to identify your Paypal account.
-- **Use IPN**: either you want to use Instant Payment Notification. Already checked, you don't have
+- **Email**: your login email address in Paypal.
+- **Merchant Account ID**: the code of the merchant account used to identify your Paypal account.
+- **PDT Identity Token**: the key used to verify the authenticity of transactions.
+- **Use IPN**: whether you want to use Instant Payment Notification. Already checked, you don't have
   to change it.
 
-You can copy your credentials from your Paypal account, and paste them in the related fields under
+You can copy your credentials from your Paypal account and paste them into the related fields under
 the **Credentials** tab.
 
-To retrieve them, log into your Paypal account, and go to :menuselection:`Your account menu -->
-Account settings --> Business Profile --> Business Information`
+To retrieve the **Merchant Account ID**, log into your Paypal account and go to
+:menuselection:`Account menu --> Account Settings --> Business information`.
+
+To set the **PDT Identity Token**, switch to :ref:`developer mode <developer-mode>` and retrieve the
+token by following the configuration step :ref:`paypal/enable-pdt`.
 
 .. important::
-   If you are trying Paypal as a test, with a *sandbox account*, change the **State** to *Test
-   Mode*. We recommend doing this on a test Odoo database, rather than on your main database.
+   If you are trying Paypal as a test, using a :ref:`Paypal Sandbox account <paypal/testing>`,
+   change the **State** to *Test Mode*. We recommend doing this on a test Odoo database rather than
+   on your main database.
 
 Configuration tab
 -----------------
 
-You can charge extra fees to your customers for paying with Paypal;
-This to cover the transaction fees Paypal charges you. Once redirected to Paypal, your customer sees
-an extra applied to the order amount.
+You can charge extra fees to your customers for paying with Paypal to cover the transaction fees
+Paypal charges you. Once redirected to Paypal, your customer sees an extra amount applied to the
+order amount.
 
-To activate this, go to the Configuration tab of Paypal configuration in Odoo and check *Add Extra
+To activate this, go to Paypal configuration's Configuration tab in Odoo and activate *Add Extra
 Fees*.
 
 You can refer to `Paypal Fees <https://www.paypal.com/webapps/mpp/paypal-fees>`_ to set up fees.
@@ -52,28 +57,36 @@ You can refer to `Paypal Fees <https://www.paypal.com/webapps/mpp/paypal-fees>`_
 Settings in Paypal
 ==================
 
-First, let’s see how to set up your Paypal account in order to build a seamless customer experience
-with Odoo.
+First, set up your Paypal account to build a seamless customer experience with Odoo.
 
-Log in and open the settings. Go to :menuselection:`Your account menu --> Account settings -->
-Product & Services --> Website payments` and click **Update** on **Website preferences**.
+Log into your PayPal account and open the account settings. Then, go to :menuselection:`Account menu
+--> Account settings --> Website payments`.
 
-Auto Return
------------
+Enable Auto Return
+------------------
 
-*Auto Return* automatically redirects your customers to Odoo once the payment is processed. Check
-*Auto Return* and enter your domain name with the suffix ``/shop/confirmation`` as *Return URL*
-(e.g. `https://yourcompany.odoo.com/shop/confirmation`).
+The *Auto Return* feature automatically redirects your customers to Odoo once the payment is
+processed.
 
-This URL is requested in Paypal but not used in practice as Odoo transmits it at each transaction.
-Don’t worry if you manage several sales channels or Odoo databases.
+From the *Website payments* settings page, go to :menuselection:`Website preferences --> Update -->
+Auto return for website payments` and select **On**. Enter the address of your Odoo database (e.g.,
+`https://yourcompany.odoo.com`) in the **Return URL** field.
 
-Payment Data Transfer (PDT)
----------------------------
+.. note::
+   Any URL will do the job. Odoo only needs the setting to be enabled since it uses another URL.
 
-*Payment Data Transfer* delivers the payment confirmation to Odoo as soon as it is processed.
-Without it, Odoo cannot end the sales flow. This setting must be activated as well. When saving, an
-*Identity Token* is generated. You will be later requested to enter it in Odoo.
+.. _paypal/enable-pdt:
+
+Enable Payment Data Transfer (PDT)
+----------------------------------
+
+Enable the *Payment Data Transfer* feature to receive payment confirmations immediately. This
+feature also displays the payment status to the customers and verifies the authenticity of the
+payments.
+
+From the *Website payments* settings page, go to :menuselection:`Website preferences --> Update -->
+Payment data transfer` and select **On**. PayPal displays your **PDT Identity Token** as soon as
+the change is saved.
 
 Paypal Account Optional
 -----------------------
@@ -82,59 +95,48 @@ We advise you to not prompt customers to log in with a Paypal account when they 
 pay with debit/credit cards as well, or you might lose some deals. Make sure this setting is turned
 on.
 
-Instant Payment Notification (IPN)
-----------------------------------
-
-PDT sends order confirmations once and only once. As a result, your site must be running when it
-happens; otherwise, it will never receive the message. That’s why we advise to activate the *Instant
-Payment Notification* (IPN) on top. With IPN, delivery of order confirmations is virtually
-guaranteed since IPN resends a confirmation until your site acknowledges receipt.
-
-| To activate IPN, get back to *Website payments* menu and click *Update* in *Instant Payment
-  Notification*.
-| The *Notification URL* to set is your domain name + “payment/paypal/ipn” (e.g.
-  `https://yourcompany.odoo.com/payment/paypal/ipn`).
-
 Payment Messages Format
 -----------------------
 
-If you use accented characters (or anything else than basic Latin characters) for your customer
-names, addresses... you MUST configure the encoding format of the payment request sent by Odoo to
-Paypal.
+Suppose you use accented characters (or anything else than primary Latin characters) for your
+customer names or addresses. In that case, you **must** configure the encoding format of the payment
+request sent by Odoo to Paypal. Otherwise, some transactions fail without notice.
 
-.. danger::
-   If you don't configure this setting, some transactions fail without notice.
-
-To do so, open:
-
-- `this page for a test account <https://sandbox.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-language-encoding>`_
-- `this page for a production account <https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-language-encoding>`_
-
-Then, click *More Options* and set the two default encoding formats as **UTF-8**.
+To do so, go to `your production account <https://www.paypal.com/cgi-bin/customerprofileweb
+?cmd=_profile-language-encoding>`_. Then, click *More Options* and set the two default encoding
+formats as **UTF-8**.
 
 Your Paypal account is ready!
 
 .. tip::
-   For Encrypted Website Payments & EWP_SETTINGS error, please check the `Paypal documentation
-   <https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/
-   encryptedwebpayments#encrypted-website-payments-ewp>`_.
+   - For Encrypted Website Payments & EWP_SETTINGS error, please check the `Paypal documentation
+     <https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/
+     encryptedwebpayments#encrypted-website-payments-ewp>`_.
+   - Configure your :ref:`Paypal Sandbox account <paypal/testing>`, then follow this
+     `link <https://sandbox.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-language-encoding>`_
+     to configure the encoding format in a test environment.
+
+.. _paypal/testing:
 
 Test environment
 ================
 
-You can test the entire payment flow in Odoo thanks to Paypal Sandbox accounts.
+Configuration
+-------------
 
-Log in to `Paypal Developer Site <https://developer.paypal.com/>`__ with your Paypal credentials.
+Thanks to Paypal Sandbox accounts, you can test the entire payment flow in Odoo.
 
-This will create two sandbox accounts:
+Log into the `Paypal Developer Site <https://developer.paypal.com/>`_ using your Paypal
+credentials, which creates two sandbox accounts:
 
--  A business account (to use as merchant, e.g. `pp.merch01-facilitator@example.com <mailto:pp.merch01-facilitator@example.com>`__).
+-  A business account (to use as merchants, e.g.,
+   `pp.merch01-facilitator@example.com <mailto:pp.merch01-facilitator@example.com>`_).
+-  A default personal account (to use as shoppers, e.g.,
+   `pp.merch01-buyer@example.com <mailto:pp.merch01-buyer@example.com>`_).
 
--  A default personal account (to use as shopper, e.g. `pp.merch01-buyer@example.com <mailto:pp.merch01-buyer@example.com>`__).
-
-Log in to Paypal Sandbox with the merchant account and follow the same configuration instructions.
-Enter your sandbox credentials in Odoo and make sure Paypal is still set on *Test Mode*. We
-recommend doing this on a test Odoo database, rather than on your main database.
+Log into Paypal Sandbox using the merchant account and follow the same configuration instructions.
+Enter your sandbox credentials in Odoo and ensure Paypal is set on *Test Mode*. We recommend doing
+this on a test Odoo database rather than your main database.
 
 Run a test transaction from Odoo using the sandbox personal account.
 


### PR DESCRIPTION
The "Enable IPN" step is also removed because this setting is overruled
by the payment request that Odoo sends to PayPal. Enabling IPN in PayPal
has no effect.

task-2744043

See also:
- https://github.com/odoo/odoo/pull/83140