### PR TITLE
[IMP] developer: remove utf-8 line from manifest

### DIFF
--- a/content/developer/howtos/rdtraining/C_data.rst
+++ b/content/developer/howtos/rdtraining/C_data.rst
@@ -105,8 +105,6 @@ Your manifest should look like this:
 
 .. code-block:: python
 
-  # -*- coding: utf-8 -*-
-
   {
       "name": "Real Estate",
       "depends": [


### PR DESCRIPTION
Since Python3, it's no longer required to add `# -*- coding: utf-8 -*-` at the beginning of the file. We didn't make a commit to remove all of them but we agreed it wasn't useful to put it anymore.

Let's remove it from the tutorial to avoid some copy pasting from here