### PR TITLE
[IMP] amazon: explain how to use a carrier

### DIFF
--- a/content/applications/sales/sales/amazon_connector/manage.rst
+++ b/content/applications/sales/sales/amazon_connector/manage.rst
@@ -47,6 +47,13 @@ turn, notify the customer that the order (or a part of it) is on its way.
    module in order to provide the tracking reference. There is unfortunately no workaround to comply
    with this new Amazon policy.
 
+.. tip::
+   - If your chosen carrier isn't one supported by Odoo, you can still create a carrier bearing its
+     name (e.g. create a carrier named `Colissimo`). This name is case insensitive, but be careful
+     about typos, as Amazon won't recognize them.
+   - Create a delivery carrier named `Self Delivery` to inform Amazon that you make your own
+     deliveries. You still have to enter a tracking reference, but Amazon won't do anything with it.
+
 .. seealso::
    - :doc:`../../../inventory_and_mrp/inventory/shipping/setup/third_party_shipper`
 


### PR DESCRIPTION
In case of an unsupported carrier or a self Delivery, Odoo won't block
the user to use the Amazon connector, but explanation were needed for
these cases.

task-2804907

see also:
- https://github.com/odoo/odoo/pull/82772
- https://github.com/odoo/enterprise/pull/23504