### PR TITLE
[FIX] inventory_and_mrp: documentation update

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.rst
+++ b/content/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.rst
@@ -38,12 +38,10 @@ are:
    customer. Then, the default scheduled date on the delivery order
    is **SO delivery date - Security Lead Time**.
 
--  **Purchase Security Lead Time**: additional time to mitigate the risk
-   of a vendor delay. The receipt will be scheduled that many days
-   earlier to cope with unexpected vendor delays. In case of a
-   *Replenish to Order*, the **Delivery order scheduled date -
-   Security lead time** for purchase will be the default
-   *Receipt* scheduled date.
+-  **Purchase Security Lead Time**: margin of error for vendor lead times.
+   When the system generates Purchase Orders for procuring products,
+   they will be scheduled that many days earlier to cope with unexpected
+   vendor delays.
 
 -  **Purchase Delivery Lead Time**: this is the expected time between a
    PO being confirmed and the receipt of the ordered products. The

--- a/locale/sources/inventory_and_mrp.pot
+++ b/locale/sources/inventory_and_mrp.pot
@@ -1528,7 +1528,7 @@ msgid "**Sales Security Lead Time**: the purpose is to be ready shipping that ma
 msgstr ""
 
 #: ../../content/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.rst:41
-msgid "**Purchase Security Lead Time**: additional time to mitigate the risk of a vendor delay. The receipt will be scheduled that many days earlier to cope with unexpected vendor delays. In case of a *Replenish to Order*, the **Delivery order scheduled date - Security lead time** for purchase will be the default *Receipt* scheduled date."
+msgid "**Purchase Security Lead Time**: Margin of error for vendor lead times. When the system generates Purchase Orders for procuring products, they will be scheduled that many days earlier to cope with unexpected vendor delays."
 msgstr ""
 
 #: ../../content/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.rst:48


### PR DESCRIPTION
After this PR: https://github.com/odoo/odoo/pull/78199

The explanation of the `Security Lead Time for Purchase` field needs to be updated

opw-2766940