### PR TITLE
Update RD training chapter 2

### DIFF
--- a/content/developer/howtos/rdtraining/02_setup.rst
+++ b/content/developer/howtos/rdtraining/02_setup.rst
@@ -326,6 +326,9 @@ This is useful for training and we assume that the user is in developer mode for
 
 To activate the developer or debug mode you can follow the steps `here <https://www.odoo.com/documentation/user/general/developer_mode/activate.html>`_.
 
+.. note::
+   The main page of the Settings screen is only accessible if at least one application is installed. You will be led into installing your own application in the next chapter.
+
 Extra tools
 ===========
 


### PR DESCRIPTION
At the point when the developer mode is introduced in the training, it is confusing because the documentation page describes the option inside the Settings page, but that page only appears if at least one application is installed. (Otherwise, the Settings app shows the Users instead)