### PR TITLE
[CLN] conf.py: stop labelling saas-15.1 in version switcher

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -158,7 +158,6 @@ sphinx.transforms.i18n.docname_to_domain = (
 versions_names = {
     'master': "Master",
     'saas-15.2': "Odoo Online",
-    'saas-15.1': "Odoo Online",
     '15.0': "Odoo 15",
     '14.0': "Odoo 14",
     '13.0': "Odoo 13",


### PR DESCRIPTION
The branch was recently dropped from the supported versions. We no
longer need to add a label for it in the version switcher.