### PR TITLE
Update 08_relations.rst

### DIFF
--- a/content/developer/howtos/rdtraining/08_relations.rst
+++ b/content/developer/howtos/rdtraining/08_relations.rst
@@ -218,6 +218,7 @@ on our test model a link to the ``res.partner`` model thanks to the field ``part
 We can define the inverse relation, i.e. the list of test models linked to our partner::
 
     test_ids = fields.One2many("test.model", "partner_id", string="Tests")
+    offer_ids = fields.one2many("estate.property.offer", "property_id", string="Offers")
 
 The first parameter is called the ``comodel`` and the second parameter is the field we want to
 inverse.


### PR DESCRIPTION
one2many throws "ValueError: Invalid field 'Title' on model 'res.partner' while working with offer_ids field.  when you use this example here: 
`test_ids = fields.One2many("test.model", "partner_id", string="Tests")`

Here is the proposed work around that works:
partner_id it should be replaced by property_id
offer_ids = fields.one2many("estate.property.offer", "property_id", string="Offers")