### PR TITLE
[IMP] conf.py, *: interpolate the version and releases in the content

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -3,7 +3,6 @@ import re
 import sys
 from pathlib import Path
 
-import docutils
 import sphinx
 from pygments.lexers import JsonLexer, XmlLexer
 from sphinx.util import logging
@@ -17,10 +16,24 @@ _logger = logging.getLogger(__name__)
 project = 'Odoo'
 copyright = 'Odoo S.A.'
 
-# `version` if the version info for the project being documented, acts as replacement for |version|,
+# `version` is the version info for the project being documented, acts as replacement for |version|,
 # also used in various other places throughout the built documents.
 # `release` is the full version, including alpha/beta/rc tags. Acts as replacement for |release|.
 version = release = '14.0'
+
+# `current_branch` is the technical name of the current branch.
+# E.g., saas-15.4 -> saas-15.4; 12.0 -> 12.0, master -> master (*).
+current_branch = version
+# `current_version` is the Odoo version linked to the current branch.
+# E.g., saas-15.4 -> 15.4; 12.0 -> 12; master -> master (*).
+current_version = current_branch.replace('saas-', '').replace('.0', '')
+# `current_major_branch` is the technical name of the major branch before the current branch.
+# E.g., saas-15.4 -> 15.0; 12.0 -> 12.0; master -> master (*).
+current_major_branch = re.sub(r'\.\d', '.0', current_branch.replace('saas-', ''))
+# `current_major_version` is the Odoo version linked to the current major branch.
+# E.g., saas-15.4 -> 15; 12.0 -> 12; master -> master (*).
+current_major_version = current_major_branch.replace('.0', '')
+# (*): We don't care for master.
 
 # The minimal Sphinx version required to build the documentation.
 needs_sphinx = '3.0.0'
@@ -59,6 +72,11 @@ add_function_parentheses = True
 #=== Extensions configuration ===#
 
 source_read_replace_vals = {
+    'BRANCH': current_branch,
+    'CURRENT_BRANCH': current_branch,
+    'CURRENT_VERSION': current_version,
+    'CURRENT_MAJOR_BRANCH': current_major_branch,
+    'CURRENT_MAJOR_VERSION': current_major_version,
     'GITHUB_PATH': f'https://github.com/odoo/odoo/blob/{version}',
     'GITHUB_ENT_PATH': f'https://github.com/odoo/enterprise/blob/{version}',
 }

--- a/content/administration/install/install.rst
+++ b/content/administration/install/install.rst
@@ -107,7 +107,8 @@ Linux
 Debian/Ubuntu
 '''''''''''''
 
-Odoo 13.0 'deb' package currently supports `Debian Buster`_, `Ubuntu 18.04`_ or above.
+Odoo {CURRENT_MAJOR_VERSION} 'deb' package currently supports `Debian Buster`_, `Ubuntu 18.04`_ or
+above.
 
 Prepare
 ^^^^^^^
@@ -134,7 +135,7 @@ used to install *Odoo Community Edition* by executing the following commands **a
 .. code-block:: console
 
     # wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
-    # echo "deb http://nightly.odoo.com/13.0/nightly/deb/ ./" >> /etc/apt/sources.list.d/odoo.list
+    # echo "deb http://nightly.odoo.com/{CURRENT_MAJOR_BRANCH}/nightly/deb/ ./" >> /etc/apt/sources.list.d/odoo.list
     # apt-get update && apt-get install odoo
 
 You can then use the usual `apt-get upgrade` command to keep your installation up-to-date.
@@ -180,7 +181,7 @@ and automatically start the server.
 Fedora
 ''''''
 
-Odoo 13.0 'rpm' package supports Fedora 30.
+Odoo {CURRENT_MAJOR_VERSION} 'rpm' package supports Fedora 30.
 
 Prepare
 ^^^^^^^
@@ -209,7 +210,7 @@ commands:
 
 .. code-block:: console
 
-    $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/13.0/nightly/rpm/odoo.repo
+    $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/{CURRENT_MAJOR_BRANCH}/nightly/rpm/odoo.repo
     $ sudo dnf install -y odoo
     $ sudo systemctl enable odoo
     $ sudo systemctl start odoo
@@ -224,7 +225,7 @@ Once downloaded, the package can be installed using the 'dnf' package manager:
 
 .. code-block:: console
 
