### PR TITLE
[IMP] developer/cli: mention the different ways of calling the CLI

### DIFF
--- a/content/administration/install/install.rst
+++ b/content/administration/install/install.rst
@@ -409,8 +409,10 @@ A typical way to run the server would be:
 
 Where `CommunityPath` is the path of the Odoo Community installation, `dbuser` is the
 PostgreSQL login, `dbpassword` is the PostgreSQL password
-and `mydb` is the default database to serve on `localhost:8069`. You can add other
-directory paths separated by a comma to ``addons`` at the end of the addons-path option.
+and `mydb` is the default database to serve on `localhost:8069`.
+
+.. seealso::
+   - :doc:`The exhaustive list of arguments for odoo-bin </developer/misc/other/cmdline>`.
 
 Linux
 -----
@@ -578,8 +580,10 @@ A typical way to run the server would be:
     $ python3 odoo-bin --addons-path=addons -d mydb
 
 Where `CommunityPath` is the path of the Odoo Community installation
-and `mydb` is the default database to serve on `localhost:8069`. You can add other
-directory paths separated by a comma to ``addons`` at the end of the addons-path option.
+and `mydb` is the default database to serve on `localhost:8069`.
+
+.. seealso::
+   - :doc:`The exhaustive list of arguments for odoo-bin </developer/misc/other/cmdline>`.
 
 Mac OS
 ------
@@ -740,9 +744,10 @@ A typical way to run the server would be:
     $ python3 odoo-bin --addons-path=addons -d mydb
 
 Where `CommunityPath` is the path of the Odoo Community installation
-and `mydb` is the default database to serve on `localhost:8069`. You can add other
-directory paths separated by a comma to ``addons`` at the end of the addons-path option.
+and `mydb` is the default database to serve on `localhost:8069`.
 
+.. seealso::
+   - :doc:`The exhaustive list of arguments for odoo-bin </developer/misc/other/cmdline>`.
 
 .. _setup/install/docker:
 
@@ -750,7 +755,7 @@ Docker
 ======
 
 The full documentation on how to use Odoo with Docker can be found on the
-official Odoo `docker image <https://registry.hub.docker.com/_/odoo/>`_ page.
+official Odoo `docker image <https://hub.docker.com/_/odoo/>`_ page.
 
 .. _Debian Buster: https://www.debian.org/releases/buster/
 .. _demo: https://demo.odoo.com

--- a/content/developer/misc/other/cmdline.rst
+++ b/content/developer/misc/other/cmdline.rst
@@ -1,9 +1,39 @@
 
 .. _reference/cmdline:
 
-=============
-CLI: odoo-bin
-=============
+============================
+Command-line interface (CLI)
+============================
+
+The CLI :dfn:`command-line interface` offers several functionalities related to Odoo. You can use it
+to :ref:`run the server <reference/cmdline/server>`, :ref:`launch Odoo as a Python console
+environment <reference/cmdline/shell>`, :ref:`scaffold an Odoo module <reference/cmdline/scaffold>`,
+or :ref:`count the number of lines of code <reference/cmdline/cloc>`.
+
+.. important::
+   The command to use to call the CLI depends on how you installed Odoo. In the examples below, we
+   assume that you are :ref:`running Odoo from source <setup/install/source>` with the
+   :file:`odoo-bin` file. If you installed Odoo :ref:`from a distribution package
+   <setup/install/packaged>` or :ref:`with Docker <setup/install/docker>`, you must adapt the
+   command.
+
+   .. tabs::
+
+      .. tab:: Run Odoo from source
+
+         #. Navigate to the root of the directory where you downloaded the source files of Odoo
+            Community.
+         #. Run all CLI commands with :command:`./odoo-bin`
+
+      .. tab:: Odoo was installed from a distribution package
+
+         When Odoo was installed, an executable named `odoo` was added to your user's PATH. Replace
+         all occurrences of :command:`odoo-bin` with :command:`odoo` in the examples below.
+
+      .. tab:: Odoo was installed with Docker
+
+         Please refer to the `documentation of the official Docker image of Odoo
+         <https://hub.docker.com/_/odoo/>`_.
 
 .. _reference/cmdline/server:
 
@@ -495,6 +525,7 @@ to that file.
     http://werkzeug.pocoo.org/docs/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix
 .. _pyinotify: https://github.com/seb-m/pyinotify/wiki
 
+.. _reference/cmdline/shell:
 
 Shell
 =====
@@ -547,6 +578,7 @@ Scaffolding is available via the :command:`odoo-bin scaffold` subcommand.
 
 This will create module *my_module* in directory */addons/*.
 
+.. _reference/cmdline/cloc:
 
 Cloc
 ====


### PR DESCRIPTION
All examples on the page suggest calling the CLI with "odoo-bin" while
it is recommended to call it with "odoo" when Odoo was installed from a
distribution package. It also failed to mention the location of
"odoo-bin" relative to the source files.

The chance is also taken to rename the somewhat unclear page title to
something more clear and generic.

See also:
- https://github.com/odoo/odoo/pull/85878