### PR TITLE
[FIX] odoo_theme: fix highlight blocks in field-list

### DIFF
--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -644,10 +644,18 @@ header.o_main_header {
                 font-family: var(--bs-font-monospace);
             }
 
-            .field-list {
+            dl.field-list {
                 @include font-size($font-size-secondary);
                 padding: .5rem;
                 border: 1px solid $gray-light;
+                @include media-breakpoint-down(lg) {
+                    display: block;
+                }
+
+                > dt, > dd {
+                    padding-left: 0;
+                    padding-right: 0;
+                }
 
                 ul {
                     list-style: none;


### PR DESCRIPTION
On pages such as /developer/reference/backend/orm.html#fields, the
highlight blocks inside `dl.field-list` items were pushing the width of
the page to go outside the screen on mobile. This is fixed by changing
the `.field-list`'s `display: grid` into `block` on mobile.