### PR TITLE
[IMP] contributing/doc, install: add an extension for content tabs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -124,9 +124,13 @@ extensions = [
     # Code switcher (switcher and case directives)
     'switcher',
 
+    # Content tabs
+    'sphinx_tabs.tabs',
+
     # Strange html domain logic used in memento pages
     'html_domain',
 ]
+
 if odoo_dir_in_path:
     # GitHub links generation
     extensions += [
@@ -166,6 +170,9 @@ supported_languages = {
 
 # The specifications of redirect rules used by the redirects extension.
 redirects_file = 'redirects.txt'
+
+sphinx_tabs_disable_tab_closing = True
+sphinx_tabs_disable_css_loading = False
 
 #=== Options for HTML output ===#
 

--- a/content/administration/install.rst
+++ b/content/administration/install.rst
@@ -4,6 +4,8 @@
 Install
 =======
 
+.. If you add content on this page, remove the redirect rule 'install -> install/install'
+
 .. toctree::
 
     install/install

--- a/content/administration/install/install.rst
+++ b/content/administration/install/install.rst
@@ -82,7 +82,7 @@ These packages automatically set up all dependencies (for the Community version)
 but may be difficult to keep up-to-date.
 
 Official Community packages with all relevant dependency requirements are
-available on our nightly_ server. Both Communtiy and Enterprise packages can
+available on our nightly_ server. Both Community and Enterprise packages can
 be downloaded from our download_ page (you must to be logged in as a paying
 customer or partner to download the Enterprise packages).
 
@@ -93,8 +93,9 @@ Windows
    the download_ page (any edition).
 #. Execute the downloaded file.
 
-   .. warning:: | On Windows 8 and later you may see a warning titled "Windows protected your PC".
-                | Click on **More Info** and then on **Run anyway**.
+   .. warning::
+      | On Windows 8 and later you may see a warning titled "Windows protected your PC".
+      | Click on **More Info** and then on **Run anyway**.
 
 #. Accept the UAC_ prompt.
 #. Go through the various installation steps.
@@ -104,134 +105,137 @@ Odoo will automatically be started at the end of the installation.
 Linux
 -----
 
-Debian/Ubuntu
-'''''''''''''
-
-Odoo 13.0 'deb' package currently supports `Debian Buster`_, `Ubuntu 18.04`_ or above.
-
 Prepare
-^^^^^^^
+~~~~~~~
 
-Odoo needs a `PostgreSQL`_ server to run properly. The default configuration for
-the Odoo 'deb' package is to use the PostgreSQL server on the same host as your
-Odoo instance. Execute the following command in order to install the PostgreSQL server:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Debian/Ubuntu
 
-  $ sudo apt install postgresql -y
+      Odoo needs a `PostgreSQL`_ server to run properly. The default configuration for
+      the Odoo 'deb' package is to use the PostgreSQL server on the same host as your
+      Odoo instance. Execute the following command in order to install the PostgreSQL server:
 
-.. warning:: `wkhtmltopdf` is not installed through **pip** and must be installed manually in
-             version `0.12.5 <the wkhtmltopdf download page_>`_ for it to support headers and
-             footers. See our `wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more
-             details on the various versions.
+      .. code-block:: console
+
+         $ sudo apt install postgresql -y
+
+   .. group-tab:: Fedora
+
+      Odoo needs a `PostgreSQL`_ server to run properly. Make sure that the `sudo` command is
+      available and well configured and, only then, execute the following command in order to
+      install the PostgreSQL server:
+
+      .. code-block:: console
+
+         $ sudo dnf install -y postgresql-server
+         $ sudo postgresql-setup --initdb --unit postgresql
+         $ sudo systemctl enable postgresql
+         $ sudo systemctl start postgresql
+
+.. warning::
+   `wkhtmltopdf` is not installed through **pip** and must be installed manually in version `0.12.5
+   <the wkhtmltopdf download page_>`_ for it to support headers and footers. See our `wiki
+   <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more details on the various versions.
 
 Repository
-^^^^^^^^^^
+~~~~~~~~~~
 
-Odoo S.A. provides a repository that can be used with  Debian and Ubuntu distributions. It can be
-used to install *Odoo Community Edition* by executing the following commands **as root**:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Debian/Ubuntu
 
-    # wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
-    # echo "deb http://nightly.odoo.com/13.0/nightly/deb/ ./" >> /etc/apt/sources.list.d/odoo.list
-    # apt-get update && apt-get install odoo
+      Odoo S.A. provides a repository that can be used with Debian and Ubuntu distributions. It can
+      be used to install *Odoo Community Edition* by executing the following commands **as root**:
 
-You can then use the usual `apt-get upgrade` command to keep your installation up-to-date.
+      .. code-block:: console
 
-At this moment, there is no nightly repository for the Enterprise Edition.
+          # wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
+          # echo "deb http://nightly.odoo.com/13.0/nightly/deb/ ./" >> /etc/apt/sources.list.d/odoo.list
+          # apt-get update && apt-get install odoo
 
-Deb Package
-^^^^^^^^^^^
+      You can then use the usual `apt-get upgrade` command to keep your installation up-to-date.
 
-Instead of using the repository as described above, the 'deb' packages for both the *Community* and
-*Enterprise* editions can be downloaded from the `official download page <download_>`_.
+   .. group-tab:: Fedora
 
-Next, execute the following commands **as root**:
+      Odoo S.A. provides a repository that can be used with the Fedora distributions. It can be used
+      to install *Odoo Community Edition* by executing the following commands:
 
-.. code-block:: console
+      .. code-block:: console
 
-    # dpkg -i <path_to_installation_package> # this probably fails with missing dependencies
-    # apt-get install -f # should install the missing dependencies
-    # dpkg -i <path_to_installation_package>
+         $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/13.0/nightly/rpm/odoo.repo
+         $ sudo dnf install -y odoo
+         $ sudo systemctl enable odoo
+         $ sudo systemctl start odoo
 
-This will install Odoo as a service, create the necessary PostgreSQL_ user
-and automatically start the server.
+.. note::
+   At this moment, there is no nightly repository for the Enterprise Edition.
 
-.. warning:: The `python3-xlwt` Debian package does not exists in Debian Buster nor Ubuntu 18.04.
-             This python module is needed to export into xls format.
+Distribution package
+~~~~~~~~~~~~~~~~~~~~
 
-             If you need the feature, you can install it manually with:
+.. tabs::
 
-             .. code-block:: console
+   .. group-tab:: Debian/Ubuntu
 
-                $ sudo pip3 install xlwt
+      Instead of using the repository as described above, the 'deb' packages for both the
+      *Community* and *Enterprise* editions can be downloaded from the `official download page
+      <download_>`_.
 
-.. warning:: The `num2words` python package does not exists in Debian Buster nor Ubuntu 18.04.
-             Textual amounts will not be rendered by Odoo and this could cause problems with the
-             `l10n_mx_edi` module.
+      .. note::
+         Odoo 13.0 'deb' package currently supports `Debian Buster`_, `Ubuntu 18.04`_ or above.
 
-             If you need this feature, you can install manually with:
+      Next, execute the following commands **as root**:
 
-             .. code-block:: console
+      .. code-block:: console
 
-                $ sudo pip3 install num2words
+         # dpkg -i <path_to_installation_package> # this probably fails with missing dependencies
+         # apt-get install -f # should install the missing dependencies
+         # dpkg -i <path_to_installation_package>
 
-Fedora
-''''''
+      This will install Odoo as a service, create the necessary PostgreSQL_ user
+      and automatically start the server.
 
-Odoo 13.0 'rpm' package supports Fedora 30.
+      .. warning::
+         - The `python3-xlwt` Debian package does not exists in Debian Buster nor Ubuntu 18.04. This
+           python module is needed to export into xls format.
 
-Prepare
-^^^^^^^
-Odoo needs a `PostgreSQL`_ server to run properly. Make sure that the `sudo` command is available
-and well configured and, only then, execute the following command in order to install the PostgreSQL
-server:
+           If you need the feature, you can install it manually with:
 
-.. code-block:: console
+           .. code-block:: console
 
-    $ sudo dnf install -y postgresql-server
-    $ sudo postgresql-setup --initdb --unit postgresql
-    $ sudo systemctl enable postgresql
-    $ sudo systemctl start postgresql
+              $ sudo pip3 install xlwt
 
-.. warning:: `wkhtmltopdf` is not installed through **pip** and must be installed manually in
-             version `0.12.5 <the wkhtmltopdf download page_>`_ for it to support headers and
-             footers. See our `wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more
-             details on the various versions.
+         - The `num2words` python package does not exists in Debian Buster nor Ubuntu 18.04. Textual
+           amounts will not be rendered by Odoo and this could cause problems with the `l10n_mx_edi`
+           module.
 
-Repository
-^^^^^^^^^^
+           If you need this feature, you can install manually with:
 
-Odoo S.A. provides a repository that can be used with the Fedora distributions.
-It can be used to install *Odoo Community Edition* by executing the following
-commands:
+           .. code-block:: console
 
-.. code-block:: console
+              $ sudo pip3 install num2words
 
-    $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/13.0/nightly/rpm/odoo.repo
-    $ sudo dnf install -y odoo
-    $ sudo systemctl enable odoo
-    $ sudo systemctl start odoo
+   .. group-tab:: Fedora
 
-RPM package
-^^^^^^^^^^^
+      Instead of using the repository as described above, the 'rpm' packages for both the
+      *Community* and *Enterprise* editions can be downloaded from the `official download page
+      <download_>`_.
 
-Instead of using the repository as described above, the 'rpm' packages for both the *Community* and
-*Enterprise* editions can be downloaded from the `official download page <download_>`_.
+      .. note::
+         Odoo 13.0 'rpm' package supports Fedora 30.
 
-Once downloaded, the package can be installed using the 'dnf' package manager:
+      Once downloaded, the package can be installed using the 'dnf' package manager:
 
-.. code-block:: console
+      .. code-block:: console
 
-    $ sudo dnf localinstall odoo_13.0.latest.noarch.rpm
-    $ sudo systemctl enable odoo
-    $ sudo systemctl start odoo
-
+         $ sudo dnf localinstall odoo_13.0.latest.noarch.rpm
+         $ sudo systemctl enable odoo
+         $ sudo systemctl start odoo
 
 .. _setup/install/source:
 
-Source Install
+Source install
 ==============
 
 The source "installation" is really about not installing Odoo, and running it directly from source
@@ -248,16 +252,13 @@ packaged installations, and allows overriding settings using
 Finally it provides greater control over the system's set up, and allows to more easily keep
 (and run) multiple versions of Odoo side-by-side.
 
-Windows
--------
-
 Fetch the sources
-'''''''''''''''''
+-----------------
 
 There are two ways to obtain the source code of Odoo: as a zip **archive** or through **git**.
 
 Archive
-^^^^^^^
+~~~~~~~
 
 Community Edition:
 
@@ -271,503 +272,403 @@ Enterprise Edition:
 * `GitHub repository <enterprise-repository_>`_
 
 Git
-^^^
+~~~
 
-The following requires git_ to be installed on your machine and that you have basic knowledge of
-git commands.
+The following requires `git <https://git-scm.com/>`_ to be installed on your machine and that you
+have basic knowledge of git commands.
 
 Community Edition:
 
-.. code-block:: doscon
+.. tabs::
 
-    C:\> git clone https://github.com/odoo/odoo.git
+   .. group-tab:: Windows
 
+      .. code-block:: doscon
+
+          C:\> git clone https://github.com/odoo/odoo.git
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          $ git clone https://github.com/odoo/odoo.git
+
+   .. group-tab:: Mac OS
+
+      .. code-block:: console
+
+          $ git clone https://github.com/odoo/odoo.git
 
 Enterprise Edition: (see :ref:`setup/install/editions` to get access)
 
-.. code-block:: doscon
+.. tabs::
 
-  C:\> git clone https://github.com/odoo/enterprise.git
+   .. group-tab:: Windows
 
-.. note:: **The Enterprise git repository does not contain the full Odoo source code**. It is only
-          a collection of extra add-ons. The main server code is in the Community version. Running
-          the Enterprise version actually means running the server from the Community version with
-          the addons-path option set to the folder with the Enterprise version. You need to clone
-          both the Community and Enterprise repository to have a working Odoo Enterprise
-          installation.
+      .. code-block:: doscon
 
-Prepare
-'''''''
+        C:\> git clone https://github.com/odoo/enterprise.git
 
-Python
-^^^^^^
+   .. group-tab:: Linux
 
-Odoo requires Python 3.7 or later to run. Visit `Python's download page <https://www.python.org/downloads/windows/>`_
-to download and install the latest version of Python 3 on your machine.
+      .. code-block:: console
 
-During installation, check **Add Python 3 to PATH**, then click **Customize Installation** and make
-sure that **pip** is checked.
+        $ git clone https://github.com/odoo/enterprise.git
 
-.. note:: If Python 3 is already installed, make sure that the version is 3.7 or above, as previous
-          versions are not compatible with Odoo.
+   .. group-tab:: Mac OS
 
-          .. code-block:: doscon
+      .. code-block:: console
 
-              C:\> python --version
-
-          Verify also that pip_ is installed for this version.
-
-          .. code-block:: doscon
-
-              C:\> pip --version
-
-PostgreSQL
-^^^^^^^^^^
-
-Odoo uses PostgreSQL as database management system. `Download and install PostgreSQL <https://www.postgresql.org/download/windows/>`_
-(supported version: 10.0 and later).
-
-By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need to
-create a new PostgreSQL user:
-
-#. Add PostgreSQL's `bin` directory (by default: `C:\\Program Files\\PostgreSQL\\<version>\\bin`) to
-   your `PATH`.
-#. Create a postgres user with a password using the pg admin gui:
-
-   1. Open **pgAdmin**.
-   2. Double-click the server to create a connection.
-   3. Select :menuselection:`Object --> Create --> Login/Group Role`.
-   4. Enter the username in the **Role Name** field (e.g. `odoo`).
-   5. Open the **Definition** tab and enter the password (e.g. ``odoo``), then click **Save**.
-   6. Open the **Privileges** tab and switch **Can login?** to `Yes` and **Create database?** to
-      `Yes`.
-
-Dependencies
-^^^^^^^^^^^^
-
-Before installing the dependencies, you must download and install the
-`Build Tools for Visual Studio <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019>`_.
-When prompted, select **C++ build tools** in the **Workloads** tab and install them.
-
-Odoo dependencies are listed in the `requirements.txt` file located at the root of the Odoo
-community directory.
-
-.. tip:: It can be preferable to not mix python modules packages between different instances of Odoo
-         or with your system. You can use virtualenv_ to create isolated Python environments.
-
-Navigate to the path of your Odoo Community installation (`CommunityPath`) and run **pip**
-on the requirements file in a terminal **with Administrator privileges**:
-
-.. code-block:: doscon
-
-    C:\> cd \CommunityPath
-    C:\> pip install setuptools wheel
-    C:\> pip install -r requirements.txt
-
-.. warning:: `wkhtmltopdf` is not installed through **pip** and must be installed manually in
-             version `0.12.5 <the wkhtmltopdf download page_>`_ for it to support headers and
-             footers. See our `wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more
-             details on the various versions.
-
-For languages with right-to-left interface (such as Arabic or Hebrew), the package `rtlcss` is
-needed:
-
-#. Download and install `nodejs <https://nodejs.org/en/download/>`_.
-#. Install `rtlcss`:
-
-   .. code-block:: doscon
-
-       C:\> npm install -g rtlcss
-
-#. Edit the System Environment's variable `PATH` to add the folder where `rtlcss.cmd` is located
-   (typically: `C:\\Users\\<user>\\AppData\\Roaming\\npm\\`).
-
-Running Odoo
-''''''''''''
-
-Once all dependencies are set up, Odoo can be launched by running `odoo-bin`, the
-command-line interface of the server. It is located at the root of the Odoo Community directory.
-
-To configure the server, you can either specify :ref:`command-line arguments <reference/cmdline/server>` or a
-:ref:`configuration file <reference/cmdline/config>`.
-
-.. tip:: For the Enterprise edition, you must add the path to the `enterprise` addons to the
-         `addons-path` argument. Note that it must come before the other paths in `addons-path` for
-         addons to be loaded correctly.
-
-Common necessary configurations are:
-
-* PostgreSQL user and password.
-* Custom addon paths beyond the defaults, to load your own modules.
-
-A typical way to run the server would be:
-
-.. code-block:: doscon
-
-    C:\> cd CommunityPath/
-    C:\> python odoo-bin -r dbuser -w dbpassword --addons-path=addons -d mydb
-
-Where `CommunityPath` is the path of the Odoo Community installation, `dbuser` is the
-PostgreSQL login, `dbpassword` is the PostgreSQL password
-and `mydb` is the default database to serve on `localhost:8069`. You can add other
-directory paths separated by a comma to ``addons`` at the end of the addons-path option.
-
-Linux
------
-
-Fetch the sources
-'''''''''''''''''
-
-There are two ways to obtain the source code of Odoo: as a zip **archive** or through **git**.
-
-Archive
-^^^^^^^
-
-Community Edition:
-
-* `Official download page <download_>`_
-* `GitHub repository <community-repository_>`_
-* `Nightly server <nightly_>`_
-
-Enterprise Edition:
-
-* `Official download page <download_>`_
-* `GitHub repository <enterprise-repository_>`_
-
-Git
-^^^
-
-The following requires git_ to be installed on your machine and that you have basic knowledge of
-git commands.
-
-Community Edition:
-
-.. code-block:: console
-
-    $ git clone https://github.com/odoo/odoo.git
-
-
-Enterprise Edition: (see :ref:`setup/install/editions` to get access)
-
-.. code-block:: console
-
-  $ git clone https://github.com/odoo/enterprise.git
-
-.. note:: **The Enterprise git repository does not contain the full Odoo source code**. It is only
-          a collection of extra add-ons. The main server code is in the Community version. Running
-          the Enterprise version actually means running the server from the Community version with
-          the addons-path option set to the folder with the Enterprise version. You need to clone
-          both the Community and Enterprise repository to have a working Odoo Enterprise
-          installation.
-
-Prepare
-'''''''
-
-Python
-^^^^^^
-
-Odoo requires Python 3.7 or later to run. Use your package manager to download and install Python 3
-on your machine if it is not already done.
-
-.. note:: If Python 3 is already installed, make sure that the version is 3.7 or above, as previous
-          versions are not compatible with Odoo.
-
-          .. code-block:: console
-
-              $ python3 --version
-
-          Verify also that pip_ is installed for this version.
-
-          .. code-block:: console
-
-              $ pip3 --version
-
-PostgreSQL
-^^^^^^^^^^
-
-Odoo uses PostgreSQL as database management system. Use your package manager to download and install
-PostgreSQL (supported version: 10.0 and later).
-
-On Debian/Unbuntu, it can be achieved by executing the following:
-
-.. code-block:: console
-
-    $ sudo apt install postgresql postgresql-client
-
-By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need to
-create a new PostgreSQL user:
-
-.. code-block:: console
-
-  $ sudo -u postgres createuser -s $USER
-  $ createdb $USER
-
-.. note:: Because your PostgreSQL user has the same name as your Unix login, you will be able to
-          connect to the database without password.
-
-.. _install/python-dependencies:
-
-Python Dependencies
-^^^^^^^^^^^^^^^^^^^
-
-Debian/Ubuntu
-~~~~~~~~~~~~~
-
-Using your **distribution packages** is the preferred way of installing dependencies.
-
-For Debian-based systems, these packages are listed in the `debian/control
-<https://github.com/odoo/odoo/blob/master/debian/control>`_ file of the Odoo sources.
-
-On Debian/Ubuntu, the following commands should install the required packages:
-
-.. code-block:: console
-
-   $ cd /CommunityPath
-   $ sed -n -e '/^Depends:/,/^Pre/ s/ python3-\(.*\),/python3-\1/p' debian/control | sudo xargs apt-get install -y
-
-Install with pip
-~~~~~~~~~~~~~~~~
-
-Alternatively, you can use **pip** to install python dependencies. As some of the packages need a
-compilation step, they require system libraries to be installed.
-
-On Debian/Ubuntu-based systems, the following command should install these required libraries:
-
-.. code-block:: console
-
-   $ sudo apt install python3-pip libldap2-dev libpq-dev libsasl2-dev
-
-Odoo dependencies are listed in the :file:`requirements.txt` file located at the root of the Odoo
-community directory.
+        $ git clone https://github.com/odoo/enterprise.git
 
 .. note::
-   The python packages in :file:`requirements.txt` are based on their stable/LTS Debian/Ubuntu
-   corresponding version at the moment of the Odoo release.
-
-   E.g., for Odoo 15.0, the `python3-babel` package version is 2.8.0 in Debian Bullseye and 2.6.0
-   in Ubuntu Focal. The lowest version is then chosen in the :file:`requirements.txt`.
-
-Navigate to the path of your Odoo Community installation (:file:`CommunityPath`) and run **pip** on
-the requirements file to install the requirements for the current user.
-
-.. code-block:: console
-
-   $ cd /CommunityPath
-   $ pip install -r requirements.txt
-
-.. tip::
-   It can be preferable not to mix python modules packages between different instances of Odoo or
-   with your system. You can use virtualenv_ to create isolated Python environments.
-
-Other Dependencies
-^^^^^^^^^^^^^^^^^^
-
-- `wkhtmltopdf` must be installed manually in version `0.12.5
-  <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.5/>`_ to support headers and footers.
-  See our `wiki about wkhtmltopdf <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more details
-  on the various versions.
-- Languages with a right-to-left interface (such as Arabic or Hebrew) require the `rtlcss` package:
-
-  #. Download and install **nodejs** and **npm** with your package manager.
-  #. Install `rtlcss`:
-
-     .. code-block:: console
-
-         $ sudo npm install -g rtlcss
-
-Running Odoo
-''''''''''''
-
-Once all dependencies are set up, Odoo can be launched by running `odoo-bin`, the
-command-line interface of the server. It is located at the root of the Odoo Community directory.
-
-To configure the server, you can either specify :ref:`command-line arguments <reference/cmdline/server>` or a
-:ref:`configuration file <reference/cmdline/config>`.
-
-.. tip:: For the Enterprise edition, you must add the path to the `enterprise` addons to the
-         `addons-path` argument. Note that it must come before the other paths in `addons-path` for
-         addons to be loaded correctly.
-
-Common necessary configurations are:
-
-* PostgreSQL user and password. Odoo has no defaults beyond
-  `psycopg2's defaults <http://initd.org/psycopg/docs/module.html>`_: connects over a UNIX socket on
-  port `5432` with the current user and no password.
-* Custom addon paths beyond the defaults, to load your own modules.
-
-A typical way to run the server would be:
-
-.. code-block:: console
-
-    $ cd /CommunityPath
-    $ python3 odoo-bin --addons-path=addons -d mydb
-
-Where `CommunityPath` is the path of the Odoo Community installation
-and `mydb` is the default database to serve on `localhost:8069`. You can add other
-directory paths separated by a comma to ``addons`` at the end of the addons-path option.
-
-Mac OS
-------
-
-Fetch the sources
-'''''''''''''''''
-
-There are two ways to obtain the source code of Odoo: as a zip **archive** or through **git**.
-
-Archive
-^^^^^^^
-
-Community Edition:
-
-* `Official download page <download_>`_
-* `GitHub repository <community-repository_>`_
-* `Nightly server <nightly_>`_
-
-Enterprise Edition:
-
-* `Official download page <download_>`_
-* `GitHub repository <enterprise-repository_>`_
-
-Git
-^^^
-
-The following requires git_ to be installed on your machine and that you have basic knowledge of
-git commands.
-
-Community Edition:
-
-.. code-block:: console
-
-    $ git clone https://github.com/odoo/odoo.git
-
-
-Enterprise Edition: (see :ref:`setup/install/editions` to get access)
-
-.. code-block:: console
-
-  $ git clone https://github.com/odoo/enterprise.git
-
-.. note:: **The Enterprise git repository does not contain the full Odoo source code**. It is only
-          a collection of extra add-ons. The main server code is in the Community version. Running
-          the Enterprise version actually means running the server from the Community version with
-          the addons-path option set to the folder with the Enterprise version. You need to clone
-          both the Community and Enterprise repository to have a working Odoo Enterprise
-          installation.
+   **The Enterprise git repository does not contain the full Odoo source code**. It is only a
+   collection of extra add-ons. The main server code is in the Community version. Running the
+   Enterprise version actually means running the server from the Community version with the
+   addons-path option set to the folder with the Enterprise version. You need to clone both the
+   Community and Enterprise repository to have a working Odoo Enterprise installation.
 
 Prepare
-'''''''
+-------
 
 Python
-^^^^^^
+~~~~~~
 
-Odoo requires Python 3.7 or later to run. Use your preferred package manager (homebrew_, macports_)
-to download and install Python 3 on your machine if it is not already done.
+.. tabs::
 
-.. note:: If Python 3 is already installed, make sure that the version is 3.7 or above, as previous
-          versions are not compatible with Odoo.
+   .. group-tab:: Windows
 
-          .. code-block:: console
+      Odoo requires Python 3.7 or later to run. Visit `Python's download page <https://www.python.org/downloads/windows/>`_
+      to download and install the latest version of Python 3 on your machine.
 
-              $ python3 --version
+      During installation, check **Add Python 3 to PATH**, then click **Customize Installation** and make
+      sure that **pip** is checked.
 
-          Verify also that pip_ is installed for this version.
+      .. note::
+         If Python 3 is already installed, make sure that the version is 3.7 or above, as previous
+         versions are not compatible with Odoo.
 
-          .. code-block:: console
+         .. code-block:: doscon
 
-              $ pip3 --version
+            C:\> python --version
+
+         Verify also that pip_ is installed for this version.
+
+         .. code-block:: doscon
+
+            C:\> pip --version
+
+   .. group-tab:: Linux
+
+      Odoo requires Python 3.7 or later to run. Use your package manager to download and install Python 3
+      on your machine if it is not already done.
+
+      .. note::
+         If Python 3 is already installed, make sure that the version is 3.7 or above, as previous
+         versions are not compatible with Odoo.
+
+         .. code-block:: console
+
+            $ python3 --version
+
+         Verify also that pip_ is installed for this version.
+
+         .. code-block:: console
+
+            $ pip3 --version
+
+   .. group-tab:: Mac OS
+
+      Odoo requires Python 3.7 or later to run. Use your preferred package manager (homebrew_, macports_)
+      to download and install Python 3 on your machine if it is not already done.
+
+      .. note::
+         If Python 3 is already installed, make sure that the version is 3.7 or above, as previous
+         versions are not compatible with Odoo.
+
+         .. code-block:: console
+
+            $ python3 --version
+
+         Verify also that pip_ is installed for this version.
+
+         .. code-block:: console
+
+            $ pip3 --version
 
 PostgreSQL
-^^^^^^^^^^
+~~~~~~~~~~
 
-Odoo uses PostgreSQL as database management system. Use `postgres.app <https://postgresapp.com>`_
-to download and install PostgreSQL (supported version: 10.0 and later).
+.. tabs::
 
-By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need to
-create a new PostgreSQL user:
+   .. group-tab:: Windows
 
-.. code-block:: console
+      Odoo uses PostgreSQL as database management system. `Download and install PostgreSQL
+      <https://www.postgresql.org/download/windows/>`_ (supported version: 10.0 and later).
 
-  $ sudo -u postgres createuser -s $USER
-  $ createdb $USER
+      By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need
+      to create a new PostgreSQL user:
 
-.. note:: Because your PostgreSQL user has the same name as your Unix login, you will be able to
-          connect to the database without password.
+      #. Add PostgreSQL's `bin` directory (by default:
+         :file:`C:\\Program Files\\PostgreSQL\\<version>\\bin`) to your `PATH`.
+      #. Create a postgres user with a password using the pg admin gui:
+
+         1. Open **pgAdmin**.
+         2. Double-click the server to create a connection.
+         3. Select :menuselection:`Object --> Create --> Login/Group Role`.
+         4. Enter the username in the **Role Name** field (e.g. `odoo`).
+         5. Open the **Definition** tab and enter the password (e.g. `odoo`), then click **Save**.
+         6. Open the **Privileges** tab and switch **Can login?** to `Yes` and **Create database?**
+            to `Yes`.
+
+   .. group-tab:: Linux
+
+      Odoo uses PostgreSQL as database management system. Use your package manager to download and
+      install PostgreSQL (supported version: 10.0 and later).
+
+      It can be achieved by executing the following:
+
+      .. code-block:: console
+
+          $ sudo apt install postgresql postgresql-client
+
+      By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need
+      to create a new PostgreSQL user:
+
+      .. code-block:: console
+
+        $ sudo -u postgres createuser -s $USER
+        $ createdb $USER
+
+      .. note::
+         Because your PostgreSQL user has the same name as your Unix login, you will be able to
+         connect to the database without password.
+
+   .. group-tab:: Mac OS
+
+      Odoo uses PostgreSQL as database management system. Use `postgres.app
+      <https://postgresapp.com>`_ to download and install PostgreSQL (supported version: 10.0 and
+      later).
+
+      By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need
+      to create a new PostgreSQL user:
+
+      .. code-block:: console
+
+        $ sudo -u postgres createuser -s $USER
+        $ createdb $USER
+
+      .. note::
+         Because your PostgreSQL user has the same name as your Unix login, you will be able to
+         connect to the database without password.
+
+.. _install/dependencies:
 
 Dependencies
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
-Odoo dependencies are listed in the `requirements.txt` file located at the root of the Odoo
-community directory.
+.. tabs::
 
-.. tip:: It can be preferable to not mix python modules packages between different instances of Odoo
+   .. group-tab:: Windows
+
+      Before installing the dependencies, you must download and install the `Build Tools for Visual
+      Studio <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019>`_.
+      When prompted, select **C++ build tools** in the **Workloads** tab and install them.
+
+      Odoo dependencies are listed in the `requirements.txt` file located at the root of the Odoo
+      community directory.
+
+      .. tip::
+         It can be preferable to not mix python modules packages between different instances of Odoo
          or with your system. You can use virtualenv_ to create isolated Python environments.
 
-Navigate to the path of your Odoo Community installation (`CommunityPath`) and run **pip**
-on the requirements file:
+      Navigate to the path of your Odoo Community installation (`CommunityPath`) and run **pip** on
+      the requirements file in a terminal **with Administrator privileges**:
 
-.. code-block:: console
+      .. code-block:: doscon
 
-   $ cd /CommunityPath
-   $ pip3 install setuptools wheel
-   $ pip3 install -r requirements.txt
+          C:\> cd \CommunityPath
+          C:\> pip install setuptools wheel
+          C:\> pip install -r requirements.txt
 
-.. warning:: Non-Python dependencies need to be installed with a package manager:
+      For languages with right-to-left interface (such as Arabic or Hebrew), the package `rtlcss`
+      is needed:
 
-             #. Download and install the **Command Line Tools**:
+      #. Download and install `nodejs <https://nodejs.org/en/download/>`_.
+      #. Install `rtlcss`:
 
-                .. code-block:: console
+         .. code-block:: doscon
 
-                   $ xcode-select --install
+             C:\> npm install -g rtlcss
 
-             #. Download and install the package manager of your choice (homebrew_, macports_).
-             #. Install non-python dependencies.
+      #. Edit the System Environment's variable `PATH` to add the folder where `rtlcss.cmd` is
+         located (typically: :file:`C:\\Users\\<user>\\AppData\\Roaming\\npm\\`).
 
-.. warning:: `wkhtmltopdf` is not installed through **pip** and must be installed manually in
-             version `0.12.5 <the wkhtmltopdf download page_>`_ for it to support headers and
-             footers. See our `wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more
-             details on the various versions.
+   .. group-tab:: Linux
 
-For languages with right-to-left interface (such as Arabic or Hebrew), the package `rtlcss` is
-needed:
+      Using your **distribution packages** is the preferred way of installing dependencies.
+      Alternatively, you can install the python dependencies with **pip**.
 
-#. Download and install **nodejs** with your preferred package manager (homebrew_, macports_).
-#. Install `rtlcss`:
+      .. tabs::
 
-   .. code-block:: console
+         .. tab:: Debian/Ubuntu
 
-       $ sudo npm install -g rtlcss
+            For Debian-based systems, the packages are listed in the `debian/control
+            <https://github.com/odoo/odoo/blob/master/debian/control>`_ file of the Odoo sources.
+
+            On Debian/Ubuntu, the following commands should install the required packages:
+
+            .. code-block:: console
+
+               $ cd /CommunityPath
+               $ sed -n -e '/^Depends:/,/^Pre/ s/ python3-\(.*\),/python3-\1/p' debian/control | sudo xargs apt-get install -y
+
+         .. tab:: Install with pip
+
+            As some of the python packages need a compilation step, they require system libraries to
+            be installed.
+
+            On Debian/Ubuntu-based systems, the following command should install these required
+            libraries:
+
+            .. code-block:: console
+
+               $ sudo apt install python3-pip libldap2-dev libpq-dev libsasl2-dev
+
+            Odoo dependencies are listed in the :file:`requirements.txt` file located at the root of
+            the Odoo community directory.
+
+            .. note::
+               | The python packages in :file:`requirements.txt` are based on their stable/LTS
+                 Debian/Ubuntu corresponding version at the moment of the Odoo release.
+               | E.g., for Odoo 15.0, the `python3-babel` package version is 2.8.0 in Debian
+                 Bullseye and 2.6.0 in Ubuntu Focal. The lowest version is then chosen in the
+                 :file:`requirements.txt`.
+
+            .. tip::
+               It can be preferable to not mix python modules packages between different instances
+               of Odoo or with your system. You can use virtualenv_ to create isolated Python
+               environments.
+
+            Navigate to the path of your Odoo Community installation (:file:`CommunityPath`) and run
+            **pip** on the requirements file to install the requirements for the current user.
+
+            .. code-block:: console
+
+               $ cd /CommunityPath
+               $ pip install -r requirements.txt
+
+      For languages with right-to-left interface (such as Arabic or Hebrew), the package `rtlcss` is
+      needed:
+
+      #. Download and install **nodejs** and **npm** with your package manager.
+      #. Install `rtlcss`:
+
+         .. code-block:: console
+
+            $ sudo npm install -g rtlcss
+
+   .. group-tab:: Mac OS
+
+      Odoo dependencies are listed in the `requirements.txt` file located at the root of the Odoo
+      community directory.
+
+      .. tip::
+         It can be preferable to not mix python modules packages between different instances of Odoo
+         or with your system. You can use virtualenv_ to create isolated Python environments.
+
+      Navigate to the path of your Odoo Community installation (`CommunityPath`) and run **pip** on
+      the requirements file:
+
+      .. code-block:: console
+
+         $ cd /CommunityPath
+         $ pip3 install setuptools wheel
+         $ pip3 install -r requirements.txt
+
+      .. warning::
+         Non-Python dependencies need to be installed with a package manager:
+
+         #. Download and install the **Command Line Tools**:
+
+            .. code-block:: console
+
+               $ xcode-select --install
+
+         #. Download and install the package manager of your choice (homebrew_, macports_).
+         #. Install non-python dependencies.
+
+      For languages with right-to-left interface (such as Arabic or Hebrew), the package `rtlcss` is
+      needed:
+
+      #. Download and install **nodejs** with your preferred package manager (homebrew_, macports_).
+      #. Install `rtlcss`:
+
+         .. code-block:: console
+
+             $ sudo npm install -g rtlcss
+
+.. important::
+   `wkhtmltopdf` is not installed through **pip** and must be installed manually in version `0.12.5
+   <the wkhtmltopdf download page_>`_ for it to support headers and footers. See our `wiki
+   <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for more details on the various versions.
 
 Running Odoo
-''''''''''''
+------------
 
 Once all dependencies are set up, Odoo can be launched by running `odoo-bin`, the
 command-line interface of the server. It is located at the root of the Odoo Community directory.
 
-To configure the server, you can either specify :ref:`command-line arguments <reference/cmdline/server>` or a
-:ref:`configuration file <reference/cmdline/config>`.
+To configure the server, you can either specify :ref:`command-line arguments
+<reference/cmdline/server>` or a :ref:`configuration file <reference/cmdline/config>`.
 
-.. tip:: For the Enterprise edition, you must add the path to the `enterprise` addons to the
-         `addons-path` argument. Note that it must come before the other paths in `addons-path` for
-         addons to be loaded correctly.
+.. tip::
+   For the Enterprise edition, you must add the path to the `enterprise` addons to the `addons-path`
+   argument. Note that it must come before the other paths in `addons-path` for addons to be loaded
+   correctly.
 
 Common necessary configurations are:
 
-* PostgreSQL user and password. Odoo has no defaults beyond
-  `psycopg2's defaults <http://initd.org/psycopg/docs/module.html>`_: connects over a UNIX socket on
-  port `5432` with the current user and no password.
-* Custom addon paths beyond the defaults, to load your own modules.
+- PostgreSQL user and password.
+- Custom addon paths beyond the defaults, to load your own modules.
 
 A typical way to run the server would be:
 
-.. code-block:: console
+.. tabs::
 
-    $ cd /CommunityPath
-    $ python3 odoo-bin --addons-path=addons -d mydb
+   .. group-tab:: Windows
 
-Where `CommunityPath` is the path of the Odoo Community installation
-and `mydb` is the default database to serve on `localhost:8069`. You can add other
-directory paths separated by a comma to ``addons`` at the end of the addons-path option.
+      .. code-block:: doscon
 
+          C:\> cd CommunityPath/
+          C:\> python odoo-bin -r dbuser -w dbpassword --addons-path=addons -d mydb
+
+      Where `CommunityPath` is the path of the Odoo Community installation, `dbuser` is the
+      PostgreSQL login, `dbpassword` is the PostgreSQL password and `mydb` is the default database
+      to serve on `localhost:8069`. You can add other directory paths separated by a comma to
+      `addons` at the end of the `addons-path` option.
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+          $ cd /CommunityPath
+          $ python3 odoo-bin --addons-path=addons -d mydb
+
+      Where `CommunityPath` is the path of the Odoo Community installation and `mydb` is the default
+      database to serve on `localhost:8069`. You can add other directory paths separated by a comma
+      to `addons` at the end of the `addons-path` option.
+
+   .. group-tab:: Mac OS
+
+      .. code-block:: console
+
+          $ cd /CommunityPath
+          $ python3 odoo-bin --addons-path=addons -d mydb
+
+      Where `CommunityPath` is the path of the Odoo Community installation and `mydb` is the default
+      database to serve on `localhost:8069`. You can add other directory paths separated by a comma
+      to `addons` at the end of the `addons-path` option.
 
 .. _setup/install/docker:
 
@@ -801,7 +702,6 @@ official Odoo `docker image <https://registry.hub.docker.com/_/odoo/>`_ page.
 .. _pywin32: http://sourceforge.net/projects/pywin32/files/pywin32/
 .. _community-repository: https://github.com/odoo/odoo
 .. _enterprise-repository: https://github.com/odoo/enterprise
-.. _git: https://git-scm.com/
 .. _Editions: https://www.odoo.com/pricing#pricing_table_features
 .. _nightly: https://nightly.odoo.com/
 .. _extra: https://nightly.odoo.com/extra/

--- a/content/contributing/documentation/rst_cheat_sheet.rst
+++ b/content/contributing/documentation/rst_cheat_sheet.rst
@@ -502,6 +502,219 @@ Render
 
    Customize this admonition with a **Title** of your choice.
 
+.. _contributing/tabs:
+
+Content tabs
+============
+
+.. caution::
+   The `tabs` directive may not work well in some situations. In particular:
+
+   - The tabs' headers cannot be translated.
+   - A tab cannot contain :ref:`headings <contributing/headings>`.
+   - An :ref:`admonition <contributing/admonitions>` cannot contain tabs.
+   - A tab cannot contain :ref:`internal hyperlink targets
+     <contributing/internal-hyperlink-targets>`.
+
+Basic tabs
+----------
+
+RST
+~~~
+
+.. code-block:: rst
+
+   .. tabs::
+
+      .. tab:: Odoo Online
+
+         Content dedicated to Odoo Online users.
+
+      .. tab:: Odoo.sh
+
+         Alternative for Odoo.sh users.
+
+      .. tab:: On-premise
+
+         Third version for On-premise users.
+
+Render
+~~~~~~
+
+.. tabs::
+
+   .. tab:: Odoo Online
+
+      Content dedicated to Odoo Online users.
+
+   .. tab:: Odoo.sh
+
+      Alternative for Odoo.sh users.
+
+   .. tab:: On-premise
+
+      Third version for On-premise users.
+
+Nested tabs
+-----------
+
+RST
+~~~
+
+.. code-block:: rst
+
+   .. tabs::
+
+      .. tab:: Stars
+
+         .. tabs::
+
+            .. tab:: The Sun
+
+               The closest star to us.
+
+            .. tab:: Proxima Centauri
+
+               The second closest star to us.
+
+            .. tab:: Polaris
+
+               The North Star.
+
+      .. tab:: Moons
+
+         .. tabs::
+
+            .. tab:: The Moon
+
+               Orbits the Earth.
+
+            .. tab:: Titan
+
+               Orbits Jupiter.
+
+Render
+~~~~~~
+
+.. tabs::
+
+   .. tab:: Stars
+
+      .. tabs::
+
+         .. tab:: The Sun
+
+            The closest star to us.
+
+         .. tab:: Proxima Centauri
+
+            The second closest star to us.
+
+         .. tab:: Polaris
+
+            The North Star.
+
+   .. tab:: Moons
+
+      .. tabs::
+
+         .. tab:: The Moon
+
+            Orbits the Earth.
+
+         .. tab:: Titan
+
+            Orbits Jupiter.
+
+Group tabs
+----------
+
+RST
+~~~
+
+.. code-block:: rst
+
+   .. tabs::
+
+      .. group-tab:: C++
+
+         C++
+
+      .. group-tab:: Python
+
+         Python
+
+      .. group-tab:: Java
+
+         Java
+
+   .. tabs::
+
+      .. group-tab:: C++
+
+         .. code-block:: c++
+
+            int main(const int argc, const char **argv) {
+                return 0;
+            }
+
+      .. group-tab:: Python
+
+         .. code-block:: python
+
+            def main():
+                return
+
+      .. group-tab:: Java
+
+         .. code-block:: java
+
+            class Main {
+                public static void main(String[] args) {}
+            }
+
+Render
+~~~~~~
+
+.. tabs::
+
+   .. group-tab:: C++
+
+      C++
+
+   .. group-tab:: Python
+
+      Python
+
+   .. group-tab:: Java
+
+      Java
+
+.. tabs::
+
+   .. group-tab:: C++
+
+      .. code-block:: c++
+
+         int main(const int argc, const char **argv) {
+             return 0;
+         }
+
+   .. group-tab:: Python
+
+      .. code-block:: python
+
+         def main():
+             return
+
+   .. group-tab:: Java
+
+      .. code-block:: java
+
+         class Main {
+             public static void main(String[] args) {}
+         }
+
 .. _contributing/document-metadata:
 
 Document metadata

--- a/content/developer/howtos/rdtraining/02_setup.rst
+++ b/content/developer/howtos/rdtraining/02_setup.rst
@@ -184,7 +184,7 @@ You can check your Python version with:
 Install required packages
 -------------------------
 
-See :ref:`install/python-dependencies`
+See :ref:`install/dependencies`.
 
 .. _howto/rdtraining/02_setup/install-wkhtmltopdf:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ libsass==0.18.0
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 sphinx~=3.0
+sphinx-tabs~=3.2.0
 werkzeug==0.14.1


### PR DESCRIPTION
In many places in the docs, we need to document several flows that
differ only by a few details. For example, the steps to install Odoo
from the sources are almost identical for Windows, Linux, and Mac OS.
In other places, we'd want to suggest a command in different
environments or programming languages, etc.

This commit thus adds an extension for content tabs (tabs within the
content) to help reduce content repetition in the documentation. As a
proof of concept, the "Packaged installers" and "Source install"
sections of the "Installing Odoo" page are reworked to present their
content within tabs whenever it helps clarify the instructions.

A new python dependency is added as of this commit: `sphinx-tabs`

task-2713983