### PR TITLE
[FIX] developer/cli: remove unsupported cli options

### DIFF
--- a/content/developer/cli.rst
+++ b/content/developer/cli.rst
@@ -485,16 +485,6 @@ customize the amount of logging output.
 
         $ odoo-bin --log-handler :DEBUG --log-handler werkzeug:CRITICAL --log-handler odoo.fields:WARNING
 
-.. option:: --log-request
-
-    enable DEBUG logging for RPC requests, equivalent to
-    ``--log-handler=odoo.http.rpc.request:DEBUG``
-
-.. option:: --log-response
-
-    enable DEBUG logging for RPC responses, equivalent to
-    ``--log-handler=odoo.http.rpc.response:DEBUG``
-
 .. option:: --log-web
 
     enables DEBUG logging of HTTP requests and responses, equivalent to


### PR DESCRIPTION
Removed by https://github.com/odoo/odoo/commit/c0647b5c527440cf9f94b51f1c9a9c4d1f3b508e

Fixes odoo/odoo#104060