### PR TITLE
[FIX] point_of_sale: use the correct terms in Chrome interface

### DIFF
--- a/content/applications/sales/point_of_sale/overview/epos_ssc.rst
+++ b/content/applications/sales/point_of_sale/overview/epos_ssc.rst
@@ -68,8 +68,7 @@ Click on :menuselection:`Connection is not secure --> Certificate is not valid`.
    :align: center
    :alt: The web browser indicates that the connection to the printer is not secure.
 
-Go to the *Details* tab and click on **Copy to file**.
-Select X.509 in base 64 and save it.
+Go to the :guilabel:`Details` tab and click on :guilabel:`Export` Select X.509 in base 64 and save it.
 
 Import the Self-signed certificate to Windows (Using Chrome)
 ============================================================
@@ -77,7 +76,7 @@ Import the Self-signed certificate to Windows (Using Chrome)
 In your Chrome browser, go to :menuselection:`Settings --> Privacy and security --> Security -->
 Manage certificates`
 
-Go to the *Trusted Root Certification Authorities* tab and click on **Import** and select
+Go to the :guilabel:`Authorities` tab and click on :guilabel:`Import` and select
 your previous file. Accept all warnings and restart your browser.
 
 Import the Self-signed certificate to your Android device


### PR DESCRIPTION
Because of a recent Chrome security update, a lot of customers using peripheral devices (printers, ...) will have to follow this doc.

Therefore, I followed the doc and did the flow on my side. 

I modified 'Copy to file' to 'Export' and 'Trusted Root Certification Authorities' to 'Authorities' in order to have the exact same terms as in Chrome (I guess they updated their terms at some point).