### PR TITLE
[FIX] redirects: add missing redirect rule for external_api.rst

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -253,7 +253,7 @@ administration/upgrade/process.rst  administration/upgrade.rst                  
 administration/upgrade/service_level.rst administration/upgrade.rst                          # upgrade/service_level -> upgrade
 
 developer/webservices/iap.rst                           developer/misc/api/iap.rst
-developer/webservices/odoo.rst                          developer/misc/api/odoo.rst
+developer/webservices/odoo.rst                          developer/misc/api/external_api.rst
 developer/webservices/localizations.rst                 developer/misc/i18n/localization.rst
 developer/reference/translations.rst                    developer/misc/i18n/translations.rst
 developer/reference/cmdline.rst                         developer/misc/other/cmdline.rst
@@ -277,6 +277,8 @@ developer/reference/qweb.rst                              developer/reference/ja
 services/support/supported_versions.rst administration/maintain/supported_versions.rst       # services/support/* -> administration/maintain/*
 
 # Redirections introduced in 14.0 :
+
+developer/misc/api/odoo.rst developer/misc/api/external_api.rst
 
 applications/sales/crm/acquire_leads/generate_from_email.rst applications/sales/crm/acquire_leads/generate_leads.rst       # (#986)
 applications/sales/crm/acquire_leads/generate_from_website.rst applications/sales/crm/acquire_leads/generate_leads.rst       # (#986)


### PR DESCRIPTION
The redirect rule was omitted in commit 3465475f.