### PR TITLE
[CHG] legal: enterprise terms for fall 2022 pricing

### DIFF
--- a/content/legal/terms/enterprise.rst
+++ b/content/legal/terms/enterprise.rst
@@ -4,7 +4,7 @@
 Odoo Enterprise Subscription Agreement
 ======================================
 
-.. note:: Version 9c - 2020-06-15
+.. note:: Version 10 - 2022-10-13
 
 .. v6: add "App" definition + update pricing per-App
 .. v7: remove possibility of price change at renewal after prior notice
@@ -16,6 +16,7 @@ Odoo Enterprise Subscription Agreement
 .. v9b: clarification that maintenance is opt-out + name of `cloc` command
 .. v9c: minor wording changes, tuned User definition, + copyright guarantee (re-application of v8a changes
         on all branches)
+.. v10: fall 2022 pricing change - removal of "per app" notions
 
 By subscribing to the Odoo Enterprise services (the "Services") provided by Odoo SA and its
 affiliates (collectively, "Odoo SA") in relation with Odoo Enterprise Edition or Odoo Community
@@ -45,8 +46,7 @@ User
     counted as Users.
 
 App
-    An "App" is a specialized group of features available for installation in the Software,
-    and listed in the public Pricing section of `Odoo SA's website <https://www.odoo.com>`_.
+    An "App" is a specialized group of features available for installation in the Software.
 
 Odoo Partner
     An Odoo Partner is a third-party company or individual, chosen by the Customer, and working
@@ -77,6 +77,10 @@ Covered Versions
     to the Covered Versions of the Software, which include the 3 most recently released major
     versions.
 
+Subscription Plan
+    A Subscription Plan defines a set of Apps, features and hosting solutions covered by this
+    Agreement, and is defined in writing at the conclusion of this Agreement.
+
 
 .. _enterprise_access:
 
@@ -105,7 +109,7 @@ Upon expiration or termination of this Agreement, this license is revoked immedi
 Customer agrees to stop using the Odoo Enterprise Edition software and the Cloud Platform.
 
 Should the Customer breach the terms of this section, the Customer agrees to pay Odoo SA an extra
-fee equal to 300% of the applicable list price for the actual number of Users and installed Apps.
+fee equal to 300% of the applicable list price for the actual number of Users.
 
 
 .. _services:
@@ -271,24 +275,26 @@ are provided *if and only if* the Customer is hosted on the Odoo Cloud Platform.
 --------------------
 
 The standard charges for the Odoo Enterprise subscription and the Services are based on the number
-of Users and the installed Apps used by the Customer, and specified in writing
+of Users and the Subscription Plan used by the Customer, and specified in writing
 at the conclusion of the Agreement.
 
-When during the Term, the Customer has more Users or more installed Apps than specified at the time
+When during the Term, the Customer has more Users or uses features that require another
+Subscription Plan than specified at the time
 of conclusion of this Agreement, the Customer agrees to pay an extra fee equivalent to the applicable
-list price (at the beginning of the Term) for the additional Users or Apps, for the remainder of the Term.
+list price (at that time) for the additional Users or the required Subscription Plan,
+for the remainder of the Term.
 
 In addition, services for Covered Extra Modules are charged based on the number of lines of code
 in these modules. When the Customer opts for the maintenance of Covered Extra Modules, the charge
-is a monthly fee of 16€ per 100 lines of code (rounded up to the next hundred), unless otherwise
+is a monthly fee per 100 lines of code (rounded up to the next hundred), as
 specified in writing at the conclusion of the Agreement. Lines of code will be counted with the ``cloc``
 command of the Software, and include all text lines in the source code of those modules, regardless
 of the programming language (Python, Javascript, XML, etc.), excluding blank lines, comment lines
 and files that are not loaded when installing or executing the Software.
 
 When the Customer requests an upgrade, for each Covered Extra Module that has not been covered by
-a maintenance fee for the last 12 months, Odoo SA may charge a one-time extra fee of 16€ per 100
-lines of code, for each missing month of coverage.
+a maintenance fee for the last 12 months, Odoo SA may charge a one-time extra fee
+for each missing month of coverage.
 
 .. _charges_renewal:
 
@@ -296,7 +302,6 @@ lines of code, for each missing month of coverage.
 -------------------
 
 Upon renewal as covered in section :ref:`term`, if the charges applied during the previous Term
