### PR TITLE
[ADD] extensions: add a custom `example` admonition

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -112,7 +112,7 @@ extensions = [
     # Youtube and Vimeo videos integration (youtube, vimeo directives)
     'embedded_video',
 
-    'exercise_admonition',
+    'custom_admonitions',
 
     # Redirection generator
     'redirects',

--- a/content/developer/reference/addons/mixins.rst
+++ b/content/developer/reference/addons/mixins.rst
@@ -26,7 +26,7 @@ Integrating messaging features to your model is extremely easy. Simply inheritin
 the ``mail.thread`` model and adding the messaging fields (and their appropriate
 widgets) to your form view will get you up and running in no time.
 
-.. admonition:: Example
+.. example::
 
     Let's create a simplistic model representing a business trip. Since organizing
     this kind of trip usually involves a lot of people and a lot of discussion, let's
@@ -200,7 +200,7 @@ The ``mail`` module adds a powerful tracking system on fields, allowing you
 to log changes to specific fields in the record's chatter. To add tracking
 to a field, simple set the tracking attribute to True.
 
-.. admonition:: Example
+.. example::
 
     Let's track changes on the name and responsible of our business trips:
 
@@ -272,7 +272,7 @@ can override the ``_track_subtype()`` function:
     :returns: a subtype's full external id or False if no subtype is triggered
 
 
-.. admonition:: Example
+.. example::
 
     Let's add a ``state`` field on our example class and trigger a notification
     with a specific subtype when this field change values.
@@ -422,7 +422,7 @@ The urls in the actions list can be generated automatically by calling the
     :returns: link of the type selected for the record
     :rtype: str
 
-.. admonition:: Example
+.. example::
 
     Let's add a custom button to the Business Trip state change notification;
     this button will reset the state to Draft and will be only visible to a member
@@ -609,7 +609,7 @@ which means that while the alias is stored in another table, you have
 access to all these fields directly from your parent object. This allows
 you to make your alias easily configurable from the record's form view.
 
-.. admonition:: Example
+.. example::
 
     Let's add aliases on our business trip class to create expenses on the fly via
     e-mail.
@@ -738,7 +738,7 @@ and the specific widgets to display them (via the field ``activity_ids``) in the
 view and kanban view of your records (``mail_activity`` and ``kanban_activity``
 widgets, respectively).
 
-.. admonition:: Example
+.. example::
 
     Organizing a business trip is a tedious process and tracking needed activities
     like ordering plane tickets or a cab for the airport could be useful. To do so,

--- a/content/developer/reference/addons/orm.rst
+++ b/content/developer/reference/addons/orm.rst
@@ -165,7 +165,7 @@ into a compatible type:
 * :func:`~odoo.fields.Date.to_date` will convert to a :class:`datetime.date`
 * :func:`~odoo.fields.Datetime.to_datetime` will convert to a :class:`datetime.datetime`.
 
-.. admonition:: Example
+.. example::
 
     To parse date/datetimes coming from external sources::
 
@@ -814,7 +814,7 @@ Domain criteria can be combined using logical operators in *prefix* form:
         Individual criterion generally have a negative form (e.g. ``=`` ->
         ``!=``, ``<`` -> ``>=``) which is simpler than negating the positive.
 
-.. admonition:: Example
+.. example::
 
     To search for partners named *ABC*, from belgium or germany, whose language
     is not english::

--- a/content/developer/reference/addons/views.rst
+++ b/content/developer/reference/addons/views.rst
@@ -980,7 +980,7 @@ take the following attributes:
     * ``plan``: If enabled and ``edit`` enabled, a "magnifying glass" button will be displayed
       on time slots to plan unassigned records into that time slot.
 
-    .. admonition:: Example
+    .. example::
 
         When you do not want to create records on the gantt view and the beginning and end
         dates are required on the model, the planning feature should be disabled

--- a/extensions/custom_admonitions/__init__.py
+++ b/extensions/custom_admonitions/__init__.py
@@ -1,8 +1,16 @@
-""" Add a new "exercise" admonition directive. """
+""" Add new custom admonition directives. """
 
 from docutils import nodes
 from docutils.parsers.rst.directives import admonitions
 from sphinx.locale import admonitionlabels
+
+
+class example(nodes.Admonition, nodes.Element):
+    pass
+
+
+class Example(admonitions.BaseAdmonition):
+    node_class = example
 
 
 class exercise(nodes.Admonition, nodes.Element):
@@ -14,6 +22,11 @@ class Exercise(admonitions.BaseAdmonition):
 
 
 def setup(app):
+    app.add_directive('example', Example)
+    app.add_node(example, html=(
+        lambda self, node: self.visit_admonition(node, 'example'),
+        lambda self, node: self.depart_admonition(node),
+    ))
     app.add_directive('exercise', Exercise)
     app.add_node(exercise, html=(
         lambda self, node: self.visit_admonition(node, 'exercise'),
@@ -26,4 +39,5 @@ def setup(app):
     }
 
 
+admonitionlabels['example'] = 'Example'
 admonitionlabels['exercise'] = 'Exercise'

--- a/extensions/odoo_theme/static/scss/_variables.scss
+++ b/extensions/odoo_theme/static/scss/_variables.scss
@@ -217,6 +217,7 @@ $brand-danger  :                            #D9534F;
 
 $doc_paper_dark:                            $gray-lighter;
 $doc_paper:                                 #ffffff;
+$doc_example:                               #519161;
 $doc_exercise:                              #938E94;
 $doc_code-bg:                               #F8F8F8;
 $doc_lime:                                  #CDDC39;

--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -938,10 +938,25 @@ header.o_main_header {
                 border-color: $danger;
 
                 > .alert-title, > h3 {
-                    color: darken($brand-danger,20%);
+                    color: darken($brand-danger, 20%);
+
                     &:before {
                         content: '#{$i-danger}';
                     }
+                }
+            }
+
+            &.alert-example {
+                border-color: tint-color($doc_example, 30%);
+                background-color: tint-color($doc_example, 90%);
+                color: shade-color($doc_example, 35%);
+
+                > .alert-title, > h3 {
+                    color: shade-color($doc_example, 35%);
+                }
+
+                > .alert-title:before, > h3:before {
+                    content: '#{$i-knowledge}';
                 }
             }
 

--- a/extensions/odoo_theme/translator.py
+++ b/extensions/odoo_theme/translator.py
@@ -34,6 +34,7 @@ ADMONITION_MAPPING = {
     'danger': 'alert-danger',
     'error': 'alert-danger',
 
+    'example': 'alert-example',
     'exercise': 'alert-exercise',
 }
 


### PR DESCRIPTION
Backported from https://github.com/odoo/documentation/pull/1334 since this could have some use in older versions as well.