### PR TITLE
[FIX] requirements.txt: pin Jinja2 < 3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+jinja2<3.1  # Compatibility with Sphinx 3.5.4.
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 pysass~=0.1.0


### PR DESCRIPTION
The latest versions of Jinja2 are no longer compatible with the latest
version of Sphinx 3 (3.5.4).

task-2828982