### PR TITLE
[FIX]: fix odoo_version detection

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -95,7 +95,7 @@ else:
     import odoo.addons
     odoo.addons.__path__.append(str(odoo_dir) + '/addons')
     from odoo import release as odoo_release  # Don't collide with Sphinx's 'release' config option
-    odoo_version = odoo_release.version.replace('~', '-')  # Change saas~XX.Y to saas-XX.Y
+    odoo_version = '.'.join(str(s) for s in odoo_release.version_info[:2]).replace('~', '-')  # Change saas~XX.Y to saas-XX.Y
     odoo_version = 'master' if 'alpha' in odoo_release.version else odoo_version
     if release != odoo_version:
         _logger.warning(


### PR DESCRIPTION
Right now if the version is not "final (and not alpha)" documentation will say 16.0beta != 16.0