### PR TITLE
[IMP] account_reports: create abstract model for custom reports

### DIFF
--- a/content/developer/reference/standard_modules/account/account_report.rst
+++ b/content/developer/reference/standard_modules/account/account_report.rst
@@ -13,7 +13,6 @@ Report
     .. autofield:: chart_template_id
     .. autofield:: country_id
     .. autofield:: only_tax_exigible
-    .. autofield:: caret_options_initializer
     .. autofield:: availability_condition
     .. autofield:: load_more_limit
     .. autofield:: search_bar


### PR DESCRIPTION
See https://github.com/odoo/odoo/pull/98973
See https://github.com/odoo/enterprise/pull/30777

The field `caret_options_initializer` is removed in the aforementioned PRs,
so it should no longer be referenced in the documentation.

task-2954761