### PR TITLE
[FIX] legal: RST cleanup (headings delimiters characters)

### DIFF
--- a/content/legal/terms/enterprise.rst
+++ b/content/legal/terms/enterprise.rst
@@ -153,7 +153,7 @@ or in Covered Extra Modules.
 .. _secu_self_hosting:
 
 Self-Hosting
-++++++++++++
+~~~~~~~~~~~~
 
 For the duration of this Agreement, Odoo SA commits to sending a "Security Advisory" to the Customer
 for any security Bug that is discovered in the Covered Versions of the Software (this excludes Extra
@@ -169,7 +169,7 @@ the public disclosure.
 .. _secu_cloud_platform:
 
 Cloud Platform
-++++++++++++++
+~~~~~~~~~~~~~~
 
 Odoo SA commits to apply the security remedies for any security Bug discovered in a version of
 the Software hosted on the Cloud Platform, on all systems under its control, as soon as
@@ -184,7 +184,7 @@ the remedy is available, without requiring any manual action of the Customer.
 .. _upgrade_odoo:
 
 Upgrade Service for the Software
-++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For the duration of this Agreement, the Customer can submit upgrade requests through the appropriate
 channel (typically Odoo SA's upgrade service website), in order to convert a database of the Software
@@ -235,7 +235,7 @@ https://www.odoo.com/cloud-sla.
 --------------------
 
 Scope
-+++++
+~~~~~
 
 For the duration of this Agreement, the Customer may open an unlimited number of support tickets
 free of charge, exclusively for questions regarding Bugs (see :ref:`bugfix`) or guidance
@@ -247,7 +247,7 @@ In case it’s not clear if a request is covered by this Agreement,
 the decision is at the discretion of Odoo SA.
 
 Availability
-++++++++++++
+~~~~~~~~~~~~
 
 Tickets can be submitted via the web form or phone numbers listed on `odoo.com/help <https://www.odoo.com/help>`_,
 or when working with an Odoo Partner, the channel provided by the partner, subject to local
@@ -421,7 +421,7 @@ Definitions
     (hereafter referred to as “Data Protection Legislation”)
 
 Processing of Personal Data
-+++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The parties acknowledge that the Customer's database may contain Personal Data, for which the
 Customer is the Controller. This data will be processed by Odoo SA when the Customer instructs so,
@@ -459,7 +459,7 @@ With regard to points (d) to (f), the Customer agrees to provide Odoo SA with ac
 information at all times, as necessary to notify the Customer's Data Protection responsible.
 
 Subprocessors
-+++++++++++++
+~~~~~~~~~~~~~
 
 The Customer acknowledges and agrees that in order to provide the Services, Odoo SA may use
 third-party service providers (Subprocessors) to process Personal Data. Odoo SA commits to only

--- a/content/legal/terms/i18n/enterprise_de.rst
+++ b/content/legal/terms/i18n/enterprise_de.rst
@@ -159,7 +159,7 @@ unterstützten  Zusatzmodulen haftbar gemacht werden kann.
 .. _secu_self_hosting_de:
 
 Self-Hosting
-++++++++++++
+~~~~~~~~~~~~
 
     Für die Dauer dieser Vereinbarung verpflichtet sich Odoo SA, dem Kunden für jeden
     Sicherheitsfehler, der in den unterstützten Versionen der Software (dies schließt Zusatzmodule
@@ -176,7 +176,7 @@ Self-Hosting
 .. _secu_cloud_platform_de:
 
 Cloud-Plattform
-+++++++++++++++
+~~~~~~~~~~~~~~~
 
     Odoo SA verpflichtet sich, die Sicherheitsmaßnahmen für jeden Sicherheitsfehler, der in einer
     auf der Cloud-Plattform gehosteten Version der Software entdeckt wird, auf alle von Odoo SA
@@ -191,7 +191,7 @@ Cloud-Plattform
 .. _upgrade_odoo_de:
 
 Upgrade-Service für die Software
-++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Während der Laufzeit dieser Vereinbarung kann der Kunde über den entsprechenden Kanal (in der Regel
 die Upgrade-Service-Website von Odoo SA) Upgrade-Anträge stellen, um eine Datenbank der Software von
@@ -244,7 +244,7 @@ https://www.odoo.com/cloud-sla beschrieben.
 -------------------
 
 Umfang
-++++++
+~~~~~~
 
 Während der Laufzeit dieser Vereinbarung kann der Kunde eine unbegrenzte Anzahl von kostenlosen
 Support-Tickets öffnen, die ausschließlich Fragen zu Fehlern (siehe :ref:`bugfix_de`) oder
@@ -256,7 +256,7 @@ Erwerb einer separaten Servicevereinbarung abgedeckt werden. Falls nicht klar is
 von diesem Vertrag abgedeckt ist, liegt die Entscheidung im Ermessen von Odoo SA.
 
 Verfügbarkeit
-+++++++++++++
+~~~~~~~~~~~~~
 
 Tickets können über das Webformular oder die auf https://odoo.com/help aufgeführten Telefonnummern
 eingereicht werden, oder, wenn Sie mit einem Odoo-Partner zusammenarbeiten, über den von diesem
@@ -430,7 +430,7 @@ Definitionen
     "Datenschutzgesetzgebung" bezeichnet).
 
 Verarbeitung von personenbezogenen Daten
-++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Die Parteien erkennen an, dass die Datenbank des Kunden personenbezogene Daten enthalten kann, für
 die der Kunde verantwortlich ist. Diese Daten werden von Odoo SA verarbeitet, wenn der Kunde dies
@@ -472,7 +472,7 @@ Kontaktinformationen zur Verfügung zu stellen, die für die Benachrichtigung de
 Datenschutzbeauftragten des Kunden erforderlich sind.
 
 Unterauftragsverarbeiter
-++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Der Kunde nimmt zur Kenntnis und erklärt sich damit einverstanden, dass Odoo SA zur Erbringung der
 Dienstleistungen Dritte (Unterauftragsverarbeiter) mit der Verarbeitung personenbezogener Daten

--- a/content/legal/terms/i18n/enterprise_es.rst
+++ b/content/legal/terms/i18n/enterprise_es.rst
@@ -151,7 +151,7 @@ Acuerdo y en la licencia del Software.
 .. _secu_self_hosting_es:
 
 Hospedaje en servidores propios
-+++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Durante la vigencia de este Acuerdo, Odoo SA se compromete a enviar un “Aviso de Seguridad” al
 Cliente al identificar algún Bug de seguridad en las versiones cubiertas del Software (excluyendo
@@ -165,7 +165,7 @@ tratados como Información Confidencial de acuerdo a lo descrito en la sección
 :ref:`confidentiality_es` del presente Acuerdo, hasta la fecha de publicación del Aviso de Seguridad.
 
 Plataforma en la nube
-+++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~
 
 En el momento que exista una medida de seguridad, Odoo SA se compromete a aplicar dicha medida de
 seguridad ante cualquier Bug que comprometa la seguridad del Software, siempre y cuando este Bug
@@ -180,7 +180,7 @@ bajo el control de esta plataforma, sin requerir de alguna acción manual por pa
 .. _upgrade_odoo_es:
 
 Servicio de actualización para el software
-++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Durante la vigencia de este Acuerdo, el Cliente puede solicitar la actualización de su versión del
 Software a través del medio apropiado (generalmente a través de la sección de servicios de
@@ -234,7 +234,7 @@ el nivel del servicio, disponible en `Cloud SLA <http://www.odoo.com/cloud-sla>`
 ------------------------
 
 Alcance
-+++++++
+~~~~~~~
 
 Durante la vigencia del presente Acuerdo, el Cliente puede crear un número ilimitado de tickets de
 soporte sin costos adicionales, exclusivamente para preguntas relacionadas a Bugs (consultar sección
@@ -247,7 +247,7 @@ claro si una solicitud puede ser respondida por el Servicio de soporte, la decis
 discreción de Odoo SA.
 
 Disponibilidad
-++++++++++++++
+~~~~~~~~~~~~~~
 
 Los tickets de soporte pueden ser enviados a través del formulario en el sitio web o a los números
 de contacto que se encuentran en `Odoo Help <https://www.odoo.com/es_ES/help>`__, o cuando se
@@ -431,7 +431,7 @@ Definiciones
     o legislación que los modifique o sustituya (en adelante, “Legislacion de Proteccion de Datos”).
 
 Procesamiento de datos personales
-+++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Las Partes reconocen que la base de datos del Cliente puede contener Datos Personales, de los cuales
 el Cliente es el Responsable del tratamiento. Esta data será procesada por Odoo SA cuando el Cliente
@@ -470,7 +470,7 @@ precisa en todo momento, según sea necesario para notificar al responsable de l
 Protección de Datos del Cliente.
 
 Sub procesadores
-++++++++++++++++
+~~~~~~~~~~~~~~~~
 
 El Cliente reconoce y acepta que, para proporcionar los Servicios, Odoo SA puede utilizar a terceros
 como proveedores de servicios para procesar Datos Personales (en adelante “Sub-procesadores”).

--- a/content/legal/terms/i18n/enterprise_fr.rst
+++ b/content/legal/terms/i18n/enterprise_fr.rst
@@ -165,7 +165,7 @@ des Modules Supplémentaires Couverts.
 .. _secu_self_hosting_fr:
 
 Auto-Hébergement
-++++++++++++++++
+~~~~~~~~~~~~~~~~
 
 Pour la durée du Contrat, Odoo SA s'engage à envoyer une "alerte de sécurité"" au Client
 pour tout Bug présentant un risque de sécurité qui serait découvert dans les Versions Couvertes
@@ -181,7 +181,7 @@ sécurité comme des Informations Confidentielles telles que décrites à la sec
 .. _secu_cloud_platform_fr:
 
 Plate-forme Cloud
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 Odoo SA s'engage à appliquer les correctifs de sécurité pour tout Bug de sécurité découvert
 dans une version du Logiciel hébergé sur la Plate-forme Cloud, sur tous les systèmes sous son
@@ -196,7 +196,7 @@ contrôle, dès que le correctif est disponible, et sans intervention manuelle d
 .. _upgrade_odoo_fr:
 
 Service de migration du Logiciel
-++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pour la durée du présent Contrat, le Client peut soumettre des demandes de migration en suivant
 les procédures appropriées (généralement, via le site du service de migration d'Odoo SA),
@@ -252,7 +252,7 @@ https://www.odoo.com/cloud-sla.
 ------------------------
 
 Portée
-++++++
+~~~~~~
 
 Pour la durée du présent Contrat, le Client peut ouvrir un nombre non limité de demandes d'assistance
 sans frais, exclusivement pour des questions relatives à des Bugs (voir :ref:`bugfix_fr`) ou des
@@ -265,7 +265,7 @@ Au cas où il n'est pas clair qu'une demande est couverte par ce Contrat, la dé
 discrétion d'Odoo SA.
 
 Disponibilité
-+++++++++++++
+~~~~~~~~~~~~~
 
 Les demandes d'assistances peuvent être soumises via le formulaire en ligne ou les numéros
 de téléphone indiqués sur https://www.odoo.com/help, ou en cas de travail avec un
@@ -446,7 +446,7 @@ Définitions
     qui les amende ou les remplace (collectivement, la "Législation sur la Protection des Données")
 
 Traitement de Données à Caractère Personnel
-+++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Les parties conviennent que la base de données du Client peut contenir des Données à Caractère Personnel,
 pour lesquelles le Client est le Responsable de Traitement. Ces données seront traitées par Odoo SA
@@ -486,7 +486,7 @@ contact valables, tel que nécessaire pour toute notification auprès du respons
 données du Client.
 
 Sous-traitants
-++++++++++++++
+~~~~~~~~~~~~~~
 
 Le Client convient et accepte que pour fournir les Services, Odoo SA peut faire appel à des
 prestataires de service tiers (Sous-traitants) pour traiter les Données à Caractère Personnel.

--- a/content/legal/terms/i18n/enterprise_nl.rst
+++ b/content/legal/terms/i18n/enterprise_nl.rst
@@ -174,7 +174,7 @@ Extra Modules.
 .. _secu_self_hosting_nl:
 
 Self-Hosting
-++++++++++++
+~~~~~~~~~~~~
 
 Voor de duur van deze Overeenkomst verbingt Odoo NV zich ertoe een "Veiligheidsadvies"
 naar de Klant te sturen voor elke beveiligingsfout die wordt ontdekt in de Ondersteunde
@@ -192,7 +192,7 @@ als Vertrouwelijke Informatie zoals beschreven in
 .. _secu_cloud_platform_nl:
 
 Cloudplatform
-+++++++++++++
+~~~~~~~~~~~~~
 
 Odoo NV verbindt zich ertoe om de beveiligingsoplossingen voor elke beveiligingsbug
 die wordt ontdekt in een versie van de Software die op het Cloudplatform wordt gehost,
@@ -207,7 +207,7 @@ zonder dat daarvoor enige handmatige actie van de Klant nodig is.
 .. _upgrade_odoo_nl:
 
 Upgradedienst voor de Software
-++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Voor de duur van deze Overeenkomst kan de Klant via het juiste kanaal
 (doorgaans de upgradedienstwebsite van Odoo NV) upgradeaanvragen indienen om
@@ -263,7 +263,7 @@ Agreement-pagina op https://www.odoo.com/cloud-sla.
 ------------------------
 
 Toepassingsgebied
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 Voor de duur van deze Overeenkomst kan de klant gratis een onbeperkt aantal ondersteuningstickets
 openen, uitsluitend voor vragen over Bugs (zie :ref:`bugfix_nl`) of begeleiding met betrekking
@@ -275,7 +275,7 @@ duidelijk is of een verzoek onder deze Overeenkomst valt, ligt het uiteindelijke
 bij Odoo NV.
 
 Beschikbaarheid
-+++++++++++++++
+~~~~~~~~~~~~~~~
 
 Tickets kunnen worden ingediend via het websiteformulier of de telefoonnummers
 vermeld op https://www.odoo.com/help of, in geval van samenwerking met een
@@ -466,7 +466,7 @@ Definities
     "Gegevensbeschermingswetgeving" genoemd).
 
 Verwerken van persoonsgegevens
-++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 De partijen erkennen dat de database van de Klant Persoonsgegevens kan bevatten, waarvoor
 de Klant de Verwerkingsverantwoordelijke is. Deze gegevens worden verwerkt door Odoo NV wanneer
@@ -508,7 +508,7 @@ voorzien van nauwkeurige contactgegevens, die nodig zijn om de verantwoordelijke
 gegevensbescherming van de Klant in kennis te stellen.
 
 Subverwerkers
-+++++++++++++
+~~~~~~~~~~~~~
 
 De Klant erkent en gaat ermee akkoord dat Odoo NV voor de levering van de Diensten een beroep kan doen
 op externe dienstverleners (Subverwerkers) om Persoonsgegevens te verwerken. Odoo NV verbindt zich ertoe


### PR DESCRIPTION
RST cleanup to comply with the RST guidelines. This is required so we can use "make test", as there are currently hundreds of errors. For now, it is unusable because of the oldest code in this repo.