### PR TITLE
[I18N] migrate to the nex transifex API

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,63 +1,63 @@
 [main]
 host = https://www.transifex.com
-type = PO
 
-[odoo-14-doc.applications]
+[o:odoo:p:odoo-14-doc:r:applications]
 file_filter = locale/<lang>/LC_MESSAGES/applications.po
 source_file = locale/sources/applications.pot
 source_lang = en
 
-[odoo-14-doc.finance]
+[o:odoo:p:odoo-14-doc:r:finance]
 file_filter = locale/<lang>/LC_MESSAGES/finance.po
 source_file = locale/sources/finance.pot
 source_lang = en
 
-[odoo-14-doc.general]
+[o:odoo:p:odoo-14-doc:r:general]
 file_filter = locale/<lang>/LC_MESSAGES/general.po
 source_file = locale/sources/general.pot
 source_lang = en
 
-[odoo-14-doc.index]
+[o:odoo:p:odoo-14-doc:r:index]
 file_filter = locale/<lang>/LC_MESSAGES/index.po
 source_file = locale/sources/index.pot
 source_lang = en
 
-[odoo-14-doc.inventory_and_mrp]
+[o:odoo:p:odoo-14-doc:r:inventory_and_mrp]
 file_filter = locale/<lang>/LC_MESSAGES/inventory_and_mrp.po
 source_file = locale/sources/inventory_and_mrp.pot
 source_lang = en
 
-[odoo-14-doc.marketing]
+[o:odoo:p:odoo-14-doc:r:marketing]
 file_filter = locale/<lang>/LC_MESSAGES/marketing.po
 source_file = locale/sources/marketing.pot
 source_lang = en
 
-[odoo-14-doc.productivity]
+[o:odoo:p:odoo-14-doc:r:productivity]
 file_filter = locale/<lang>/LC_MESSAGES/productivity.po
 source_file = locale/sources/productivity.pot
 source_lang = en
 
-[odoo-14-doc.sales]
+[o:odoo:p:odoo-14-doc:r:sales]
 file_filter = locale/<lang>/LC_MESSAGES/sales.po
 source_file = locale/sources/sales.pot
 source_lang = en
 
-[odoo-14-doc.services]
+[o:odoo:p:odoo-14-doc:r:services]
 file_filter = locale/<lang>/LC_MESSAGES/services.po
 source_file = locale/sources/services.pot
 source_lang = en
 
-[odoo-14-doc.theme]
+[o:odoo:p:odoo-14-doc:r:theme]
 file_filter = locale/<lang>/LC_MESSAGES/sphinx.po
 source_file = locale/sources/sphinx.pot
 source_lang = en
 
-[odoo-14-doc.user_settings]
+[o:odoo:p:odoo-14-doc:r:user_settings]
 file_filter = locale/<lang>/LC_MESSAGES/settings.po
 source_file = locale/sources/settings.pot
 source_lang = en
 
-[odoo-14-doc.websites]
+[o:odoo:p:odoo-14-doc:r:websites]
 file_filter = locale/<lang>/LC_MESSAGES/websites.po
 source_file = locale/sources/websites.pot
 source_lang = en
+


### PR DESCRIPTION
Tansifex is deprecating it's client and switches to a go-based solution in its API v3

The new client is still backward compatible with the old format but the v2 API is going to be phased out.
See https://github.com/transifex/cli to install the deplyments using the tx client

This PR is the result of the "tx migrate" command