### PR TITLE
[IMP] switch admonitions' display type to inline-block

### DIFF
--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -853,7 +853,7 @@ header.o_main_header {
 // alert-success // removed : never used in doc
         .alert {
             position: relative;
-            display: block;
+            display: inline-block;
             border-radius: 0;
             border-width: 0 0 0 3px;
             @include font-size($font-size-secondary);


### PR DESCRIPTION
When placing an image before an admonition block and setting its alignment to left or right, the admonition block would hide the image. The reason for this is the use of "float" on the image. In order for the image to reappear, we change the admonition's `display: block` to `display: inline-block`.

task-2582954