### PR TITLE
[IMP] install: guide the user through the login page

### DIFF
--- a/content/administration/install/install.rst
+++ b/content/administration/install/install.rst
@@ -422,10 +422,21 @@ A typical way to run the server would be:
 
 Where `CommunityPath` is the path of the Odoo Community installation, `dbuser` is the
 PostgreSQL login, `dbpassword` is the PostgreSQL password
-and `mydb` is the default database to serve on `localhost:8069`.
+and `mydb` is the name of the PostgreSQL database.
+
+After the server has started (the INFO log `odoo.modules.loading: Modules loaded.` is printed), open
+http://localhost:8069 in your web browser and log in with the base administrator account: Use
+`admin` for the :guilabel:`Email` and, again, `admin` for the :guilabel:`Password`. That's it, you
+just logged into your own Odoo database!
+
+.. tip::
+   - From there, you can create and manage new :doc:`users
+     </applications/general/users/manage_users>`.
+   - The user account you use to log into Odoo's web interface differs from the :option:`--db_user
+     <odoo-bin -r>` CLI argument.
 
 .. seealso::
-   - :doc:`The exhaustive list of arguments for odoo-bin </developer/cli>`.
+   :doc:`The exhaustive list of CLI arguments for odoo-bin </developer/cli>`.
 
 .. _setup/install/source/linux:
 
@@ -606,10 +617,21 @@ A typical way to run the server would be:
     $ python3 odoo-bin --addons-path=addons -d mydb
 
 Where `CommunityPath` is the path of the Odoo Community installation
-and `mydb` is the default database to serve on `localhost:8069`.
+and `mydb` is the name of the PostgreSQL database.
+
+After the server has started (the INFO log `odoo.modules.loading: Modules loaded.` is printed), open
+http://localhost:8069 in your web browser and log in with the base administrator account: Use
+`admin` for the :guilabel:`Email` and, again, `admin` for the :guilabel:`Password`. That's it, you
+just logged into your own Odoo database!
+
+.. tip::
+   - From there, you can create and manage new :doc:`users
+     </applications/general/users/manage_users>`.
+   - The user account you use to log into Odoo's web interface differs from the :option:`--db_user
+     <odoo-bin -r>` CLI argument.
 
 .. seealso::
-   - :doc:`The exhaustive list of arguments for odoo-bin </developer/cli>`.
+   :doc:`The exhaustive list of CLI arguments for odoo-bin </developer/cli>`.
 
 .. _setup/install/source/mac_os:
 
@@ -788,15 +810,26 @@ A typical way to run the server would be:
     $ python3 odoo-bin --addons-path=addons -d mydb
 
 Where `CommunityPath` is the path of the Odoo Community installation
-and `mydb` is the default database to serve on `localhost:8069`.
+and `mydb` is the name of the PostgreSQL database.
 
 .. warning::
    Some versions of python on Mac might lead to the following error message: `current limit exceeds
    maximum limit`. In that case, add the following parameter `--limit-memory-hard 0` to avoid the
    problem.
 
+After the server has started (the INFO log `odoo.modules.loading: Modules loaded.` is printed), open
+http://localhost:8069 in your web browser and log in with the base administrator account: Use
+`admin` for the :guilabel:`Email` and, again, `admin` for the :guilabel:`Password`. That's it, you
+just logged into your own Odoo database!
+
+.. tip::
+   - From there, you can create and manage new :doc:`users
+     </applications/general/users/manage_users>`.
+   - The user account you use to log into Odoo's web interface differs from the :option:`--db_user
+     <odoo-bin -r>` CLI argument.
+
 .. seealso::
-   - :doc:`The exhaustive list of arguments for odoo-bin </developer/cli>`.
+   :doc:`The exhaustive list of CLI arguments for odoo-bin </developer/cli>`.
 
 .. _setup/install/docker:
 


### PR DESCRIPTION
Developers sometimes have a hard time making the difference between the
PostgreSQL user and the internal user. They would try to log into Odoo's
web client with their PostgreSQL credentials rather than with admin. See
https://reddit.com/r/Odoo/comments/w8zubf/logging_in_on_source_install.