### PR TITLE
[IMP] install: troubleshoot typical problems for Mac users

### DIFF
--- a/content/administration/install/install.rst
+++ b/content/administration/install/install.rst
@@ -700,6 +700,11 @@ PostgreSQL
 Odoo uses PostgreSQL as database management system. Use `postgres.app <https://postgresapp.com>`_
 to download and install PostgreSQL (supported version: 10.0 and later).
 
+.. tip::
+   To make the command line tools bundled with `postgres.app` available, make sure to setup your
+   `$PATH` variable by following the `Postgres.app CLI Tools Instructions
+   <https://postgresapp.com/documentation/cli-tools.html>`_.
+
 By default, the only user is `postgres` but Odoo forbids connecting as `postgres`, so you need to
 create a new PostgreSQL user:
 
@@ -784,6 +789,11 @@ A typical way to run the server would be:
 
 Where `CommunityPath` is the path of the Odoo Community installation
 and `mydb` is the default database to serve on `localhost:8069`.
+
+.. warning::
+   Some versions of python on Mac might lead to the following error message: `current limit exceeds
+   maximum limit`. In that case, add the following parameter `--limit-memory-hard 0` to avoid the
+   problem.
 
 .. seealso::
    - :doc:`The exhaustive list of arguments for odoo-bin </developer/cli>`.


### PR DESCRIPTION
As mentioned in [1], because of [2], some python implementation for Mac
fail on startup with default parameters.

Also, when installing requirements, the psycopg requirement can fail
because the $PATH does not contain the postgresql tools installed with
the .app.

This commit provides instructions to avoid those issues.

[1]: https://github.com/odoo/odoo/issues/79112
[2]: https://bugs.python.org/issue40518

task-2922249