### PR TITLE
[IMP] accounting/electronic_invoicing: add a-nz einvoicing format

### DIFF
--- a/content/applications/finance/accounting/receivables/customer_invoices/electronic_invoicing.rst
+++ b/content/applications/finance/accounting/receivables/customer_invoices/electronic_invoicing.rst
@@ -47,6 +47,8 @@ Odoo supports, among others, the following formats.
      - For Dutch companies
    * - EHF 3.0
      - For Norwegian companies
+   * - A-NZ BIS Billing 3.0
+     - For Australian/New Zealand companies
 
 .. seealso::
    - :doc:`../../fiscal_localizations/overview/fiscal_localization_packages`


### PR DESCRIPTION
Since commit
https://github.com/odoo/odoo/commit/9431dddd7c13ae130e7af29936307d22459d543f, the 'A-NZ BIS Billing 3.0' format is available for australian and new zealand companies.