### PR TITLE
[ADD] accounting/l10n_mx: Warn not to create separate payments for invoices in USD

### DIFF
--- a/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
+++ b/content/applications/finance/accounting/fiscal_localizations/localizations/mexico.rst
@@ -496,6 +496,14 @@ payment, 15 days, 21 days, all falling within the current month).
 Payments
 --------
 
+.. warning::
+   - When creating a payment in MXN for an invoice in USD, the payment **must** be created using the
+     'Register Payment' button on the invoice view and not separately as a payment. Otherwise, the
+     payment CFDI will not be correctly generated.
+   - As such, a payment in MXN cannot be used to pay multiple invoices in USD. Rather, the payment
+     should be separated into multiple payments, and each payment created using the 'Register Payment'
+     button on its corresponding invoice.
+
 `According to the SAT documentation
 <https://www.sat.gob.mx/consultas/92764/comprobante-de-recepcion-de-pagos>`_, there may be 2 types
 of payments: **PUE** or **PPD**. In both cases the payment process in Odoo is the same, the


### PR DESCRIPTION
Mexican companies very commonly issue invoices in USD, to be fulfiled
in MXN, at the official exchange rate defined by the Banco de Mexico
on the day of payment.

(Presumably, this is to insure against the volatility of the Mexican
peso.)

Odoo supports this workflow, but only if the payment is registered
directly on the invoice using the 'Register Payment' button.

If the payment is created separately, and then reconciled manually
with the invoice, a whole host of problems occur:
- the payment typically can't be reconciled fully with the invoice,
  (even though that can usually be solved by manually creating
  an exchange move)
- but more problematically, the amounts on the payment CFDI will
  be wrong, and even manually creating an exchange move won't solve
  that.

So, we absolutely need to warn users not to try to do that.

(We've been encountering lots of tickets lately in the tech-support
pipe because of users who tried this and then wonder why it doesn't
work.)

This is currently an issue in 14.0, 15.0 and master.