### PR TITLE
[IMP] manufacturing: scrap location warning fw of #950

### DIFF
--- a/content/applications/inventory_and_mrp/manufacturing/management/bill_configuration.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/management/bill_configuration.rst
@@ -33,6 +33,10 @@ by going to the :menuselection:`Top Menu --> Products --> Create`, and add them 
 .. image:: media/bom_1.png
     :align: center
 
+.. warning::
+   The destination location should **not** be a scrap location. A scrap location is where you put
+   products that you don't need.
+
 Using the same BoM to describe Variants
 ---------------------------------------
 


### PR DESCRIPTION
The destination location in manufacturing order shouldn't be a scrap location.
Otherwise, the user won't be able to complete manufacturing orders.

fw of #950