### PR TITLE
[IMP] account: refactor account types

### DIFF
--- a/content/developer/reference/backend/standard_modules/account/account_account.rst
+++ b/content/developer/reference/backend/standard_modules/account/account_account.rst
@@ -10,7 +10,7 @@ Account
     .. autofield:: name
     .. autofield:: currency_id
     .. autofield:: code
-    .. autofield:: user_type_id
+    .. autofield:: account_type
     .. autofield:: reconcile
     .. autofield:: note
     .. autofield:: tax_ids


### PR DESCRIPTION
See
odoo/odoo#93212
odoo/enterprise#28205

user_type_id on account.account is being deleted and now there is a simple account_type selection field.