### PR TITLE
[FIX] core: latex build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ html: $(HTML_BUILD_DIR)/_static/style.css
 
 # To call *after* `make html`
 # Binary dependencies (Debian): texlive-fonts-recommended texlive-latex-extra
-# texlive-generic-recommended texlive-fonts-extra
+# texlive-fonts-extra
 latexpdf:
 	@echo "Starting build..."
 	$(SPHINX_BUILD) -c $(CONFIG_DIR) -b latex $(SPHINXOPTS) $(SOURCE_DIR) $(BUILD_DIR)/latex

--- a/static/latex/odoo.sty
+++ b/static/latex/odoo.sty
@@ -1,4 +1,4 @@
-\usepackage{droid}
+\usepackage{droidsans}
 %\usepackage[default]{lato}
 \usepackage{inconsolata}
 \usepackage{fancyhdr}


### PR DESCRIPTION
* latest droid package does not allow \usepackage{droid} anymore, replace it with the right package

See https://github.com/MiKTeX/miktex-packaging/issues/136

* remove reference to package texlive-generic-recommended since it's not available nor necessary since ubuntu 20.04.