-    $ sudo dnf localinstall odoo_13.0.latest.noarch.rpm
+    $ sudo dnf localinstall odoo_{CURRENT_MAJOR_BRANCH}.latest.noarch.rpm
     $ sudo systemctl enable odoo
     $ sudo systemctl start odoo
 

--- a/content/administration/odoo_sh/advanced/containers.rst
+++ b/content/administration/odoo_sh/advanced/containers.rst
@@ -17,7 +17,7 @@ The platform will take care to install these dependencies in your containers.
 `The pip requirements specifiers <https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers>`_
 documentation can help you write a :file:`requirements.txt` file.
 To have a concrete example,
-check out the `requirements.txt file of Odoo <https://github.com/odoo/odoo/blob/14.0/requirements.txt>`_.
+check out the `requirements.txt file of Odoo <{GITHUB_PATH}/requirements.txt>`_.
 
 The :file:`requirements.txt` files of submodules are taken into account as well. The platform
 looks for :file:`requirements.txt` files in each folder containing Odoo modules: Not in the module folder itself,
@@ -174,9 +174,9 @@ Look for "*odoo: addons paths*":
 
 ::
 
-  2018-02-19 10:51:39,267 4 INFO ? odoo: Odoo version 13.0
+  2018-02-19 10:51:39,267 4 INFO ? odoo: Odoo version {BRANCH}
   2018-02-19 10:51:39,268 4 INFO ? odoo: Using configuration file at /home/odoo/.config/odoo/odoo.conf
-  2018-02-19 10:51:39,268 4 INFO ? odoo: addons paths: ['/home/odoo/data/addons/13.0', '/home/odoo/src/user', '/home/odoo/src/enterprise', '/home/odoo/src/themes', '/home/odoo/src/odoo/addons', '/home/odoo/src/odoo/odoo/addons']
+  2018-02-19 10:51:39,268 4 INFO ? odoo: addons paths: ['/home/odoo/data/addons/{BRANCH}', '/home/odoo/src/user', '/home/odoo/src/enterprise', '/home/odoo/src/themes', '/home/odoo/src/odoo/addons', '/home/odoo/src/odoo/odoo/addons']
 
 **Be careful**, especially with your production database.
 Operations that you perform running this Odoo server instance are not isolated:

--- a/content/contributing/documentation.rst
+++ b/content/contributing/documentation.rst
@@ -237,7 +237,7 @@ Python comes with its own package manager: `pip
 a single command.
 
 #. Download and install the recommended release (`see README file
-   <https://github.com/odoo/documentation/tree/14.0/README.md>`_) of **Python 3** on your machine.
+   <https://github.com/odoo/documentation/tree/{BRANCH}/README.md>`_) of **Python 3** on your machine.
 #. Make sure to have **pip** installed on your machine (on Windows, you can install pip alongside
    Python).
 #. Execute the following commands in a terminal to verify that both installations finished
@@ -291,12 +291,12 @@ Prepare your version
 --------------------
 
 Now that your machine is all set up, it is time to do the same for your version of the documentation
-files. As it would not be convenient to have several people working on the version 13.0 in parallel
-(conflicts of content would occur all the time), and in order to be able to create a :abbr:`PR
-(Pull Request)`, you must `create a new branch
-<https://www.atlassian.com/git/tutorials/using-branches>`_ starting from the branch 13.0. In other
-words, you copy the entirety of this version’s files and give it another name. For this example, we
-will go with ``13.0-my_contribution``.
+files. As it would not be convenient to have several people working on the version {BRANCH} in
+parallel (conflicts of content would occur all the time), and in order to be able to create a
+:abbr:`PR (Pull Request)`, you must `create a new branch
+<https://www.atlassian.com/git/tutorials/using-branches>`_ starting from the branch {BRANCH}. In
+other words, you copy the entirety of this version’s files and give it another name. For this
+example, we will go with ``{BRANCH}-my_contribution``.
 
 Execute the following commands in a terminal to...
 
@@ -306,17 +306,17 @@ Execute the following commands in a terminal to...
 
       $ cd documentation/
 
-#. Switch to the version 13.0:
+#. Switch to the version {BRANCH}:
 
    .. code-block:: console
 
-      $ git checkout 13.0
+      $ git checkout {BRANCH}
 
-#. Create your own branch which will be a copy of 13.0:
+#. Create your own branch which will be a copy of {BRANCH}:
 
    .. code-block:: console
 
