### PR TITLE
[FIX] redirections: duplicate rule + misplaced rules

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -200,7 +200,7 @@ applications/general/payment_acquirers/wire_transfer.rst applications/finance/pa
 discuss/monitoring.rst applications/productivity/discuss/overview/get_started.rst                    # (#655)
 discuss/mentions.rst applications/productivity/discuss/overview/get_started.rst                      # (#655)
 discuss/tracking.rst applications/services/project/tasks/collaborate.rst                         # (#655)
-discuss/email_servers.rst applications/productivity/discuss/advanced/email_servers.rst               # (#655)
+discuss/email_servers.rst applications/general/email_communication/email_servers.rst                 # (#655)
 discuss/plan_activities.rst applications/productivity/discuss/overview/plan_activities.rst           # (#655)
 discuss/team_communication.rst applications/productivity/discuss/overview/team_communication.rst     # (#655)
 discuss/overview.rst applications/productivity/discuss/overview/get_started.rst                      # (#655)
@@ -225,6 +225,8 @@ applications/general/developer_mode/activate.rst applications/general/developer_
 applications/general/odoo_basics/users.rst applications/general/users.rst                                 # odoo_basics/users -> users
 applications/general/odoo_basics/choose_language.rst  applications/general/users/language.rst             # odoo_basics/choose_language -> users/language
 applications/general/auth/google_spreadsheets.rst applications/sales/crm/performance/google_spreadsheets.rst  # general/auth/* -> sales/crm/performance/
+applications/productivity/discuss/advanced/email_servers.rst applications/general/email_communication/email_servers.rst     # productivity/discuss/advanced/* -> general/email_communication/*
+applications/productivity/discuss/advanced/email_template.rst applications/general/email_communication/email_template.rst   # productivity/discuss/advanced/* -> general/email_communication/*
 
 applications/finance/sign/overview/signature_validity.rst applications/finance/sign.rst        # sign/overview/signature_validity -> sign/*
 
@@ -269,7 +271,3 @@ developer/reference/mobile.rst                            developer/reference/ja
 developer/reference/qweb.rst                              developer/reference/javascript/qweb.rst
 
 services/support/supported_versions.rst administration/maintain/supported_versions.rst       # services/support/* -> administration/maintain/*
-applications/finance/sign/overview/signature_validity.rst applications/finance/sign.rst        #sign/overview/signature_validity -> sign/*
-
-applications/productivity/discuss/advanced/email_servers.rst applications/general/email_communication/email_servers.rst
-applications/productivity/discuss/advanced/email_template.rst applications/general/email_communication/email_template.rst


### PR DESCRIPTION
- removes a duplicate rule:
  applications/finance/sign/overview/signature_validity.rst
  applications/finance/sign.rst
- moves two rules closer to their related redirections
- adds comments to these two rules
- updates redirection to "email_servers" with the new path (line 203)


This PR fixes issues in redirects.txt added with PR #1092 
cc @Abridbus 