### PR TITLE
[IMP] * : kanban, unify dropdown definition in archs

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -1748,6 +1748,11 @@ Possible children of the view element are:
   least one root template ``kanban-box``, which will be rendered once for each
   record.
 
+  Two additional templates can be defined: ``kanban-menu`` and ``kanban-tooltip``.
+  If defined, the ``kanban-menu`` template is rendered inside a dropdown that can be
+  toggled with a vertical ellipsis (:guilabel:`⋮`) on the top right of the card.
+  The ``kanban-tooltip`` template is rendered inside a tooltip when hovering kanban cards.
+
   The kanban view uses mostly-standard :ref:`javascript qweb
   <reference/qweb/javascript>` and provides the following context variables:
 


### PR DESCRIPTION
This commit add the documentation for the new 'kanban-menu' template (the ellipsis dropdown menu).

No that, this commit add also the documentation for the 'kanban-tooltip' template.

task-id: 3096776