-      $ git checkout -b 13.0-my_contribution
+      $ git checkout -b {BRANCH}-my_contribution
 
 .. _contributing/perform-changes:
 
@@ -343,8 +343,8 @@ guidelines.
      #. Delete :file:`my-image.png`.
      #. Rename :file:`my-image-fs8.png` to :file:`my-image.png`.
    - If your changes include renaming or moving an RST file to a new location, follow the `manual
-     for redirect rules <https://github.com/odoo/documentation/tree/13.0/redirects/MANUAL.md>`_ to
-     create the appropriate redirect rule(s).
+     for redirect rules <https://github.com/odoo/documentation/tree/{BRANCH}/redirects/MANUAL.md>`_
+     to create the appropriate redirect rule(s).
 
 .. _contributing/preview-changes:
 
@@ -390,7 +390,7 @@ Submit your changes
 
       $ git add *
       $ git commit
-      $ git push -u origin 13.0-my_contribution
+      $ git push -u origin {BRANCH}-my_contribution
 
 #. Go to `github.com/odoo/documentation/pulls
    <https://github.com/odoo/documentation/pulls>`_ and click on the **New pull request** button.
@@ -403,7 +403,8 @@ Submit your changes
    .. image:: documentation/compare-across-forks.png
 
 #. In the dropdown for the selection of the base branch (i.e., the version of the documentation that
-   your changes concern), make sure to select the version that your changes target (here **13.0**).
+   your changes concern), make sure to select the version that your changes target (here
+   **{BRANCH}**).
 
    .. image:: documentation/select-branches-fork.png
 

--- a/content/contributing/documentation/rst_guidelines.rst
+++ b/content/contributing/documentation/rst_guidelines.rst
@@ -36,8 +36,8 @@ A reference to the rendered :file:`prices.html` and :file:`variants.html` could 
 
 #. Absolute:
 
-   - ``https://odoo.com/documentation/14.0/applications/sales/sales/products_prices/prices.html``
-   - ``https://odoo.com/documentation/14.0/applications/sales/sales/products_prices/products/variants.html``
+   - ``https://odoo.com/documentation/{BRANCH}/applications/sales/sales/products_prices/prices.html``
+   - ``https://odoo.com/documentation/{BRANCH}/applications/sales/sales/products_prices/products/variants.html``
 
 #. Relative:
 

--- a/content/developer/howtos/localization.rst
+++ b/content/developer/howtos/localization.rst
@@ -137,7 +137,7 @@ Each ``account.account.template`` is able to create an ``account.account`` for e
 Some of the described fields above deserve a bit more explanation.
 
 The ``user_type_id`` field requires a value of type ``account.account.type``.
-Although some additional types could be created in a localization module, we encourage the usage of the existing types in the `account/data/data_account_type.xml <https://github.com/odoo/odoo/blob/14.0/addons/account/data/data_account_type.xml>`_ file.
+Although some additional types could be created in a localization module, we encourage the usage of the existing types in the `account/data/data_account_type.xml <{GITHUB_PATH}/addons/account/data/data_account_type.xml>`_ file.
 The usage of these generic types ensures the generic reports working correctly in addition to those that you could create in your localization module.
 
 .. warning::

--- a/content/developer/howtos/rdtraining/02_setup.rst
+++ b/content/developer/howtos/rdtraining/02_setup.rst
@@ -249,10 +249,10 @@ Here are some useful Git commands for your day-to-day work.
   .. code-block:: console
 
      $ cd $HOME/src/odoo
-     $ git switch 14.0
+     $ git switch {CURRENT_MAJOR_BRANCH}
 
      $ cd $HOME/src/enterprise
-     $ git switch 14.0
+     $ git switch {CURRENT_MAJOR_BRANCH}
 
 - Fetch and rebase:
 
@@ -260,11 +260,11 @@ Here are some useful Git commands for your day-to-day work.
 
      $ cd $HOME/src/odoo
      $ git fetch --all --prune
-     $ git rebase --autostash odoo/14.0
+     $ git rebase --autostash odoo/{CURRENT_MAJOR_BRANCH}
 
      $ cd $HOME/src/enterprise
      $ git fetch --all --prune
-     $ git rebase --autostash enterprise/14.0
+     $ git rebase --autostash enterprise/{CURRENT_MAJOR_BRANCH}
 
 Code Editor
 -----------

