### PR TITLE
[IMP] inventory: add note about detailed operations in one_step.rst

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/management/incoming/one_step.rst
+++ b/content/applications/inventory_and_mrp/inventory/management/incoming/one_step.rst
@@ -43,7 +43,12 @@ on the dashboard, you can click the *1 TO PROCESS* button under the
 
 Now, enter the picking that you want to process. You will be able to
 click on *Validate* to complete the move directly as products coming
-from suppliers are considered as being always available.
+from suppliers are considered as being always available. 
+
+.. note::
+   If you have :guilabel:`Storage Locations` activated, you can click the hamburger menu next to 
+   the :guilabel:`Done quantity` to specify the location(s) where you are storing the received
+   product(s).
 
 .. image:: media/one_step_04.png
    :align: center


### PR DESCRIPTION
Backport of #1639 

User tripped up due to the creation of a second warehouse enabling
Storage Locations and changingthe workflow.

https://www.odoo.com/forum/help-1/inventory-receipt-in-second-warehouse-199962