### PR TITLE
[IMP] developer: rename reference directories to "Py/Js framework"

### DIFF
--- a/content/developer/reference.rst
+++ b/content/developer/reference.rst
@@ -1,5 +1,4 @@
 :nosearch:
-:types: reference
 
 =========
 Reference

--- a/content/developer/reference/backend.rst
+++ b/content/developer/reference/backend.rst
@@ -1,8 +1,8 @@
 :nosearch:
 
-=======
-Backend
-=======
+================
+Python framework
+================
 
 .. toctree::
     :titlesonly:

--- a/content/developer/reference/frontend.rst
+++ b/content/developer/reference/frontend.rst
@@ -1,8 +1,8 @@
 :nosearch:
 
-========
-Frontend
-========
+====================
+JavaScript framework
+====================
 
 .. toctree::
     :titlesonly:


### PR DESCRIPTION
It was confusing to label the directory for pages related to the Python
framework "Backend" as, in Odoo, the backend is the web client, and the
frontend is the portal/website. It also led to the "Standard modules"
directory to be placed within the "Backend" directory as of `saas-15.1`
to indicate that they were part of the backend too, but that was a
mistake. Indeed, most standard modules comprise JavaScript methods, and
we could want to document these in the reference at some point.