### PR TITLE
[IMP] developer/howtos: deprecate themes tutorial

### DIFF
--- a/content/developer/howtos.rst
+++ b/content/developer/howtos.rst
@@ -8,7 +8,6 @@ Tutorials
     :titlesonly:
 
     howtos/rdtraining
-    howtos/themes
     howtos/website
     howtos/backend
     howtos/profilecode

--- a/content/developer/howtos/themes.rst
+++ b/content/developer/howtos/themes.rst
@@ -1,14 +1,12 @@
+:orphan:
 
-=====================
+==============
 Theme Tutorial
-=====================
+==============
 
 .. warning::
 
-    This tutorial provides a great overview of what you can do creating an
-    Odoo theme. It is however incomplete. We are currently working on a new
-    detailed theme tutorial, come back here soon to unleash the true power of
-    Odoo themes!
+    This tutorial is outdated and won't work out of the box.
 
 .. rst-class:: lead
 


### PR DESCRIPTION
This tutorial was already outdated in 13.0 (but
supposedly working).

In 14.0+, a lot of changes happened in website logic, especially for 'website option definitions', breaking the existing theme tutorial.

Considering the fact that a new tutorial is being made, and that fixing the whole existing tutorial would be a big work, it will be kept, but hidden as 'most things being said still make sense'.

Fixes odoo/odoo#105932