### PR TITLE
[FIX] conf.py: improve master check

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -94,9 +94,11 @@ else:
     sys.path.insert(0, str(odoo_dir))
     import odoo.addons
     odoo.addons.__path__.append(str(odoo_dir) + '/addons')
-    from odoo import release as odoo_release  # Don't collide with Sphinx's 'release' config option
-    odoo_version = odoo_release.version.replace('~', '-')  # Change saas~XX.Y to saas-XX.Y
-    odoo_version = 'master' if 'alpha' in odoo_release.version else odoo_version
+    from odoo.release import version_info
+    if version_info[3] == 'alpha' and version_info[1] != 0:
+        odoo_version = 'master'
+    else:
+        odoo_version = '{0}.{1}'.format(*version_info)
     if release != odoo_version:
         _logger.warning(
             "Found Odoo sources in %(directory)s but with version '%(odoo_version)s' incompatible "


### PR DESCRIPTION
While alpha of saas generally designate master, we used it for the new stable in order to temper expectations, and may keep using it in the future (though maybe we'll use beta, tbd).

As a result, make the check a bit more restrictive by treating all the "x.0 alpha" as x.0, rather than masters.