### PR TITLE
[FIX] orm: remove `autoattribute` directive for `BaseModel._sequence`

### DIFF
--- a/content/developer/reference/backend/orm.rst
+++ b/content/developer/reference/backend/orm.rst
@@ -56,7 +56,6 @@ value::
         Defaults to whatever value was set for :attr:`~._auto`.
 
     .. autoattribute:: _table
-    .. autoattribute:: _sequence
     .. autoattribute:: _sql_constraints
 
     .. autoattribute:: _register


### PR DESCRIPTION
The attribute was dropped with PR odoo/odoo#82727