### PR TITLE
Update Odoo version references on `install.rst` (13.0 -> 15.0)

### DIFF
--- a/content/administration/install/install.rst
+++ b/content/administration/install/install.rst
@@ -107,7 +107,7 @@ Linux
 Debian/Ubuntu
 '''''''''''''
 
-Odoo 13.0 'deb' package currently supports `Debian Buster`_, `Ubuntu 18.04`_ or above.
+Odoo 15.0 'deb' package currently supports `Debian Buster`_, `Ubuntu 18.04`_ or above.
 
 Prepare
 ^^^^^^^
@@ -134,7 +134,7 @@ used to install *Odoo Community Edition* by executing the following commands **a
 .. code-block:: console
 
     # wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
-    # echo "deb http://nightly.odoo.com/13.0/nightly/deb/ ./" >> /etc/apt/sources.list.d/odoo.list
+    # echo "deb http://nightly.odoo.com/15.0/nightly/deb/ ./" >> /etc/apt/sources.list.d/odoo.list
     # apt-get update && apt-get install odoo
 
 You can then use the usual `apt-get upgrade` command to keep your installation up-to-date.
@@ -180,7 +180,7 @@ and automatically start the server.
 Fedora
 ''''''
 
-Odoo 13.0 'rpm' package supports Fedora 30.
+Odoo 15.0 'rpm' package supports Fedora 30.
 
 Prepare
 ^^^^^^^
@@ -209,7 +209,7 @@ commands:
 
 .. code-block:: console
 
-    $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/13.0/nightly/rpm/odoo.repo
+    $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/15.0/nightly/rpm/odoo.repo
     $ sudo dnf install -y odoo
     $ sudo systemctl enable odoo
     $ sudo systemctl start odoo
@@ -224,7 +224,7 @@ Once downloaded, the package can be installed using the 'dnf' package manager:
 
 .. code-block:: console
 
-    $ sudo dnf localinstall odoo_13.0.latest.noarch.rpm
+    $ sudo dnf localinstall odoo_15.0.latest.noarch.rpm
     $ sudo systemctl enable odoo
     $ sudo systemctl start odoo
 


### PR DESCRIPTION
Not sure why these haven't been updated for so long -- The official website's package install instruction is still pointing to 13.0!