### PR TITLE
[IMP] conf.py, requirements.txt, *: allow building with Python 3.10

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -91,7 +91,6 @@ else:
         sys.version_info = (3, 7, 0)
     odoo_dir = odoo_sources_dirs[0].resolve()
     source_read_replace_vals['ODOO_RELPATH'] = '/../' + str(odoo_sources_dirs[0])
-    source_read_replace_vals['ODOO_ABSPATH'] = str(odoo_dir)
     sys.path.insert(0, str(odoo_dir))
     import odoo.addons
     odoo.addons.__path__.append(str(odoo_dir) + '/addons')

--- a/conf.py
+++ b/conf.py
@@ -231,8 +231,8 @@ html_favicon = os.path.join(html_theme_path[0], html_theme, 'static', 'img', 'fa
 # They are copied after the builtin static files, so a file named "default.css" will overwrite the
 # builtin "default.css".
 html_static_path = ['static']
-html_add_permalinks = '¶'  # Sphinx < 3.5
-html_permalinks = True  # Sphinx >= 3.5
+html_permalinks = True
+
 # Additional JS & CSS files that can be imported with the 'custom-js' and 'custom-css' metadata.
 # Lists are empty because the files are specified in extensions/themes.
 html_js_files = []

--- a/content/developer/howtos/accounting_localization.rst
+++ b/content/developer/howtos/accounting_localization.rst
@@ -180,7 +180,7 @@ It works with the prefix *start*/*end*, so every account where the code starts w
 
   .. csv-table::
      :condition: odoo_dir_in_path
-     :file: {ODOO_ABSPATH}/addons/l10n_il/data/account.group.template.csv
+     :file: {ODOO_RELPATH}/addons/l10n_il/data/account.group.template.csv
      :widths: 20,20,20,20,20
      :header-rows: 1
 

--- a/extensions/autodoc_field/__init__.py
+++ b/extensions/autodoc_field/__init__.py
@@ -114,11 +114,11 @@ class FieldDocumenter(AttributeDocumenter):
                 self.add_line(line, source_name)
         self.add_line('', source_name)
 
-    def get_doc(self, encoding=None, ignore=None):
+    def get_doc(self, *args, **kwargs):
         # only read docstring of field instance, do not fallback on field class
         field = self.object
         field.__doc__ = field.__dict__.get('__doc__', "")
-        res = super().get_doc(encoding, ignore)
+        res = super().get_doc(*args, **kwargs)
         return res
 
 

--- a/extensions/odoo_theme/translator.py
+++ b/extensions/odoo_theme/translator.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
-import os.path
-import posixpath
-import re
 
 from docutils import nodes
-from sphinx import addnodes, util, builders
 from sphinx.locale import admonitionlabels
 from sphinx.writers.html5 import HTML5Translator
-#from urllib.request import url2pathname
+
 
 # Translators inheritance chain:
 # Docutils Base HTML translator: https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/writers/_html_base.py
@@ -55,7 +51,6 @@ class BootstrapTranslator(HTML5Translator):
     html_head = 'html_head'
     html_title = 'html_title'
     html_subtitle = 'html_subtitle'
-
 
     def __init__(self, builder, *args, **kwds):
         super().__init__(builder, *args, **kwds)
@@ -150,7 +145,8 @@ class BootstrapTranslator(HTML5Translator):
         # type: (nodes.Node) -> None
         self.generate_targets_for_table(node)
 
-        self._table_row_index = 0
+        # c/p of https://github.com/pydata/pydata-sphinx-theme/pull/509/files
+        self._table_row_indices.append(0)
 
         classes = [cls.strip(u' \t\n')
                    for cls in self.settings.table_style.split(',')]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 docutils==0.16.0  # Compatibility with sphinx-tabs 3.2.0.
-jinja2<3.1  # Compatibility with Sphinx 3.5.4.
 libsass==0.18.0
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
-sphinx~=3.0
+sphinx==4.3.2
 sphinx-tabs==3.2.0
-werkzeug==0.14.1


### PR DESCRIPTION
- Bump Sphinx version to 4.3.2 (default for Debian Jammy).
- Remove the retrocompatibility for Sphinx < 3.5 (warnings are raised in
  4.5).
- Fix translator issue crashing builds.

Task - 2898477

- Manual Forward-port of #2349 for v15.
- Will be automatically forward-ported to saas-15.4.
- Manually forward-ported in master with #2455