### PR TITLE
[IMP] install/maintain: clarification in the upgrade SLA

### DIFF
--- a/content/administration/upgrade.rst
+++ b/content/administration/upgrade.rst
@@ -243,6 +243,7 @@ What upgrading does NOT cover
 * The cleaning of pre-existing data & configuration while upgrading
 * Any new developments and/or upgrades of your own :ref:`custom modules
   <upgrade-faq/custom-modules>`
+* Lines of code added to standard modules that are not created with Odoo Studio.
 * `Training <https://www.odoo.com/learn>`_ on the latest version
 
 You can get more information about your Enterprise Licence on our :ref:`Odoo Enterprise Subscription


### PR DESCRIPTION
The Service Level Agreement has to be updated. Any additional line of code, without using studio, in standard modules is not supposed to be covered by the upgrade team. It is slightly different than the point telling "development of custom modules"