### PR TITLE
[l10n_mx] Update exempt tax configuration.

### DIFF
--- a/content/applications/finance/fiscal_localizations/mexico.rst
+++ b/content/applications/finance/fiscal_localizations/mexico.rst
@@ -174,8 +174,9 @@ Do the same for all the sales taxes that the company needs, either those that co
 Odoo, or those that you add that are necessary for your company bill.
 
 .. tip::
-   For the 0% VAT tax, select the option *Exento* instead of *Tasa* within the **Factor Type**
-   field.
+   For the 0% VAT tax, select the option :guilabel:`Tasa` within the :guilabel:`Factor Type` field.
+   For the 0% VAT **exempt** tax, select the option :guilabel:`Exento` instead of :guilabel:`Tasa`
+   within the :guilabel:`Factor Type` field.
 
 When registering a payment, Odoo will carry out the movement of taxes from the **Cash Basis
 Transition Account** to the account set in the **Definition** tab. For such movement, a tax base


### PR DESCRIPTION
In Mexico there are two 0% taxes, 0% VAT and 0% exempt VAT. This change makes the tip clearer so users do not confuse both taxes.