### PR TITLE
[IMP] payment_ogone: add possibility to use sha256

### DIFF
--- a/content/applications/finance/payment_acquirers/ogone.rst
+++ b/content/applications/finance/payment_acquirers/ogone.rst
@@ -65,6 +65,17 @@ API key as you'll not be allowed to get it later without generating a new one.
    If you are trying Ogone as a test, with the Test Account, change the **State** to *Test Mode*. We
    recommend doing this on a test Odoo database, rather than on your main database.
 
+Hash function
+~~~~~~~~~~~~~
+
+The hash function used to communicate with Ogone. It should be similar to the one set on Ogone.
+
+For new Odoo database, it's set to 'SHA512' by default which is Ogone default.
+If you upgrade from an older Odoo version, it will be set to Odoo's old default ('SHA1').
+
+This setting is only available in developer mode.
+
+
 Configuration on Ogone
 ======================
 


### PR DESCRIPTION
SHA1 is going to be deprecated by ogone.
This change try to keep current behaviour while adding
the possibility to use SHA256 and SHA512

As this change as to be done in stable version,
We use the length of the key to know which version of SHA
we should use.

The goal is to switch add an selection to master to ensure
better code modularity.

The change was requested by PDE/ANV.

opw-2766648

See also:
- https://github.com/odoo/odoo/pull/88628
- https://github.com/odoo/upgrade/pull/3490