### PR TITLE
[MOV] reference: test form subfields not exposed directly anymore

### DIFF
--- a/content/developer/reference/backend/testing.rst
+++ b/content/developer/reference/backend/testing.rst
@@ -95,10 +95,10 @@ in each method::
 .. autoclass:: odoo.tests.common.Form
     :members:
 
-.. autoclass:: odoo.tests.common.M2MProxy
+.. autoclass:: odoo.tests.common.form.M2MProxy
     :members: add, remove, clear
 
-.. autoclass:: odoo.tests.common.O2MProxy
+.. autoclass:: odoo.tests.common.form.O2MProxy
     :members: new, edit, remove
 
 Running tests


### PR DESCRIPTION
todo: find a better way to show them off without providing a full path?

There is no reason for users to know their full path since there is no reason for users to instantiate them.