### PR TITLE
[FIX] name field of ir.ui.view is optional

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -37,9 +37,10 @@ Fields
 
 View objects expose a number of fields. They are optional unless specified otherwise.
 
-* ``name`` (mandatory) :class:`~odoo.fields.Char`
+* ``name``  :class:`~odoo.fields.Char`
 
   Only useful as a mnemonic/description of the view when looking for one in a list of some sort.
+  If the field is not defined, it will be generated automatically like this "MODEL TYPE".
 
 * ``model`` :class:`~odoo.fields.Char`
 


### PR DESCRIPTION
The documentation says that the field  ``name`` is required. 
However, since (at least) version 8, the field is optional, and will be autogenerated if not defined.