--- a/content/developer/howtos/rdtraining/B_acl_irrules.rst
+++ b/content/developer/howtos/rdtraining/B_acl_irrules.rst
@@ -10,7 +10,7 @@ Advanced B: ACL and Record Rules
     <howto/rdtraining>`.
 
     To follow the exercise, it is recommended that you fetch the branch
-    14.0-core from the repository XXX, it
+    {CURRENT_MAJOR_BRANCH}-core from the repository XXX, it
     contains a version of the module created during the core training we can use
     as a starting point.
 

--- a/content/developer/howtos/rdtraining/C_data.rst
+++ b/content/developer/howtos/rdtraining/C_data.rst
@@ -6,7 +6,7 @@ Advanced C: Master and Demo Data
 
 .. tip:: This tutorial assumes you followed the Core Training.
 
-  To do the exercise, fetch the branch 14.0-core from the repository XXX.
+  To do the exercise, fetch the branch {CURRENT_MAJOR_BRANCH}-core from the repository XXX.
   It contains a basic module we will use as a starting point
 
 Data Types

--- a/content/developer/howtos/rdtraining/E_unittest.rst
+++ b/content/developer/howtos/rdtraining/E_unittest.rst
@@ -6,7 +6,7 @@ Advanced E: Python Unit Tests
 
 .. tip:: This tutorial assumes you followed the Core Training.
 
-  To do the exercise, fetch the branch 14.0-core from the repository XXX.
+  To do the exercise, fetch the branch {CURRENT_MAJOR_BRANCH}-core from the repository XXX.
   It contains a basic module we will use as a starting point
 
 **Reference**:
@@ -288,7 +288,7 @@ These test classes are built on top of the ``unittest`` python module.
 .. note:: For more readability, split your tests into multiple files depending on the scope of the
   tests. You can also have a Common class that most of the tests should inherit from; that common
   class can define the whole set up for the module. For instance in
-  `account <https://github.com/odoo/odoo/blob/14.0/addons/account/tests/common.py>`__.
+  `account <{GITHUB_PATH}/addons/account/tests/common.py>`__.
 
 .. exercise:: Ensure no one can create an offer for a sold Property, and create a test for it.
 

--- a/content/developer/howtos/rdtraining/J_reports.rst
+++ b/content/developer/howtos/rdtraining/J_reports.rst
@@ -10,7 +10,7 @@ Advanced J: PDF Reports
     and have installed :ref:`wkhtmltopdf <setup/install/source/linux/prepare>`.
 
     To follow the exercise, it is recommended that you fetch the branch
-    14.0-core from the repository XXX, it
+    {CURRENT_MAJOR_BRANCH}-core from the repository XXX, it
     contains a version of the module created during the core training we can use
     as a starting point.
 
