### PR TITLE
[FIX] deploy: wsgi application entrypoint moved

### DIFF
--- a/content/administration/install/deploy.rst
+++ b/content/administration/install/deploy.rst
@@ -352,6 +352,11 @@ However the WSGI server will only expose the main HTTP endpoint for the web
 client, website and webservice API. Because Odoo does not control the creation
 of workers anymore it can not setup cron or livechat workers
 
+.. versionchanged:: 16.0
+
+   The application entry-point has been moved from
+   ``odoo.service.wsgi_server.application`` to ``odoo.http.root``.
+
 Cron Workers
 ------------
 


### PR DESCRIPTION
The wsgi application entrypoint moved during the httpocalypse. Some clients don't use the odoo builtin wsgi server and have troubles upgrading from 15.0 to 16.0 because the `odoo.service.wsgi_server` module doesn't exist anymore.

https://github.com/odoo/odoo/pull/105434