### PR TITLE
[FIX] developer/orm: fields_view_get is now deprecated

### DIFF
--- a/content/developer/reference/backend/orm.rst
+++ b/content/developer/reference/backend/orm.rst
@@ -785,6 +785,8 @@ Fields/Views
 
 .. automethod:: Model.fields_get
 
+.. automethod:: Model.get_view
+
 .. automethod:: Model.fields_view_get
 
 .. _reference/orm/domains:


### PR DESCRIPTION
Since odoo/odoo#87522, the method `fields_view_get` is deprecated and
`get_view` should be used and documented instead.

Community PR: https://github.com/odoo/odoo/pull/90372 + https://github.com/odoo/odoo/pull/90634