### PR TITLE
[IMP] Clarify some possible confusing points from rdtraining

### DIFF
--- a/content/developer/howtos/rdtraining/02_setup.rst
+++ b/content/developer/howtos/rdtraining/02_setup.rst
@@ -315,6 +315,10 @@ This is useful for training and we assume that the user is in developer mode for
 
 To activate the developer or debug mode you can follow the steps `here <https://www.odoo.com/documentation/user/general/developer_mode/activate.html>`__.
 
+.. note::
+   The main page of the Settings screen is only accessible if at least one application is installed.
+   You will be led into installing your own application in the next chapter.
+
 Extra tools
 ===========
 

--- a/content/developer/howtos/rdtraining/13_inheritance.rst
+++ b/content/developer/howtos/rdtraining/13_inheritance.rst
@@ -153,7 +153,7 @@ By convention, each inherited model is defined in its own Python file. In our ex
 
     - Add a domain to the field so it only lists the available properties.
 
-Now let's add the field to the view and check that everything is working well!
+In the next section let's add the field to the view and check that everything is working well!
 
 View Inheritance
 ================


### PR DESCRIPTION
This PR clarifies two points in the rdtraining:
- in chapter 2, makes it clear that the Settings page can only be accessed if at least one app is installed,
- in chapter 13, makes it clear that the task described in the transition sentence will be explained in its own section.

task-2822582
