### PR TITLE
[FIX] core: allow building doc in python 3.10

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -202,7 +202,6 @@ html_favicon = os.path.join(html_theme_path[0], html_theme, 'static', 'img', 'fa
 # They are copied after the builtin static files, so a file named "default.css" will overwrite the
 # builtin "default.css".
 html_static_path = ['static']
-html_add_permalinks = '¶'  # Sphinx < 3.5
 html_permalinks = True  # Sphinx >= 3.5
 # Additional JS & CSS files that can be imported with the 'custom-js' and 'custom-css' metadata.
 # Lists are empty because the files are specified in extensions/themes.

--- a/extensions/odoo_theme/translator.py
+++ b/extensions/odoo_theme/translator.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import os.path
-import posixpath
-import re
 
+import sphinx
+
+from distutils.version import LooseVersion
 from docutils import nodes
-from sphinx import addnodes, util, builders
 from sphinx.locale import admonitionlabels
 from sphinx.writers.html5 import HTML5Translator
 #from urllib.request import url2pathname
@@ -150,7 +149,8 @@ class BootstrapTranslator(HTML5Translator):
         # type: (nodes.Node) -> None
         self.generate_targets_for_table(node)
 
-        self._table_row_index = 0
+        # c/p of https://github.com/pydata/pydata-sphinx-theme/pull/509/files
+        self._table_row_indices.append(0)
 
         classes = [cls.strip(u' \t\n')
                    for cls in self.settings.table_style.split(',')]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ jinja2<3.1  # Compatibility with Sphinx 3.5.4.
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 pysass~=0.1.0
-sphinx~=3.0
+sphinx~=4.3.2
 sphinx-tabs==3.2.0
 werkzeug==0.14.1


### PR DESCRIPTION
Bump Sphinx version to 4.3.2 (default debian version)
Remove retrocompatibility for sphinx < 3.5 (warnings raised in 4.5)
Fix translator issue making builds crash

Task - 2898477