### PR TITLE
[IMP] payment_stripe: add information about express checkout

### DIFF
--- a/content/applications/finance/payment_acquirers.rst
+++ b/content/applications/finance/payment_acquirers.rst
@@ -64,16 +64,19 @@ Online payment acquirers
 
    * -
      - Payment flow
-     - :ref:`Save cards for later <payment_acquirers/features/tokenization>`
+     - :ref:`Tokenization <payment_acquirers/features/tokenization>`
      - :ref:`Manual capture <payment_acquirers/features/manual_capture>`
      - :ref:`Refunds <payment_acquirers/features/refund>`
+     - :ref:`Express checkout <payment_acquirers/features/express_checkout>`
    * - :doc:`Adyen <payment_acquirers/adyen>`
      - Payment from Odoo
      - |V|
      - Full only
      - Full and partial
+     -
    * - :doc:`Alipay <payment_acquirers/alipay>`
      - Payment from the acquirer website
+     -
      -
      -
      -
@@ -82,8 +85,10 @@ Online payment acquirers
      -
      -
      -
+     -
    * - :doc:`AsiaPay <payment_acquirers/asiapay>`
      - Payment from the acquirer website
+     -
      -
      -
      -
@@ -92,8 +97,10 @@ Online payment acquirers
      - |V|
      - Full only
      - Full only
+     -
    * - :doc:`Buckaroo <payment_acquirers/buckaroo>`
      - Payment from the acquirer website
+     -
      -
      -
      -
@@ -102,13 +109,16 @@ Online payment acquirers
      - |V|
      -
      -
+     -
    * - :doc:`Mercado Pago <payment_acquirers/mercado_pago>`
      - Payment from the acquirer website
      -
      -
-     - 
+     -
+     -
    * - :doc:`Mollie <payment_acquirers/mollie>`
      - Payment from the acquirer website
+     -
      -
      -
      -
@@ -117,8 +127,10 @@ Online payment acquirers
      - |V|
      -
      -
+     -
    * - :doc:`PayPal <payment_acquirers/paypal>`
      - Payment from the acquirer website
+     -
      -
      -
      -
@@ -127,13 +139,16 @@ Online payment acquirers
      -
      -
      -
+     -
    * - :doc:`Razorpay <payment_acquirers/razorpay>`
      - Payment from Odoo
      -
      - Full only
      - Full and partial
+     -
    * - :doc:`SIPS <payment_acquirers/sips>`
      - Payment from the acquirer website
+     -
      -
      -
      -
@@ -142,6 +157,7 @@ Online payment acquirers
      - |V|
      - Full only
      - Full and partial
+     - |V|
 
 .. |V| replace:: ✔
 
@@ -176,13 +192,13 @@ features.
 
 .. _payment_acquirers/features/tokenization:
 
-Save cards for later
---------------------
+Tokenization
+------------
 
-If your payment acquirer supports this feature, customers can choose to save their card details as a
-**payment token** in Odoo. When they do, they will not have to enter their card details again when
-making a subsequent payment. This is particularly useful for the eCommerce conversion rate and for
-subscriptions that use recurring payments.
+If your payment acquirer supports this feature, customers can choose to save their card for later. A
+**payment token** is created in Odoo and can be used as a payment method for subsequent payments
+without having to enter the card details again. This is particularly useful for the eCommerce
+conversion rate and for subscriptions that use recurring payments.
 
 Enable this feature by navigating to the :guilabel:`Configuration` tab from your payment acquirer
 and by ticking the :guilabel:`Allow Saving Payment Methods` checkbox.
@@ -245,6 +261,22 @@ not need to be enabled first. To refund a customer payment, navigate to it and c
      refunding the full amount have the value **Full only**.
    - Odoo does not support this feature for all payment acquirers but some allow to refund payments
      from their website interface.
+
+.. _payment_acquirers/features/express_checkout:
+
+Express checkout
+----------------
+
+If your payment acquirer supports this feature, customers can use the **Google Pay** and **Apple
+Pay** buttons to pay their eCommerce orders in one click without filling the contact form. Using one
+of those buttons, they'll go straight from the cart to the confirmation page, stopping by the
+payment form of Google or Apple to validate the payment.
+
+Enable this feature by navigating to the :guilabel:`Configuration` tab from your payment acquirer
+and by ticking the :guilabel:`Allow Express Checkout` checkbox.
+
+.. note::
+   All prices shown in the express checkout payment form are always taxes included.
 
 .. _payment_acquirers/configuration:
 

--- a/content/applications/finance/payment_acquirers/stripe.rst
+++ b/content/applications/finance/payment_acquirers/stripe.rst
@@ -22,7 +22,7 @@ The method to acquire your credentials depends on your hosting type:
       #. Confirm your email address when Stripe sends you a confirmation email.
       #. At the end of the process, you are redirected to Odoo. If you submitted all the requested
          information, you are all set and your payment acquirer is enabled.
-      #. Your can continue to :ref:`stripe/local-payment-methods`.
+      #. You can continue to :ref:`stripe/local-payment-methods`.
 
       .. tip::
          To use your own API keys, :ref:`activate the Developer mode <developer-mode>` and
@@ -133,7 +133,7 @@ To set it up, enable the :guilabel:`Capture Amount Manually` option on Odoo, as 
    payment if unsupported payment methods are selected.
 
 .. caution::
-   Odoo doesn't support the partial capture yet. Be aware that a partial capture from Stripe's 
+   Odoo doesn't support the partial capture yet. Be aware that a partial capture from Stripe's
    interface is still managed as a full capture by Odoo.
 
 .. seealso::
@@ -169,5 +169,33 @@ listed, you don't have anything to do.
      listed above, it is considered enabled with Stripe.
    - If a local payment method is not listed above, it is not supported and cannot be enabled.
 
+.. _stripe/express-checkout:
+
+Enable express checkout
+=======================
+
 .. seealso::
-   - :doc:`../payment_acquirers`
+   :ref:`payment_acquirers/features/express_checkout`
+
+After ticking the :guilabel:`Allow Express Checkout` checkbox, **Google Pay** is enabled out of the
+box, but **Apple Pay** requires extra steps: You must register your web domain with Apple. This can
+be done either automatically from Odoo, or manually from Stripe.
+
+.. tabs::
+  .. tab:: Register automatically from Odoo
+
+     #. Navigate to your payment acquirer and make sure that it is :guilabel:`enabled`.
+     #. Go to the :guilabel:`Configuration` tab and click on the :guilabel:`Enable Apple Pay`
+        button. A notification shows that the web domain was successfully registered with Apple.
+
+  .. tab:: Register manually from Stripe
+
+     Visit the `Apple pay web domains page on Stripe
+     <https://dashboard.stripe.com/settings/payments/apple_pay>`_, or log into your Stripe
+     dashboard and go to :menuselection:`Settings --> Payments methods --> Apple Pay --> Configure
+     --> Web domains`. Then, click on :guilabel:`Add new domain` and insert the web domain of your
+     Odoo database into the pop-up form. Odoo already hosts the verification file of Stripe. Click
+     on :guilabel:`Add` to register your web domain with Apple.
+
+.. important::
+   This operation must be repeated whenever your web domain changes.


### PR DESCRIPTION
One will now be able to pay using third parties express checkout
(e.g. Apple Pay, Google Pay) from the cart. At the moment, only Stripe
will support this flow.

See also:
- https://github.com/odoo/odoo/pull/88374
- https://github.com/odoo/enterprise/pull/29915

R&D: task-2754209