### PR TITLE
[IMP] payment: Allow (un-)publishing of payment acquirers

### DIFF
--- a/content/applications/finance/payment_acquirers.rst
+++ b/content/applications/finance/payment_acquirers.rst
@@ -292,6 +292,25 @@ Payment journal
 
 The **Payment journal** selected for your payment acquirer must be a *Bank* journal.
 
+.. _payment_acquirers/publish:
+
+Publish on the website
+----------------------
+
+By default, payment acquirers are *unpublished*, which means that only internal users can see them
+on the website. Your customers cannot make payments through an unpublished acquirer but they can
+still manage :dfn:`(delete and assign to a subscription)` their already existing tokens linked to
+such an acquirer. This conveniently allows you to test an acquirer while preventing making payments
+and registering new tokens.
+
+Click on the :guilabel:`Publish` button located in the top right corner of the acquirer's form to
+publish it on the website and make it available to your customers. Click on the
+:guilabel:`Unpublish` button to unpublish it.
+
+.. tip::
+   Payment acquirers are automatically published and unpublished when you respectively change their
+   state to `enabled` and `test`.
+
 .. _payment_acquirers/accounting:
 
 Accounting perspective


### PR DESCRIPTION
Before this commit, it was impossible to migrate from one payment
acquirer to another as the only way to do so was to change a payment
acquirer’s state to ‘disabled’, subsequently disabling all tokens of that
acquirer (detrimental for eg. running subscriptions).

After this commit, payment acquirers have an additional boolean
‘Published’. With this functionality, users can safely migrate by
keeping an acquirer ‘enabled’, but invisible for customers.

There are five combined states an acquirer can take:
1) ‘enabled’ & ‘published’: Visible to all users
2) ‘enabled’ & ‘unpublished’: Visible only to internal users
3) ‘disabled’ & ‘unpublished’: Same as previously ‘disabled’
4) ‘test’ & ‘published’: Same as previously ‘test’
5) ‘test’ & ‘unpublished’: visible only to internal users
  

task-2871459


See also:
- Community PR: https://github.com/odoo/odoo/pull/94242