### PR TITLE
[IMP] developer/reference: move model view related methods out of orm

### DIFF
--- a/content/developer/reference/backend/orm.rst
+++ b/content/developer/reference/backend/orm.rst
@@ -83,7 +83,6 @@ value::
     .. autoattribute:: _parent_name
     .. autoattribute:: _parent_store
 
-    .. autoattribute:: _date_name
     .. autoattribute:: _fold_name
 
 AbstractModel
@@ -856,14 +855,10 @@ Search/Read
 
 .. automethod:: Model.read_group
 
-Fields/Views
-''''''''''''
+Fields
+''''''
 
 .. automethod:: Model.fields_get
-
-.. automethod:: Model.get_view
-
-.. automethod:: Model.fields_view_get
 
 .. _reference/orm/domains:
 

--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -336,6 +336,21 @@ A view's specs are applied sequentially.
                views: ``hasclass(*classes)`` matches if the context node has
                all the specified classes
 
+Model Commons
+====================
+
+.. currentmodule:: odoo.addons.base.models.ir_ui_view
+
+Attributes
+----------
+
+.. autoattribute:: Model._date_name
+
+Methods
+-------
+.. automethod:: Model.get_views
+.. automethod:: Model.get_view
+
 .. _reference/views/types:
 
 View types


### PR DESCRIPTION
The model method `get_views` and `get_view` are moved from `odoo/models.py` to `odoo/addons/base/models/ir_ui_view.py`.

The documentation is updated accordingly,
to put the documentation related to `get_views` in the views chapter of the documentation.

Related to odoo/odoo#101200