### PR TITLE
[IMP] payment(_*): show available currencies for payment providers

### DIFF
--- a/content/applications/finance/payment_providers.rst
+++ b/content/applications/finance/payment_providers.rst
@@ -347,6 +347,26 @@ You can change the payment provider's front-end appearance by modifying its name
 **Displayed as** field and which credit card icons to display under the **Supported Payment Icons**
 field.
 
+.. _payment_providers/currencies:
+
+Currencies
+**********
+
+All payment providers have a different list of available currencies. They are preconfigured and
+available in the :guilabel:`Configuration` tab. They serve as a first filter during payment
+operations, i.e. the payment provider is not displayed as available for payment if the currency is
+not in the supported list.
+
+.. tip::
+   As there might be errors, updates, and unknowns in the lists of available currencies, it is
+   possible to add or remove currencies.
+
+If the list of supported currencies is empty, it either means the list is too long to be displayed,
+or Odoo does not have information on that payment provider. The payment provider remains available,
+even though it is possible the payment will be refused at a later stage should the currency not be
+supported. This field is required if the user needs to select a currency when setting up their
+payment provider account.
+
 .. _payment_providers/countries:
 
 Countries

--- a/content/applications/finance/payment_providers/asiapay.rst
+++ b/content/applications/finance/payment_providers/asiapay.rst
@@ -13,11 +13,11 @@ Configuration on AsiaPay Dashboard
 #. Log into `AsiaPay Dashboard <https://www.paydollar.com/b2c2/eng/merchant/index.jsp>`_ and go to
    :menuselection:`Profile --> Account Information`. Copy the values of the :guilabel:`Currency` and
    :guilabel:`Secure Hash` fields and save them for later.
-#. | Go to :menuselection:`Profile --> Payment Account Settings` and enable the options
-     :guilabel:`Return Value Link (Datefeed)`
+#. | Go to :menuselection:`Profile --> Payment Account Settings` and enable the option
+     :guilabel:`Return Value Link (Datefeed)`;
    | Enter your Odoo database URL followed by `/payment/asiapay/webhook` in the
-     :guilabel:`Return Value Link (Datefeed)` text field.
-   | For example: `https://yourcompany.odoo.com/payment/asiapay/webhook`.
+     :guilabel:`Return Value Link (Datefeed)` text field. For example:
+     `https://yourcompany.odoo.com/payment/asiapay/webhook`;
    | Click on :guilabel:`Test` to check if the webhook is working correctly.
 #. Click on :guilabel:`Update` to finalize the configuration.
 
@@ -28,13 +28,14 @@ Configuration on Odoo
 
 #. :ref:`Navigate to the payment provider AsiaPay <payment_providers/add_new>` and change its state
    to :guilabel:`Enabled`.
-#. | In the :guilabel:`Credentials` tab, fill the :guilabel:`Merchant ID`, :guilabel:`Currency`, and
-     :guilabel:`Secure Hash Secret` with the values you saved at the step
-     :ref:`payment_providers/asiapay/configure_dashboard`.
+#. | In the :guilabel:`Credentials` tab, fill in the :guilabel:`Merchant ID` and
+     :guilabel:`Secure Hash Secret`, and the :guilabel:`Currency` in the :guilabel:`Configuration`
+     tab with the values you saved at the step :ref:`payment_providers/asiapay/configure_dashboard`;
    | By default, the payment provider AsiaPay is configured to verify the secret hash with the hash
      function `SHA1`. If a different function is :ref:`set on your account
      <payment_providers/asiapay/configure_dashboard>`, activate the :ref:`developer mode
-     <developer-mode>` and set the same value to the field :guilabel:`Secure Hash Function` in Odoo.
+     <developer-mode>` and set the same value to the field :guilabel:`Secure Hash Function` in the
+     :guilabel:`Credentials` tab.
 #. Configure the rest of the options to your liking.
 
 .. seealso::


### PR DESCRIPTION
The lists of supported currencies by payment provider are hard-coded in the Python scripts, which makes them unavailable to the users.

With this commit, the implemented initial lists of supported currencies are displayed on the form view and are editable, because our list may not be up-to-date. Empty lists do not trigger any filtering on the payment providers to access payment methods.

task-2926016

See also:
- https://github.com/odoo/odoo/pull/101018
- https://github.com/odoo/enterprise/pull/34158