### PR TITLE
[FIX] 02_setup: remove gramatical error

### DIFF
--- a/content/developer/howtos/rdtraining/02_setup.rst
+++ b/content/developer/howtos/rdtraining/02_setup.rst
@@ -50,7 +50,7 @@ allows you to connect to GitHub without supplying your username and password eve
 command.
 
 .. note::
-   The following step-by-step procedure is based based on the `official GitHub documentation
+   The following step-by-step procedure is based on the `official GitHub documentation
    <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_.
 
 #. Generate a new SSH key, add it to the ssh-agent, and copy the SSH key to your clipboard.


### PR DESCRIPTION
in line 53 of the 02_setup portion of the getting started docs, there is an unnecessary doubled word "based", one of them should be removed