### PR TITLE
[IMP] install: add $connection_upgrade map documentation

### DIFF
--- a/content/administration/install/deploy.rst
+++ b/content/administration/install/deploy.rst
@@ -290,6 +290,10 @@ in ``/etc/nginx/sites-enabled/odoo.conf`` set:
   upstream odoochat {
     server 127.0.0.1:8072;
   }
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
 
   # http -> https
   server {


### PR DESCRIPTION
Before this commit, following the install documentation to setup the odoochat server would fail. This was due to the fact that the documentation about how to define the `$connection_upgrade` variable was missing.

This PR fixes this issue.