### PR TITLE
[FIX] developer: typo on a code example in the framework overview

### DIFF
--- a/content/developer/reference/frontend/framework_overview.rst
+++ b/content/developer/reference/frontend/framework_overview.rst
@@ -180,6 +180,8 @@ every 5 second:
 
     import { registry } from "./core/registry";
 
+    const serviceRegistry = registry.category("services");
+
     const myService = {
         dependencies: ["notification"],
         start(env, { notification }) {


### PR DESCRIPTION
There was a variable being used that was undeclared.