### PR TITLE
[FIX] developer/rdtraining: fix typo

### DIFF
--- a/content/developer/howtos/rdtraining/04_basicmodel.rst
+++ b/content/developer/howtos/rdtraining/04_basicmodel.rst
@@ -231,7 +231,7 @@ Common Attributes
 Much like the model itself, fields can be configured by passing
 configuration attributes as parameters::
 
-    name = field.Char(required=True)
+    name = fields.Char(required=True)
 
 Some attributes are available on all fields, here are the most common ones:
 


### PR DESCRIPTION
Fixed `name = field.Char(required=True)` to
`name = fields.Char(required=True)`.