@@ -95,9 +95,9 @@ If you don't have a set of data like this already, you can either:
 * Complete :ref:`howto/rdtraining/C_data` (if you haven't done so already) and add the extra
   cases to your demo data (you may need to create a new database to load in the demo data).
 * Manually create the data in your database.
-* Copy this `data file <https://github.com/odoo/technical-training-solutions/blob/14.0-J_reports/estate/data/estate_demo.xml>`__
+* Copy this `data file <https://github.com/odoo/technical-training-solutions/blob/{CURRENT_MAJOR_BRANCH}-J_reports/estate/data/estate_demo.xml>`__
   into a new directory (data) in your estate module and copy
-  `these lines <https://github.com/odoo/technical-training-solutions/blob/14.0-J_reports/estate/__manifest__.py#L21-L23>`__
+  `these lines <https://github.com/odoo/technical-training-solutions/blob/{CURRENT_MAJOR_BRANCH}-J_reports/estate/__manifest__.py#L21-L23>`__
   into your __manifest__.py file (you may need to create a new database to load in the demo data).
 
 Before continuing, click through your data in your database and make sure your data is as expected.

--- a/content/developer/howtos/rdtraining/K_dashboard.rst
+++ b/content/developer/howtos/rdtraining/K_dashboard.rst
@@ -10,7 +10,7 @@ Advanced K: Dashboards
     access to Odoo Enterprise features.
 
     To follow the exercise, it is recommended that you fetch the branch
-    14.0-core from the repository XXX, it
+    {CURRENT_MAJOR_BRANCH}-core from the repository XXX, it
     contains a version of the module created during the core training we can use
     as a starting point.
 
@@ -118,9 +118,9 @@ If you don't have a set of data like this already, you can either:
 * Complete :ref:`howto/rdtraining/C_data` (if you haven't done so already) and add the extra
   cases to your demo data (you may need to create a new database to load in the demo data).
 * Manually create the data in your database.
-* Copy this `data file <https://github.com/odoo/technical-training-solutions/blob/14.0-K_dashboard/estate/data/estate_demo.xml>`__
+* Copy this `data file <https://github.com/odoo/technical-training-solutions/blob/{CURRENT_MAJOR_BRANCH}-K_dashboard/estate/data/estate_demo.xml>`__
   into a new directory called ``data`` in your estate module and copy
-  `these lines <https://github.com/odoo/technical-training-solutions/blob/14.0-K_dashboard/estate/__manifest__.py#L21-L23>`__
+  `these lines <https://github.com/odoo/technical-training-solutions/blob/{CURRENT_MAJOR_BRANCH}-K_dashboard/estate/__manifest__.py#L21-L23>`__
   into your __manifest__.py file (you may need to create a new database to load in the demo data).
 
 Click through your database data and make sure it is what you expect. Of course you can add the
@@ -208,7 +208,7 @@ no xml id is provided for a graph or pivot view then the default view will be us
 The cohort view will not work in the dashboard without a specific xml id. If you have already
 created some of these views then you are welcome to add them to your dashboard! Sample graph and
 pivot views are included in the
-`solution code <https://github.com/odoo/technical-training-solutions/blob/14.0-K_dashboard/estate/views/estate_property_views.xml#L169-L191>`__
+`solution code <https://github.com/odoo/technical-training-solutions/blob/{CURRENT_MAJOR_BRANCH}-K_dashboard/estate/views/estate_property_views.xml#L169-L191>`__
 that you are welcome to use as well.
 
 .. exercise:: Add subviews.

--- a/content/developer/reference/addons/module.rst
+++ b/content/developer/reference/addons/module.rst
@@ -155,5 +155,4 @@ Available manifest fields are:
     Deprecated. Replaced by ``auto_install``.
 
 .. _semantic versioning: https://semver.org
-.. _existing categories:
-     https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
+.. _existing categories: {GITHUB_PATH}/odoo/addons/base/data/ir_module_category_data.xml

--- a/content/developer/reference/addons/testing.rst
+++ b/content/developer/reference/addons/testing.rst
@@ -595,7 +595,7 @@ Javascript
 #. Add any step you want.
 
 Every step contains at least a trigger. You can either use the `predefined steps
-<https://github.com/odoo/odoo/blob/14.0/addons/web_tour/static/src/js/tour_step_utils.js>`_
+<{GITHUB_PATH}/addons/web_tour/static/src/js/tour_step_utils.js>`_
 or write your own personalized step.
 
 Here are some example of steps:

--- a/content/developer/reference/javascript/javascript_reference.rst
+++ b/content/developer/reference/javascript/javascript_reference.rst
@@ -2405,7 +2405,7 @@ do that, several steps should be done.
           }
 
 The ``updateControlPanel`` is the main method to customize the content in controlpanel.
-For more information, look into the `control_panel_renderer.js <https://github.com/odoo/odoo/blob/13.0/addons/web/static/src/js/views/control_panel/control_panel_renderer.js#L130>`_ file.
+For more information, look into the `control_panel_renderer.js <{GITHUB_PATH}/addons/web/static/src/js/views/control_panel/control_panel_renderer.js#L130>`_ file.
 
 .. _.appendTo():
     https://api.jquery.com/appendTo/

--- a/content/legal/cla.rst
+++ b/content/legal/cla.rst
@@ -9,4 +9,4 @@ have to sign the Odoo Contributor License Agreement (CLA).
 
 More information about this requirement, the procedure to sign the agreement,
 and a FAQ can be found on our
-`GitHub project page <https://github.com/odoo/odoo/blob/14.0/doc/cla/sign-cla.md>`_.
+`GitHub project page <{GITHUB_PATH}/doc/cla/sign-cla.md>`_.


### PR DESCRIPTION
This commit replaces hard-coded occurrences of the version and of the
last, current and next releases' version with placeholders interpolated
at build time to avoid manually updating these after each freeze.

task-2917614