### PR TITLE
[FIX] content: The outlook add-in URL

### DIFF
--- a/content/applications/productivity/mail_plugins/outlook.rst
+++ b/content/applications/productivity/mail_plugins/outlook.rst
@@ -40,7 +40,7 @@ Install the Outlook Plugin
       :align: center
       :alt: Custom add-ins in Outlook
 
-#. Enter the following URL `https://download.odoo.com/plugins/v15/outlook/manifest.xml` and press
+#. Enter the following URL `https://download.odoocdn.com/plugins/v15/outlook/manifest.xml` and press
    *OK*.
 
    .. image:: outlook/enter-add-in-url.png


### PR DESCRIPTION
Cherry-pick of https://github.com/odoo/documentation/pull/3409

> The outlook add-in URL was not updated
> 
> opw:3131547

**This PR is for 15.0 only and should not be forward-ported.**