### PR TITLE
[IMP] payment_providers: add AsiaPay brand configuration

### DIFF
--- a/content/applications/finance/payment_providers/asiapay.rst
+++ b/content/applications/finance/payment_providers/asiapay.rst
@@ -10,9 +10,16 @@ covering several Asian countries and payment methods.
 Configuration on AsiaPay Dashboard
 ==================================
 
-#. Log into `AsiaPay Dashboard <https://www.paydollar.com/b2c2/eng/merchant/index.jsp>`_ and go to
-   :menuselection:`Profile --> Account Information`. Copy the values of the :guilabel:`Currency` and
-   :guilabel:`Secure Hash` fields and save them for later.
+#. Log into AsiaPay Dashboard according to the account provided by AsiaPay.
+
+   - `PayDollar <https://www.paydollar.com/b2c2/eng/merchant/index.jsp>`_: For markets in HK,
+     CN, MO, TW, SG, MY, IN, VN, NZ and AU
+   - `PesoPay <https://www.pesopay.com/b2c2/eng/merchant/index.jsp>`_: For market in PH
+   - `SiamPay <https://www.siampay.com/b2c2/eng/merchant/index.jsp>`_: For market in TH
+   - `BimoPay <https://www.bimopay.com/b2c2/eng/merchant/index.jsp>`_: For market in ID
+
+#. Go to :menuselection:`Profile --> Account Information`. Copy the values of the
+   :guilabel:`Currency` and :guilabel:`Secure Hash` fields and save them for later.
 #. | Go to :menuselection:`Profile --> Payment Account Settings` and enable the option
      :guilabel:`Return Value Link (Datefeed)`;
    | Enter your Odoo database URL followed by `/payment/asiapay/webhook` in the
@@ -28,9 +35,10 @@ Configuration on Odoo
 
 #. :ref:`Navigate to the payment provider AsiaPay <payment_providers/add_new>` and change its state
    to :guilabel:`Enabled`.
-#. | In the :guilabel:`Credentials` tab, fill in the :guilabel:`Merchant ID` and
-     :guilabel:`Secure Hash Secret`, and the :guilabel:`Currency` in the :guilabel:`Configuration`
-     tab with the values you saved at the step :ref:`payment_providers/asiapay/configure_dashboard`;
+#. | In the :guilabel:`Credentials` tab, choose the :guilabel:`Brand` of your Asiapay account. Then
+     fill in the :guilabel:`Merchant ID` and :guilabel:`Secure Hash Secret`, and the
+     :guilabel:`Currency` in the :guilabel:`Configuration` tab with the values you saved at the
+     step :ref:`payment_providers/asiapay/configure_dashboard`;
    | By default, the payment provider AsiaPay is configured to verify the secret hash with the hash
      function `SHA1`. If a different function is :ref:`set on your account
      <payment_providers/asiapay/configure_dashboard>`, activate the :ref:`developer mode


### PR DESCRIPTION
Since we are updating the payment_asiapay module for other AsiaPay endpoints,
the documentation of AsiaPay needs to update too.
Please refer to https://github.com/odoo/odoo/pull/110357 for more informations.

task-3073748