### PR TITLE
[FIX] website: warn about google api deprecation

### DIFF
--- a/content/applications/websites/website/optimize/google_analytics.rst
+++ b/content/applications/websites/website/optimize/google_analytics.rst
@@ -2,6 +2,20 @@
 How to track your website's traffic in Google Analytics
 =======================================================
 
+.. warning::
+  Google deprecated **Universal Analytics** which won't be supported anymore in
+  `July 2023 <https://support.google.com/analytics/answer/11583528>`_. They are
+  replacing it with **Analytics 4**.
+
+  New accounts are already using it, but accounts created before `October 2020
+  <https://support.google.com/analytics/answer/11583832>`_ are most likely still
+  using **Universal Analytics**.
+
+  Odoo 15.0 is already adapted and ready for **Analytics 4**. After July 2023,
+  if you want to use Google Analytics tracking in versions before 15.0, you will
+  need to insert the GA tracker code manually, instead of entering your GA key
+  in the Odoo settings.
+
 To follow your website's traffic with Google Analytics:
 
 - `Create a Google Analytics account <https://www.google.com/analytics/>`__ if 

--- a/content/applications/websites/website/optimize/google_analytics_dashboard.rst
+++ b/content/applications/websites/website/optimize/google_analytics_dashboard.rst
@@ -2,6 +2,24 @@
 How to track your website traffic from your Odoo Dashboard
 ==========================================================
 
+.. warning::
+  It is not possible anymore for new Google Analytics accounts to integrate
+  their **Google Analytics Dashboard** inside their **Odoo Dashboard**.
+  Google deprecated **Universal Analytics** which won't be supported anymore in
+  `July 2023 <https://support.google.com/analytics/answer/11583528>`_. They are
+  replacing it with **Analytics 4**. New accounts are already using it.
+
+  **Analytics 4** `doesn't allow <https://issuetracker.google.com/issues/233738709?pli=1>`_
+  its dashboard to be integrated in external websites.
+
+  You now have to check your Analytics data directly in the Google Platform as
+  it won't be possible in Odoo anymore.
+
+  Accounts created before `October 2020 <https://support.google.com/analytics/answer/11583832>`_
+  should still be using **Universal Analytics** and be able to integrate their
+  dashboard on external website until the official end of support `around mid
+  2023 <https://developers.googleblog.com/2022/03/gis-jsweb-authz-migration.html>`_.
+
 You can follow your traffic statistics straight from your Odoo Website 
 Dashboard thanks to Google Analytics.
 


### PR DESCRIPTION
Google deprecated both its "Universal Analytics" and "Google Sign-In"
API. See community counterpart commit for a detailed explanation and
links.

This PR is adding 2 warning on both Analytics doc pages:

![image](https://user-images.githubusercontent.com/30048408/177188035-9f329125-0efa-41d4-8995-257e63f7c12c.png)
--
![image](https://user-images.githubusercontent.com/30048408/177188067-b6cd78bf-8d11-43ab-8318-820b45dd396d.png)


Community PR: https://github.com/odoo/odoo/pull/95232