### PR TITLE
[CLN] rdtraining: remove reference to unexisting file

### DIFF
--- a/content/developer/howtos/rdtraining/B_acl_irrules.rst
+++ b/content/developer/howtos/rdtraining/B_acl_irrules.rst
@@ -335,11 +335,7 @@ right being checked:
   the invoice (as creating the invoice accesses the property, therefore triggers
   an ACL check) e.g.::
 
-      print(" reached ".center(100, '=')
-
-- Execute ``bypass.py`` in ``estate_account``, giving it the name of your
-  database, and the name of your version of ``action_sold`` (unless you named it
-  ``action_sold`` then it's fine)
+    print(" reached ".center(100, '='))
 
 You should see ``reached`` in your Odoo log, followed by an access error.
 


### PR DESCRIPTION
The referenced `bypass.py` file isn't specified anywhere in
the training documentation or code content.

The paragraph is removed to avoid meaningless searches and
confusing trainees.

This commit also adds a missing parenthese in the preceding
code content.

Fixes #2488