### PR TITLE
[IMP] reports: parameter type to barcode_type

### DIFF
--- a/content/developer/reference/backend/reports.rst
+++ b/content/developer/reference/backend/reports.rst
@@ -159,7 +159,7 @@ More parameters can be passed as a query string
 .. code-block:: html
 
     <img t-att-src="'/report/barcode/?
-        type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', 'text', 200, 200)"/>
+        barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', 'text', 200, 200)"/>
 
 
 Useful Remarks


### PR DESCRIPTION
 The`report_barcode` function has changed its parameter name from `type`to `barcode_type`.
See: https://github.com/odoo/odoo/commit/ee324e8374536cebca4d7302210b07e8f33d3852