### PR TITLE
[IMP] conf: show all relevant versions in the version switcher

### DIFF
--- a/extensions/odoo_theme/layout_templates/language_switcher.html
+++ b/extensions/odoo_theme/layout_templates/language_switcher.html
@@ -7,7 +7,7 @@
                 {{ language }} {# The current language #}
             </button>
         {%- else %}
-            <button class="btn border"
+            <button class="btn border dropdown-toggle"
                     id="languages"
                     disabled="">
                 {{ language }} {# The current language #}

--- a/extensions/odoo_theme/layout_templates/version_switcher.html
+++ b/extensions/odoo_theme/layout_templates/version_switcher.html
@@ -8,13 +8,13 @@
                 <button class="btn border dropdown-toggle"
                         id="versions"
                         data-bs-toggle="dropdown">
-                    {{ version }} {# The current version #}
+                    {{ version_display_name }} {# The current version #}
                 </button>
             {%- else %}
-                <button class="btn border"
+                <button class="btn border dropdown-toggle"
                         id="versions"
                         disabled="">
-                    {{ version }} {# The current version #}
+                    {{ version_display_name }} {# The current version #}
                 </button>
             {%- endif %}
             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="versions">


### PR DESCRIPTION
From now on, the master branch and the latest released SaaS branch are
always shown. SaaS branches are labeled "Odoo Online".

The list of the versions shown in the switcher is hard-coded to force
their ordering.