### PR TITLE
[IMP] payment_acquirers/stripe: support refund

### DIFF
--- a/content/applications/finance/payment_acquirers.rst
+++ b/content/applications/finance/payment_acquirers.rst
@@ -86,7 +86,7 @@ Online payment acquirers
 | :doc:`SIPS                    | Redirection to the   |            |                 |           |
 | <payment_acquirers/sips>`     | acquirer website     |            |                 |           |
 +-------------------------------+----------------------+------------+-----------------+-----------+
-| :doc:`Stripe                  | Redirection to the   | |V|        | |V|             |           |
+| :doc:`Stripe                  | Redirection to the   | |V|        | |V|             | |V|       |
 | <payment_acquirers/stripe>`   | acquirer website     |            |                 |           |
 +-------------------------------+----------------------+------------+-----------------+-----------+
 


### PR DESCRIPTION
Add a check to indicate that Stripe supports refunds.

Continuation of https://github.com/odoo/documentation/pull/1646

See also:
- https://github.com/odoo/odoo/pull/92235