### PR TITLE
[FIX] deploy.rst: nginx config for static files

### DIFF
--- a/content/administration/install/deploy.rst
+++ b/content/administration/install/deploy.rst
@@ -415,9 +415,11 @@ by intercepting all requests to :samp:`/{MODULE}/static/{FILE}`, and looking up 
 (and file) in the various addons paths.
 
 .. example::
-   Say Odoo has been installed via the **debian packages** for Community and Enterprise, the addons
-   paths is :file:`/usr/lib/python3/dist-packages/odoo/addons`. Using the above NGINX (https)
-   configuration, the following location block should be added to serve static files via NGINX.
+   Say Odoo has been installed via the **debian packages** for Community and Enterprise and the
+   :option:`--addons-path <odoo-bin --addons-path>` is ``'/usr/lib/python3/dist-packages/odoo/addons'``.
+
+   Using the above NGINX (https) configuration, the following location block should be added to
+   serve static files via NGINX.
    
    .. code-block:: nginx
    
@@ -433,11 +435,13 @@ by intercepting all requests to :samp:`/{MODULE}/static/{FILE}`, and looking up 
        }
 
 .. example::
-   Say Odoo has been installed via the **source**, and the two git repositories for Community and
-   Enterprise has been cloned in :file:`/opt/odoo` and :file:`/opt/odoo-enterprise` respectively. 
-   The addons paths is ``/opt/odoo/odoo,/opt/odoo/addons,/opt/odoo-enterprise``. Using the above
-   NGINX (https) configuragion, the following location block should be added to serve static files
-   via NGINX.
+   Say Odoo has been installed via the **source**. The two git repositories for Community and
+   Enterprise have been cloned in :file:`/opt/odoo/community` and :file:`/opt/odoo/enterprise`
+   respectively and the :option:`--addons-path <odoo-bin --addons-path>` is
+   ``'/opt/odoo/community/odoo/addons,/opt/community/addons,/opt/odoo/enterprise'``.
+
+   Using the above NGINX (https) configuration, the following location block should be added to
+   serve static files via NGINX.
 
    .. code-block:: nginx
    
@@ -447,23 +451,9 @@ by intercepting all requests to :samp:`/{MODULE}/static/{FILE}`, and looking up 
    
        # Serve static files right away
        location ~ ^/[^/]+/static/.+$ {
-           try_files /static-base$uri /static-addons$uri /static-enterprise$uri @odoo$uri;
+           root /opt/odoo;
+           try_files /community/odoo/addons$uri /community/addons$uri /enterprise$uri @odoo;
            expires 24h;
-       }
-   
-       location /static-base {
-           internal;
-           alias /opt/odoo/odoo/addons;
-       }
-   
-       location /static-addons {
-           internal;
-           alias /opt/odoo/addons;
-       }
-   
-       location /static-enterprise {
-           internal;
-           alias /opt/odoo-enterprise;
        }
 
 .. warning::


### PR DESCRIPTION
In case of a source install the various places where static files can be found are spread on the filesystem. The previous configuration sample used custom internal locations but it turns out that it is only possible to `try_files` on filesystem paths and on "named location (@ ones)".

This commit fixes the configuration sample so that it works for the given situation where community and enterprise has been cloned from git.

task-3049538