### PR TITLE
[IMP] inventory and mrp: capitalized "MRP" in toctree

### DIFF
--- a/content/applications/inventory_and_mrp.rst
+++ b/content/applications/inventory_and_mrp.rst
@@ -1,7 +1,7 @@
 :nosearch:
 
 ===============
-Inventory & Mrp
+Inventory & MRP
 ===============
 
 


### PR DESCRIPTION
Task ID: [#2946136](https://www.odoo.com/web#id=2946136&cids=3&menu_id=4720&action=333&active_id=3835&model=project.task&view_type=form)

In the toctree, "MRP" wasn't capitalized in "Inventory & MRP."
Affects all branches, can be forward ported.