### PR TITLE
[FIX] rdtraining: remove outdated line about `journal_id` in chapter 14

### DIFF
--- a/content/developer/howtos/rdtraining/14_other_module.rst
+++ b/content/developer/howtos/rdtraining/14_other_module.rst
@@ -111,8 +111,6 @@ This is enough to create an empty invoice.
 
     - the ``partner_id`` is taken from the current ``estate.property``
     - the ``move_type`` should correspond to a 'Customer Invoice'
-    - the ``journal_id`` must be a ``sale`` journal (when in doubt, have a look
-      `here <https://github.com/odoo/odoo/blob/f1f48cdaab3dd7847e8546ad9887f24a9e2ed4c1/addons/sale/models/sale.py#L534>`__)
 
     Tips:
 


### PR DESCRIPTION
In chapter 14 there was a line pointing to how to deduce a default journal for an `account.move` record. This is no longer needed as the journal is automatically deduced using the `move_type`. Also, the link point to an outdated line of code that causes an error.