### PR TITLE
[IMP] web: adds the header to the list view

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -1918,6 +1918,8 @@ Possible children elements of the list view are:
             matching the current search)
     ``name``
         see ``type``
+    ``groups``
+        lists the groups which should be able to see the button
     ``args``
         see ``type``
     ``attrs``
@@ -2048,6 +2050,31 @@ Possible children elements of the list view are:
     </groupby>
 
   A special button (`type="edit"`) can be defined to open the many2one form view.
+
+``header``
+  defines custom :ref:`buttons <reference/views/list/button>` in the control panel that perform an action/call a model's method.
+
+  .. code-block:: xml
+
+      <header>
+          <button name=toDo" type="object" string="Always Display" display="always"/>
+          <button name="toDo" type="object" string="Selection Display"/>
+      </header>
+
+  Does not support any attribute but can have a child:
+
+  .. rst-class:: o-definition-list
+
+  ``button``
+    as a :ref:`button <reference/views/list/button>` which accepts an extra attribute when placed in a `header`:
+
+    .. rst-class:: o-definition-list
+
+    ``display``
+      By default, those buttons are only displayed when some records are
+      selected, and they apply on the selection. When the attribute ``display``
+      is set to ``always``, the button is available all the time, even if there's
+      no selection.
 
 ``control``
   defines custom controls for the current view.


### PR DESCRIPTION
This commit adds the documentation related to the <header> tag to the list view.