### PR TITLE
Removal of deprecations from 15.0 and earlier

### DIFF
--- a/content/developer/reference/backend/testing.rst
+++ b/content/developer/reference/backend/testing.rst
@@ -54,8 +54,6 @@ related to testing Odoo content (modules, mainly):
 .. autoclass:: odoo.tests.common.SingleTransactionCase
     :members: browse_ref, ref
 
-.. autoclass:: odoo.tests.common.SavepointCase
-
 .. autoclass:: odoo.tests.common.HttpCase
     :members: browse_ref, ref, url_open, browser_js
 
@@ -119,8 +117,7 @@ In Odoo, Python tests can be tagged to facilitate the test selection when
 running tests.
 
 Subclasses of :class:`odoo.tests.common.BaseCase` (usually through
-:class:`~odoo.tests.common.TransactionCase`,
-:class:`~odoo.tests.common.SavepointCase` or
+:class:`~odoo.tests.common.TransactionCase` or
 :class:`~odoo.tests.common.HttpCase`) are automatically tagged with
 ``standard`` and ``at_install`` by default.
 


### PR DESCRIPTION
- SavepointCase is being removed in odoo/odoo#98138, deprecated since odoo/odoo@1398b6b44cfef4c3ed14510aa145c12fc0f6c716