### PR TITLE
[IMP] scss: alert and tabs refining

### DIFF
--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -1051,12 +1051,10 @@ header.o_main_header {
 
         &:first-of-type {
             border-left: solid 1px $gray-light;
-            margin-left: -1px;
         }
 
         &:last-of-type {
             border-right: solid 1px $gray-light;
-            margin-right: -1px;
         }
 
         &:focus {
@@ -1083,10 +1081,17 @@ header.o_main_header {
         color: $gray-900;
         border: 1px solid $gray-light;
         padding: 1rem;
-        margin: 0 -1px -1px -1px;
 
         &:focus {
             outline: none;
+        }
+
+        > div[class^="highlight-"]{
+            border: 0 !important;
+        }
+        
+        > *:last-child {
+            margin-bottom: 0 !important;
         }
     }
 }

--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -856,6 +856,7 @@ header.o_main_header {
             display: inline-block;
             border-radius: 0;
             border-width: 0 0 0 3px;
+            width: 100%;
             @include font-size($font-size-secondary);
 
             code {


### PR DESCRIPTION
Before, the alerts would all have different widths according to their content, some stretching and getting pushed under the
"on this page" menu. This way all alerts are aligned.
This branch also removes unnecessary negative margins and makes code-blocks inside content tabs lose their bottom margin and border.