-(excluding any “Initial User Discounts”)
 are lower than the most current applicable list price, these charges will increase by up to 7%.
 
 .. _taxes:
@@ -324,8 +329,8 @@ The Customer agrees to:
 
 - pay Odoo SA any applicable charges for the Services of the present Agreement, in accordance with
   the payment conditions specified at the signature of this contract ;
-- immediately notify Odoo SA when their actual number of Users or their installed Apps exceed the
-  numbers specified at the conclusion of the Agreement, and in this event, pay the applicable
+- immediately notify Odoo SA when their actual number of Users exceeds the
+  number specified at the conclusion of the Agreement, and in this event, pay the applicable
   additional fee as described in section :ref:`charges_standard`;
 - take all measures necessary to guarantee the unmodified execution of the part of the Software
   that verifies the validity of the Odoo Enterprise Edition usage, as described
@@ -347,7 +352,7 @@ When the Customer chooses the Self-Hosting option, the Customer further agrees t
 - take all reasonable measures to protect Customer’s files and databases and to ensure Customer’s
   data is safe and secure, acknowledging that Odoo SA cannot be held liable for any data loss;
 - grant Odoo SA the necessary access to verify the validity of the Odoo Enterprise Edition usage
-  upon request (e.g. if the automatic validation is found to be inoperant for the Customer);
+  upon request (e.g. if the automatic validation is found to be inoperant for the Customer).
 
 
 .. _no_soliciting:

--- a/content/legal/terms/i18n/enterprise_fr.rst
+++ b/content/legal/terms/i18n/enterprise_fr.rst
@@ -11,7 +11,7 @@ Odoo Enterprise Subscription Agreement (FR)
     La seule référence officielle des termes du contrat “Odoo Enterprise Subscription Agreement”
     est la :ref:`version originale en anglais <enterprise_agreement>`.
 
-.. note:: Version 9c - 2020-06-15
+.. note:: Version 10 - 2022-10-13
 
 .. v6: add "App" definition + update pricing per-App
 .. v7: remove possibility of price change at renewal after prior notice
@@ -24,6 +24,7 @@ Odoo Enterprise Subscription Agreement (FR)
 .. v9c: minor wording changes, tuned User definition, + copyright guarantee (re-application of v8a changes
         on all branches)
 .. v9c2: minor simplification in FR wording
+.. v10: fall 2022 pricing change - removal of "per app" notions
 
 En vous abonnant aux services de Odoo Enterprise (les "Services") fournis par Odoo SA et ses filiales
 (collectivement, "Odoo SA") en relation avec Odoo Enterprise Edition ou Odoo Community Edition
@@ -36,7 +37,7 @@ En vous abonnant aux services de Odoo Enterprise (les "Services") fournis par Od
 1 Durée du Contrat
 ==================
 
-La durée du présent contrat (la "Durée") sera spécifiée par
+La durée du présent Contrat (la "Durée") sera spécifiée par
 écrit à la conclusion du Contrat, à compter de la date de la conclusion. Celui-ci est automatiquement
 reconduit pour une même durée, à moins que l'une des parties n’envoie à l'autre partie un préavis
 écrit de résiliation, et au moins 30 jours avant la date d'échéance du contrat.
@@ -53,9 +54,7 @@ Utilisateur
     comptés comme Utilisateurs.
 
 App
-    Une "App" est un ensemble de fonctionnalités, disponible pour installation dans le Logiciel,
-    et inclus dans la section Tarifs Odoo sur `le site d'Odoo SA <https://www.odoo.com>`_, au moment
-    de la conclusion de ce Contrat.
+    Une "App" est un ensemble de fonctionnalités, disponible pour installation dans le Logiciel.
 
 Partenaire Odoo
     Un Partenaire Odoo est un individu ou société tierce, choisi par le Client et qui collabore
@@ -86,6 +85,10 @@ Bug
 Versions Couvertes
     Sauf exception explicite, tous les Services dans le cadre du présent contrat s'appliquent uniquement aux Versions
     Couvertes du Logiciel, qui comprennent les 3 plus récentes versions majeures.
+
+Formule d'Abonnement
+    Une Formule d'Abonnement définit un ensemble d'Apps, fonctionnalités et solutions d'hébergement
+    couvertes par ce Contrat, tel que précisé par écrit à la conclusion de ce Contrat.
 
 
 .. _enterprise_access_fr:
@@ -119,7 +122,7 @@ Cloud.
 
 Si le Client devait enfreindre les dispositions de la présente section, il accepte de payer
 à Odoo SA des frais supplémentaires équivalents à 300 % du tarif en vigueur applicable
-correspondant au nombre réel d'Utilisateurs et aux Apps installées.
+correspondant au nombre réel d'Utilisateurs.
 
 
 .. _services_fr:
@@ -295,17 +298,18 @@ la Plate-forme Cloud d'Odoo.
 --------------------
 
 Les tarifs standards pour le contrat d'abonnement à Odoo Enterprise et les Services sont basés sur le nombre
-d'Utilisateurs et les Apps installées, et précisés par écrit à la conclusion du contrat.
+d'Utilisateurs et la Formule d'Abonnement, et précisés par écrit à la conclusion du contrat.
 
-Pendant la durée du contrat, si le Client a plus d'Utilisateurs ou d'Apps que spécifié au moment
+Pendant la durée du contrat, si le Client a plus d'Utilisateurs ou utilise des fonctionnalités
+qui requièrent une autre Formule d'Abonnement que spécifié au moment
 de la conclusion du présent Contrat, le Client accepte de payer un supplément équivalent au tarif
-en vigueur applicable (au début du Contrat) pour les utilisateurs supplémentaires,
-pour le reste de la durée.
+en vigueur applicable (à ce moment) pour les utilisateurs supplémentaires ou la Formule d'Abonnement
+requise, pour le reste de la Durée.
 
 Par ailleurs, les services concernant les Modules Supplémentaires Couverts sont facturés sur base
 du nombre de lignes de code dans ces modules. Lorsque le client opte pour l'abonnement de maintenance
-des Modules Supplémentaires Couverts, le coût mensuel est de 16€ par 100 lignes de code (arrondi à la
-centaine supérieure), sauf si spécifié par écrit à la conclusion du Contrat. Les lignes de code
+des Modules Supplémentaires Couverts, le coût mensuel est défini par 100 lignes de code (arrondi à la
+centaine supérieure), tel que spécifié par écrit à la conclusion du Contrat. Les lignes de code
 sont comptées avec la commande ``cloc`` du Logiciel, et comprennent toutes les lignes de texte du code
 source de ces modules, peu importe le langage de programmation (Python, Javascript, XML, etc.),
 à l'exclusion des lignes vides, des lignes de commentaires et des fichiers qui ne sont pas chargés
@@ -322,7 +326,6 @@ supplémentaires unique de 16€ par 100 lignes de code, pour chaque mois de mai
 --------------------------
 
 Lors de la reconduction telle que décrite à la section :ref:`term_fr`, si les tarifs par Utilisateur
-(à l'exclusion des “Initial User Discounts”)
 qui ont été appliqués pendant la Durée précédente sont inférieurs aux tarifs par Utilisateur
 en vigueur les plus récents, les tarifs par Utilisateur augmenteront automatiquement de maximum 7%
 par reconduction, sans dépasser les tarifs en vigueur les plus récents.
@@ -350,8 +353,8 @@ Le Client accepte de / d':
 
 - Payer à Odoo SA les frais applicables pour les Services en vertu du présent Contrat,
   conformément aux conditions de paiement spécifiées à la souscription du présent Contrat ;
-- Aviser immédiatement Odoo SA si le nombre réel d'Utilisateurs ou les Apps installées dépassent
-  les nombres spécifiés à la conclusion du Contrat, et dans ce cas, de régler les frais
+- Aviser immédiatement Odoo SA si le nombre réel d'Utilisateurs dépasse
+  le nombre spécifié à la conclusion du Contrat, et dans ce cas, de régler les frais
   supplémentaires applicables telles que décrits à la section :ref:`charges_standard_fr`;
 - Prendre toutes les mesures nécessaires pour garantir l'exécution non modifiée de la partie du
   Logiciel qui vérifie la validité de l'utilisation de Odoo Enterprise Edition, comme décrit à la


### PR DESCRIPTION
Updated terms for fall 2022 pricing:
- removal of "per app" notion
- addition of "subscription plan" notion

Will be backported later due to some conflicts.

PS: pre-approved by legal team and CEO ;-)