### PR TITLE
[IMP] odoo_theme: Revert $dark color variable to initial $gray-900 + fixes

### DIFF
--- a/extensions/odoo_theme/layout_templates/homepage.html
+++ b/extensions/odoo_theme/layout_templates/homepage.html
@@ -6,8 +6,8 @@
         <div class="row gx-lg-5">
             <div class="col-lg-6">
                 <h2><a href="{{ pathto('applications') }}">{{ _("User Docs") }}</a></h2>
-                <p class="text-muted">{{ _("Discover our guide to help you use and configure the platform, by applications.") }}</p>
-                <h5 class="text-muted pt-3 text-uppercase fw_bold">{{ _("Top Apps") }}</h5>
+                <p class="text-dark">{{ _("Discover our guide to help you use and configure the platform, by applications.") }}</p>
+                <h5 class="text-dark pt-3 text-uppercase fw_bold">{{ _("Top Apps") }}</h5>
                 <ul class="list-unstyled">
                     <li>
                         <a href="{{ pathto('applications/finance/accounting') }}" class="stretched-link">
@@ -33,8 +33,8 @@
             </div>
             <div class="col-lg-6">
                 <h2 class="border-top pt-4 pt-lg-0"><a href="{{ pathto('administration') }}">{{ _("Install and Maintain") }}</a></h2>
-                <p class="text-muted">{{ _("Learn how to install, deploy and upgrade Odoo on premise or on Odoo.sh.") }}</p>
-                <h5 class="text-muted pt-3 text-uppercase fw_bold">{{ _("Top Links") }}</h5>
+                <p class="text-dark">{{ _("Learn how to install, deploy and upgrade Odoo on premise or on Odoo.sh.") }}</p>
+                <h5 class="text-dark pt-3 text-uppercase fw_bold">{{ _("Top Links") }}</h5>
                 <ul class="list-unstyled">
                     <li>
                         <a href=" {{ pathto('administration/deployment/install') }} " class="stretched-link">
@@ -62,8 +62,8 @@
         <div class="row gx-lg-5">
             <div class="col-lg-6">
                 <h2 class="border-top pt-4"><a href="{{ pathto('developer') }}">{{ _("Developer") }}</a></h2>
-                <p class="text-muted">{{ _("Learn to develop in Odoo by reading the framework references and programmer tutorials.") }}</p>
-                <h5 class="text-muted pt-3 text-uppercase fw_bold">{{ _("Top Links") }}</h5>
+                <p class="text-dark">{{ _("Learn to develop in Odoo by reading the framework references and programmer tutorials.") }}</p>
+                <h5 class="text-dark pt-3 text-uppercase fw_bold">{{ _("Top Links") }}</h5>
                 <ul class="list-unstyled">
                     <li>
                         <a href="{{ pathto('developer/howtos/rdtraining') }}" class="stretched-link">
@@ -94,8 +94,8 @@
             </div>
             <div class="col-lg-6">
                 <h2 class="border-top pt-4"><a href="{{ pathto('contributing') }}">{{ _("Contributing") }}</a></h2>
-                <p class="text-muted">{{ _("You want to contribute to Odoo but don't know where to start? The tutorials and guidelines are there to help you make Odoo even better.") }}</p>
-                <h5 class="text-muted pt-3 text-uppercase fw_bold">{{ _("Top Links") }}</h5>
+                <p class="text-dark">{{ _("You want to contribute to Odoo but don't know where to start? The tutorials and guidelines are there to help you make Odoo even better.") }}</p>
+                <h5 class="text-dark pt-3 text-uppercase fw_bold">{{ _("Top Links") }}</h5>
                 <ul class="list-unstyled">
                     <li>
                         <a href="{{ pathto('contributing/development/coding_guidelines') }}" class="stretched-link">

--- a/extensions/odoo_theme/static/scss/_variables.scss
+++ b/extensions/odoo_theme/static/scss/_variables.scss
@@ -118,15 +118,6 @@ $o-literals-border:                         $o-literals-bg;
 $o-toc-bg:                                  $o-gray-bg;
 $o-toc-border:                              $o-toc-bg;
 
