### PR TITLE
[IMP] odoo_theme: introduce fallback URLs for the page switchers

### DIFF
--- a/extensions/odoo_theme/__init__.py
+++ b/extensions/odoo_theme/__init__.py
@@ -14,6 +14,7 @@ def setup(app):
     app.add_js_file('js/layout.js')
     app.add_js_file('js/menu.js')
     app.add_js_file('js/page_toc.js')
+    app.add_js_file('js/switchers.js')
 
     return {
         'parallel_read_safe': True,

--- a/extensions/odoo_theme/static/js/switchers.js
+++ b/extensions/odoo_theme/static/js/switchers.js
@@ -1,0 +1,27 @@
+(function ($) {
+
+    document.addEventListener('DOMContentLoaded', () => {
+        // Enable fallback URLs for broken redirects from the version or language switchers.
+        _prepareSwitchersFallbacks();
+    });
+
+    /**
+     * Add event listeners on links in the version and language switchers.
+     *
+     * If a link is clicked, the user is redirected to the closest fallback URL (including the
+     * original target URL) that is available.
+     */
+    const _prepareSwitchersFallbacks = () => {
+        document.querySelectorAll('a[class="dropdown-item"]').forEach(element => {
+            element.addEventListener('click', async event => {
+                if (element.hasAttribute('href')) {
+                    event.preventDefault();
+                    const fallbackUrls = await _generateFallbackUrls(element.getAttribute('href'));
+                    const fallbackUrl = await _getFirstValidUrl(fallbackUrls);
+                    window.location.href = fallbackUrl;
+                }
+            });
+        });
+    };
+
+})();


### PR DESCRIPTION
When a user clicks on the link of an alternate page in the version or
language switcher, we now check if the page referenced by the target URL
exists or not. If not, we generate a series of fallback URLs from the
target URL and check whether the targeted resource exists or not, until
we read the root of the documentation. As soon as we find a valid URL,
we redirect the user to it.

This is inspired by the behaviour of docs.python.org's version and
language switchers.

task-2534669