### PR TITLE
[FIX] requirements: pin docutils to 0.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+docutils==0.16.0  # Compatibility with sphinx-tabs 3.2.0.
 jinja2<3.1  # Compatibility with Sphinx 3.5.4.
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 pysass~=0.1.0
 sphinx~=3.0
+sphinx-tabs==3.2.0
 werkzeug==0.14.1


### PR DESCRIPTION
Since sphinx-tabs 3.2.0 has the requirement docutils==0.16.0 and sphinx
3.5.4 has the requirement docutils>=0.12,<0.17, this commit pins
docutils to version 0.16.0.

While we're at it, the dependency to sphinx-tabs is also explicitly
listed, although it was already imported in the extensions. It causes
no trouble to install it from pip alongside the imported extension.