### PR TITLE
[IMP] backend/views: relative width of a field is no longer supported in list views

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -2003,10 +2003,9 @@ Possible children elements of the list view are:
     ``width`` (for ``editable``)
         when there is no data in the list, the width of a column can be forced
         by setting this attribute. The value can be an absolute width (e.g.
-        '100px'), or a relative weight (e.g. '3', meaning that this column will
-        be 3 times larger than the others). Note that when there are records in
-        the list, we let the browser automatically adapt the column's widths
-        according to their content, and this attribute is thus ignored.
+        '100px'). Note that when there are records in the list, we let the
+        browser automatically adapt the column's widths according to their content,
+        and this attribute is thus ignored.
     ``decoration-{$name}``
         allow changing the style of a cell's text based on the corresponding
         record's attributes.


### PR DESCRIPTION
Since the conversion of the list view to owl, the relative field size has not been reimplemented. We have decided not to support it anymore. So we will remove all its uses.

The relative width consists in adding a width attribute with an integer value. This value corresponds to the weight of the field, the higher it is, the more space the field will take. This size is only used when the list is empty.

Example of this:
<tree>
    <field ... width="2">
    <field ... width="1">
</tree>

The first field will take 2x more space than the first one when the list is empty.