### PR TITLE
[FIX] developer/guidelines: do not mention deprecated xml tags

### DIFF
--- a/content/contributing/development/coding_guidelines.rst
+++ b/content/contributing/development/coding_guidelines.rst
@@ -276,10 +276,8 @@ Odoo supports custom tags acting as syntactic sugar:
 
 - menuitem: use it as a shortcut to declare a ``ir.ui.menu``
 - template: use it to declare a QWeb View requiring only the ``arch`` section of the view.
-- report: use to declare a :ref:`report action <reference/actions/report>`
-- act_window: use it if the record notation can't do what you want
 
-The 4 first tags are preferred over the *record* notation.
+These tags are preferred over the *record* notation.
 
 
 XML IDs and naming

--- a/content/developer/reference/addons/data.rst
+++ b/content/developer/reference/addons/data.rst
@@ -257,9 +257,6 @@ section of the view, and allowing a few *optional* attributes:
     website interface) and its default status. If unset, the view is always
     enabled.
 
-.. deprecated act_window & report
-.. ignored url, act_window and ir_set
-
 .. _reference/data/csvdatafiles:
 
 CSV data files


### PR DESCRIPTION
act_window & report xml tags have been deprecated by https://github.com/odoo/odoo/commit/6835aeb0de6895f7f4d6b23e0b4654465ef21d6a two years ago, we should avoid mentioning them in the guidelines.

Furthermore, in 17.0 they won't be available anymore.