### PR TITLE
Adds note about dev mode toggle

### DIFF
--- a/content/applications/general/developer_mode.rst
+++ b/content/applications/general/developer_mode.rst
@@ -11,6 +11,9 @@ Activate through the Settings
 
 Go to :menuselection:`Settings --> Activate the developer mode`.
 
+.. note::
+   You need to have at least one app installed for this menu option to appear.
+
 .. image:: settings.png
    :align: center
    :alt: Overview of the debug options under settings in Odoo


### PR DESCRIPTION
Adds note warning users they need at least one app installed to be able to see the 'enable dev mode' option. Took me a while to figure this out as it doesn't seem to be mentioned anywhere (in these docs or in the `Development Environment Set-up`article).