### PR TITLE
[IMP] base: store gzipped assets for streaming

### DIFF
--- a/content/administration/install/deploy.rst
+++ b/content/administration/install/deploy.rst
@@ -486,6 +486,7 @@ X-Sendfile and X-Accel).
  
          location /web/filestore {
              internal;
+             gzip_static on;
              alias /path/to/odoo/data-dir/filestore;
          }
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/da8def8e410 https://github.com/odoo/documentation/commit/0f2b82cb Odoo delegates
serving attachments to NGINX. In case of an uncompressed text-file such
as css and js files and when the browser advertise it understands gzip
via the `Accept-Content: gzip` request header, NGINX will gzip the file
on-the-fly and add a `Content-Encoding: gzip` response header in order
to save some bandwidth. It is important that NGINX gzips the file on the
fly as transmitting an uncompressed file takes more time than
compressing it server side, transmitting it and uncompressing it client
side.

The companion community commit features an optimization that consist of
storing all asset files in the filestore twice: uncompressed and
gzipped. The gzipped file has the same path and an extra `.gz` suffix as
the uncompressed file.

Using the `gzip_static: on` directive and when the browser supports
gzip (i.e. `Accept-Encoding: gzip`), NGINX checks it exists a compressed
version of the file (same path with `.gz` suffix) to stream it
right-away (i.e. `Content-Encoding: gzip`).

Troubleshooting
---------------

In order for the `gzip_static` directive to work, NGINX must have been
compiled with the `--with-http_gzip_static_module` flag. On debian-based
system that module is enabled by default. You can verify you support it
via `nginx -V`.

In order for nginx to stream the `.gz` assets, the `.gz` assets must
exist on disk. The `.gz` assets are only created upon compiling the
bundles with the `--x-sendfile` CLI option set.

To verify it works, you can `strace` the nginx workers as you access the
home page via your browser (make sure to disable the cache and the debug
mode). The workers should open some files in the filestore, they are
js/css assets and images. For the js/css files, make sure the workers
**ONLY** open the `.gz` version of the file.

Task: 2901173