### PR TITLE
[FIX] homepage: fix the link to the external API page

### DIFF
--- a/extensions/odoo_theme/layout_templates/homepage.html
+++ b/extensions/odoo_theme/layout_templates/homepage.html
@@ -86,7 +86,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="{{ pathto('developer/misc/api/odoo') }}" class="stretched-link">
+                        <a href="{{ pathto('developer/misc/api/external_api') }}" class="stretched-link">
                             {{ _("External API") }}
                         </a>
                     </li>


### PR DESCRIPTION
The page was moved from odoo.rst to external_api.rst with commit
0fc52188.

task-2870501