### PR TITLE
[IMP] odoo_theme: accordion tweaks

### DIFF
--- a/extensions/odoo_theme/static/js/menu.js
+++ b/extensions/odoo_theme/static/js/menu.js
@@ -7,9 +7,12 @@
         // Allow to automatically collapse and expand TOC entries
         _prepareAccordion(navigationMenu);
 
-        // Allow to respectively highlight and expand the TOC entries and their related TOC
-        // entry list whose page is displayed.
+        // Allow to respectively highlight and expand the TOC entries and their related TOC entry
+        // list whose page is displayed.
         _flagActiveTocEntriesAndLists(navigationMenu);
+
+        // Expand the top-level menu items on the homepage.
+        _expandTopMenus(navigationMenu);
 
         // Show hidden menu when the css classes have been properly specified
         navigationMenu.removeAttribute('hidden');
@@ -20,9 +23,9 @@
      *
      * TOC entries (<li> elements) that are on the path of the displayed page receive the
      * `o_active_toc_entry` class, and their related (parent) TOC entry list (<ul> elements) receive
-     * the `show` (Bootstrap) class.
-     * Also, the deepest TOC entries of their respective branch receive the
-     * `o_deepest_active_toc_entry` class, and their child TOC entry lists receive the `show` class.
+     * the `show` (Bootstrap) class. Also, the deepest TOC entries of their respective branch
+     * receive the `o_deepest_active_toc_entry` class, and their child TOC entry lists receive the
+     * `show` class.
      *
      * @param {HTMLElement} navigationMenu - The navigation menu.
      */
@@ -44,7 +47,7 @@
                 lastLayer = currentLayer;
                 lastTocEntry = element;
             }
-        })
+        });
         if (lastTocEntry) {
             deepestTocEntries.push(lastTocEntry); // The last TOC entry is the deepest of its branch
         }
@@ -56,6 +59,19 @@
                 deepestTocEntry = deepestTocEntry.parentElement.parentElement;
             }
             deepestTocEntry.classList.add('o_deepest_active_toc_entry');
+        });
+    };
+
+    /**
+     * Add the `show` class on top-level menus if the user is browsing the homepage.
+     *
+     * @param {HTMLElement} navigationMenu - The navigation menu.
+     */
+    const _expandTopMenus = navigationMenu => {
+        navigationMenu.querySelectorAll('.toctree-l1').forEach(element => {
+            if (!element.parentElement.classList.contains('current')) { // For the homepage only.
+                element.querySelector('ul').classList.add('show'); // Expand the top-level menus.
+            }
         });
     };
 

--- a/extensions/odoo_theme/static/js/page_toc.js
+++ b/extensions/odoo_theme/static/js/page_toc.js
@@ -16,8 +16,7 @@
             // Allow to automatically collapse and expand TOC entries
             _prepareAccordion(pageToc);
 
-            // Allow to respectively highlight and expand the TOC entries and their related TOC
-            // entry list whose section is focused.
+            // Highlight TOC entries whose section is focused and expand their TOC entry list.
             _flagActiveTocEntriesAndLists(pageToc, headingRefs);
 
             // Allow to hide the TOC entry referring the title (<h1> heading)
@@ -97,6 +96,12 @@
                 if (tocEntry.tagName === 'LI') {
                     // Highlight all <li> in the active hierarchy
                     tocEntry.classList.add('o_active_toc_entry');
+
+                    // Update the attributes on the <i>.
+                    const tocEntryWrapper = tocEntry.querySelector('.o_toc_entry_wrapper');
+                    if (tocEntryWrapper) {
+                        tocEntryWrapper.querySelector('i').setAttribute('aria-expanded', true);
+                    }
 
                     // Expand all related <ul>
                     const relatedTocEntryList = tocEntry.querySelector('ul');


### PR DESCRIPTION
**[IMP] odoo_theme: expand top level menu items on the homepage**

When the user browses the homepage, it might be hard to figure out where they want to go. Expanding the top-level menu items could help them figure that out.

------

**[FIX] odoo_theme: update the aria attributes when scrolling the page TOC**

The 'aria-expanded' attribute was not correctly updated on the `i` tag
when the user scrolled through the page TOC. This caused a minor issue
where an arrow (`i`) that was collapsed manually with a click would no
longer automatically expand afterward.

-----

task-3106339