-$o-alert-note-color:                        $primary;
-$o-alert-tip-color:                         $primary;
-$o-alert-example-color:                     $success;
-$o-alert-warning-color:                     $success;
-$o-alert-danger-color:                      $danger;
-$o-alert-exercises-color:                   $dark;
-
-$o-accordion-bg:                            $o-alert-exercises-color!default;
-
 //------------------------------------------------------------------------------
 // Misc
 //------------------------------------------------------------------------------

--- a/extensions/odoo_theme/static/scss/bootstrap_overridden.scss
+++ b/extensions/odoo_theme/static/scss/bootstrap_overridden.scss
@@ -26,7 +26,7 @@ $teal:                                      #017e84;
 $primary:                                   $teal;
 $secondary:                                 $purple;
 $light:                                     $gray-100;
-$dark:                                      $gray-600;
+$dark:                                      $gray-900;
 $success:                                   $green;
 $info:                                      $blue;
 $warning:                                   $orange;

--- a/extensions/odoo_theme/static/scss/bootstrap_overridden.scss
+++ b/extensions/odoo_theme/static/scss/bootstrap_overridden.scss
@@ -89,12 +89,12 @@ $modal-xl:                                  fit-content;
 // Accordion
 $accordion-body-padding-y:                  0 !default;
 $accordion-body-padding-x:                  0 !default;
-$accordion-color:                           shade-color($gray-200, 60%) !default;
+$accordion-color:                           $dark !default;
 $accordion-bg:                              $gray-200;
 
 $accordion-button-color:                    $accordion-color !default;
 $accordion-button-active-color:             $accordion-button-color !default;
-$accordion-button-bg:                       $accordion-bg !default;
+$accordion-button-bg:                       transparent;
 $accordion-button-active-bg:                $accordion-button-bg !default;
 $accordion-button-focus-box-shadow:         transparent;
 $accordion-icon-transform:                  rotate(0deg) !default;
@@ -103,5 +103,3 @@ $accordion-icon-transform:                  rotate(0deg) !default;
 $alert-border-width:                        3px;
 $alert-border-scale:                        0;
 $alert-border-radius:                       0 3px 3px 0;
-$alert-bg-scale:                            -87%;
-$alert-color-scale:                         40%;

--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -994,6 +994,8 @@ header {
             &.alert-dark {
                 --o-alert-icon: '#{$i-exercise}';
                 --o-alert-code-border-color: #{tint-color($dark, 50%)};
+
+                background: $gray-300;
             }
         }
     }

--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -993,9 +993,9 @@ header {
             // Exercises
             &.alert-dark {
                 --o-alert-icon: '#{$i-exercise}';
-                --o-alert-code-border-color: #{tint-color($dark, 50%)};
+                --o-alert-code-border-color: $dark;
 
-                background: $gray-300;
+                background: $gray-200;
             }
         }
     }
@@ -1006,12 +1006,12 @@ header {
 //------------------------------------------------------------------------------
 
 .o_spoiler {
-    $background: shift-color($o-accordion-bg, $alert-bg-scale);
-    $border: shift-color($o-accordion-bg, $alert-border-scale);
-    $color: shift-color($o-accordion-bg, $alert-color-scale);
+    $background: $gray-200;
+    $border: shift-color($accordion-color, $alert-border-scale);
+    $color: shift-color($accordion-color, $alert-color-scale);
 
     @if (contrast-ratio($background, $color) < $min-contrast-ratio) {
-        $color: mix($o-accordion-bg, color-contrast($background), abs($alert-color-scale));
+        $color: mix($dark, color-contrast($background), abs($alert-color-scale));
     }
 
     @include alert-variant($background, $border, $color);


### PR DESCRIPTION
The `$dark` color variable was changed to get a good text/background contrast 
when `.alert-dark` ("Exercise") was generated by BS.
But by doing so, the `.text-dark` class also generated by BS became too 
light compared to the intended near-black color.

To solve this the `$dark` variable is returned to its previous color version 
and we manually override the Exercise alert's background color instead.

The accordion ("Spoiler") was facing similar issues because of previous changes
conflicting with the changes from this commit.
Its button has been changed to transparent background and the accordion's 
background, text and border color are now identical to the Exercise `alert` it 
cooperates with.

While doing these changes and recovering the`text-dark` color, 
we noticed the homepage's text color isn't aligned with the rest of the website.
`.text-muted` was too light, so we changed it to `.text-dark`.