### PR TITLE
[FIX] legal: RST cleanup (quotation marks and apostrophes)

### DIFF
--- a/content/legal/coc.rst
+++ b/content/legal/coc.rst
@@ -90,7 +90,7 @@ in communities where the conduct described above is normal and expected.
 However, failure to observe the code may be grounds for reprimand, probation,
 or removal from the lists.
 
-If you have concerns about someone’s conduct:
+If you have concerns about someone's conduct:
 Direct contact: it is always appropriate to email a list member, mention that
 you think their behavior was out of line, and (if necessary) point them to this
 document.

--- a/content/legal/terms/enterprise.rst
+++ b/content/legal/terms/enterprise.rst
@@ -36,7 +36,7 @@ following terms and conditions (the "Agreement").
 1 Term of the Agreement
 =======================
 
-The duration of this Agreement (the “Term”) shall be specified in writing on conclusion of this
+The duration of this Agreement (the "Term") shall be specified in writing on conclusion of this
 Agreement, beginning on the date of conclusion.
 It is automatically renewed for an equal Term, unless either party provides a written notice of
 termination minimum 30 days before the end of the Term to the other party.
@@ -243,7 +243,7 @@ with respect to the use of the standard features of the Software and Covered Ext
 
 Other assistance requests, such as questions related to development or customizations
 may be covered through the purchase of a separate service agreement.
-In case it’s not clear if a request is covered by this Agreement,
+In case it's not clear if a request is covered by this Agreement,
 the decision is at the discretion of Odoo SA.
 
 Availability
@@ -356,7 +356,7 @@ When the Customer chooses to use the Cloud Platform, the Customer further agrees
 
 When the Customer chooses the Self-Hosting option, the Customer further agrees to:
 
-- take all reasonable measures to protect Customer’s files and databases and to ensure Customer’s
+- take all reasonable measures to protect Customer's files and databases and to ensure Customer's
   data is safe and secure, acknowledging that Odoo SA cannot be held liable for any data loss;
 - grant Odoo SA the necessary access to verify the validity of the Odoo Enterprise Edition usage
   upon request (e.g. if the automatic validation is found to be inoperant for the Customer).
@@ -382,7 +382,7 @@ EUR (€) 30 000.00 (thirty thousand euros).
 -------------
 
 Except where notified otherwise in writing, each party grants the other a non-transferable,
-non-exclusive, royalty free, worldwide license to reproduce and display the other party’s name,
+non-exclusive, royalty free, worldwide license to reproduce and display the other party's name,
 logos and trademarks, solely for the purpose of referring to the other party as a customer or
 supplier, on websites, press releases and other marketing materials.
 
@@ -418,7 +418,7 @@ Definitions
     "Personal Data", "Controller", "Processing" take the same meanings as in the
     Regulation (EU) 2016/679 and the Directive 2002/58/EC,
     and any regulation or legislation that amends or replaces them
-    (hereafter referred to as “Data Protection Legislation”)
+    (hereafter referred to as "Data Protection Legislation")
 
 Processing of Personal Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -451,7 +451,7 @@ In particular, Odoo SA commits to:
   Data Protection Legislation, allow for and contribute reasonably to audits, including
   inspections, conducted or mandated by the Customer;
 - (h) permanently delete all copies of the Customer's database in possession of Odoo SA,
-  or return such data, at the Customer’s choice, upon termination of this Agreement,
+  or return such data, at the Customer's choice, upon termination of this Agreement,
   subject to the delays specified in Odoo SA's
   `Privacy Policy <https://www.odoo.com/privacy>`_ ;
 
@@ -484,8 +484,8 @@ the applicable fees for the Services within 21 days following the due date speci
 corresponding invoice, and after minimum 3 reminders.
 
 Surviving Provisions:
-  The sections ":ref:`confidentiality`”, “:ref:`disclaimers`”,
-  “:ref:`liability`”, and “:ref:`general_provisions`” will survive any termination or expiration of
+  The sections ":ref:`confidentiality`", ":ref:`disclaimers`",
+  ":ref:`liability`", and ":ref:`general_provisions`" will survive any termination or expiration of
   this Agreement.
 
 
@@ -508,7 +508,7 @@ with the licence of the Software.
 For the duration of this Agreement, Odoo SA commits to using commercially reasonable efforts to
 execute the Services in accordance with the generally accepted industry standards provided that:
 
-- the Customer’s computing systems are in good operational order and, for Self-Hosting, that
+- the Customer's computing systems are in good operational order and, for Self-Hosting, that
   the Software is installed in a suitable operating environment;
 - the Customer provides adequate troubleshooting information and, for Self-Hosting, any access
   that Odoo SA may need to identify, reproduce and address problems;

--- a/content/legal/terms/i18n/enterprise_es.rst
+++ b/content/legal/terms/i18n/enterprise_es.rst
@@ -18,19 +18,19 @@ Acuerdo de suscripción de Odoo Enterprise
 
 .. note:: Version 9c - 2020-06-15
 
-Al suscribirse a los servicios de Odoo Enterprise (en adelante “los Servicios”) proporcionados por
-Odoo SA y sus filiales (en adelante denominadas conjuntamente “Odoo SA”), relacionados con las
-versiones Odoo Enterprise o Odoo community (en adelante “el Software”) y alojados en los servidores
-de la nube de Odoo SA (en adelante “Servicio en la Nube”) o en servidores locales (en adelante
-“Auto-hospedaje”), usted (en adelante “el Cliente”) acepta los términos y condiciones establecidos a
-continuación (en adelante “el Acuerdo”).
+Al suscribirse a los servicios de Odoo Enterprise (en adelante "los Servicios") proporcionados por
+Odoo SA y sus filiales (en adelante denominadas conjuntamente "Odoo SA"), relacionados con las
+versiones Odoo Enterprise o Odoo community (en adelante "el Software") y alojados en los servidores
+de la nube de Odoo SA (en adelante "Servicio en la Nube") o en servidores locales (en adelante
+"Auto-hospedaje"), usted (en adelante "el Cliente") acepta los términos y condiciones establecidos a
+continuación (en adelante "el Acuerdo").
 
 .. _term_es:
 
 1 Término del Acuerdo
 =====================
 
-La duración de la suscripción (en adelante el “Plazo”) será indicada por escrito en este Acuerdo, y
+La duración de la suscripción (en adelante el "Plazo") será indicada por escrito en este Acuerdo, y
 comenzará a partir de la fecha de firma del Acuerdo. La suscripción se considerará renovada
 automáticamente por un período igual al Plazo estipulado originalmente, salvo que alguna de las
 partes del Acuerdo proporcione un aviso por escrito expresando su deseo de culminar los Servicios al
@@ -48,12 +48,12 @@ Usuario
     limitado al Software a través del portal del usuario.
 
 Aplicación
-    Una ‘aplicación’ es un grupo especializado de funciones disponibles para ser instaladas en el
+    Una 'aplicación' es un grupo especializado de funciones disponibles para ser instaladas en el
     Software, las cuales están enunciadas en la sección de Precios del
     `sitio web de Odoo SA <https://www.odoo.com/es_ES/>`__
 
 Partner de Odoo
-    Un ‘Partner’ de Odoo es una empresa o individuo externo a Odoo SA que ofrece servicios
+    Un 'Partner' de Odoo es una empresa o individuo externo a Odoo SA que ofrece servicios
     relacionados con el Software, y quien ha sido seleccionado por el Cliente para trabajar
     directamente con él. En cualquier momento, el cliente puede decidir trabajar con un Partner
     diferente o con Odoo SA directamente (sujeto a previo aviso).
@@ -71,7 +71,7 @@ Módulo adicional de mantenimiento
     corrección de errores.
 
 Error/Bug
-    Se considera como ‘bug’ a cualquier falla del Software o de un módulo adicional de mantenimiento
+    Se considera como 'bug' a cualquier falla del Software o de un módulo adicional de mantenimiento
     que resulte en una disrupción completa, una cadena de errores o un fallo de seguridad, y que no
     es causado directamente por una instalación o configuración defectuosa. El incumplimiento de
     algunas especificaciones o requisitos será considerado como un Bug a la discreción de Odoo SA
@@ -153,7 +153,7 @@ Acuerdo y en la licencia del Software.
 Hospedaje en servidores propios
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Durante la vigencia de este Acuerdo, Odoo SA se compromete a enviar un “Aviso de Seguridad” al
+Durante la vigencia de este Acuerdo, Odoo SA se compromete a enviar un "Aviso de Seguridad" al
 Cliente al identificar algún Bug de seguridad en las versiones cubiertas del Software (excluyendo
 módulos adicionales), al menos 2 semanas antes de hacer público el Aviso de Seguridad, al menos que
 el Bug ya haya sido revelado públicamente por algún tercero. Los Avisos de Seguridad pueden incluir
@@ -185,8 +185,8 @@ Servicio de actualización para el software
 Durante la vigencia de este Acuerdo, el Cliente puede solicitar la actualización de su versión del
 Software a través del medio apropiado (generalmente a través de la sección de servicios de
 actualizaciones del sitio web de Odoo SA), con la finalidad de actualizar la base de datos del
-Software que tiene a una versión más reciente de las versiones cubiertas (en adelante la “Versión
-Deseada”).
+Software que tiene a una versión más reciente de las versiones cubiertas (en adelante la "Versión
+Deseada").
 
 Las solicitudes de actualización de los Clientes que usan los servicios en la nube deben ser
 solicitadas directamente desde el panel de control de la Plataforma en la nube y no requieren
@@ -294,7 +294,7 @@ Además, los servicios de los módulos adicionales de mantenimiento se cobran en
 líneas de código de estos módulos. Cuando el cliente opta por el mantenimiento de estos módulos
 adicionales de mantenimiento, el costo es una tarifa mensual de 16 € por 100 líneas de código
 (redondeadas a las siguientes 100), al menos que se especifique lo contrario por escrito al celebrar
-este Acuerdo. Las líneas de código serán contadas con el comando ‘cloc’ del Software, e incluyen
+este Acuerdo. Las líneas de código serán contadas con el comando 'cloc' del Software, e incluyen
 todas las líneas de texto en el código fuente de esos módulos, independientemente del lenguaje de
 programación (Python, Javascript, XML, etc), excluyendo líneas en blanco, comentarios y archivos que
 no se cargan al instalar o ejecutar el software.
@@ -309,7 +309,7 @@ tarifa adicional única de 16 € por cada 100 líneas de código, por cada mes 
 ------------------------
 
 Siguiendo la renovación descrita en la sección :ref:`term_es` del presente Acuerdo, si los cargos
-aplicados durante el Plazo anterior (excluyendo cualquier “Descuento para usuarios iniciales”) son
+aplicados durante el Plazo anterior (excluyendo cualquier "Descuento para usuarios iniciales") son
 más bajos que el precio aplicable en la lista de precios actual, dichos cargos podrán aumentar 7%
 como máximo.
 
@@ -319,7 +319,7 @@ como máximo.
 -------------
 
 Todas las tarifas y cargos son exclusivos de todos los impuestos, tarifas o cargos federales,
-provinciales, estatales, locales o gubernamentales aplicables (conjuntamente los “Impuestos”). El
+provinciales, estatales, locales o gubernamentales aplicables (conjuntamente los "Impuestos"). El
 Cliente es responsable de pagar todos los Impuestos asociados con las compras realizadas por el
 Cliente en virtud de este Acuerdo, excepto cuando Odoo SA esté legítimamente obligado a pagar o
 recolectar los Impuestos que el Cliente debe asumir.
@@ -406,7 +406,7 @@ Definición de "Información confidencial":
     presente Acuerdo, ya sea oralmente o por escrito, designada como confidencial o razonablemente
     considerada confidencial dada la naturaleza de la información y las circunstancias de divulgación.
     En particular, cualquier información relacionada a los negocios, asuntos, productos, desarrollos,
-    secretos comerciales, “know-how”, el personal, los clientes y los proveedores de cualquiera de las
+    secretos comerciales, "know-how", el personal, los clientes y los proveedores de cualquiera de las
     Partes del presente Acuerdo, debe ser considerada como confidencial.
 
 Para cualquier tipo de información confidencial recibida durante el Plazo de este Acuerdo, la Parte
@@ -426,9 +426,9 @@ permita.
 -----------------------
 
 Definiciones
-    Los términos “Datos Personales”, “Responsable del tratamiento”, “Tratamiento” tienen los mismos
+    Los términos "Datos Personales", "Responsable del tratamiento", "Tratamiento" tienen los mismos
     significados que en el Reglamento (UE) 2016/679 y la Directiva 2002/58 / CE, y cualquier reglamento
-    o legislación que los modifique o sustituya (en adelante, “Legislacion de Proteccion de Datos”).
+    o legislación que los modifique o sustituya (en adelante, "Legislacion de Proteccion de Datos").
 
 Procesamiento de datos personales
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -446,7 +446,7 @@ protección de datos. En particular, Odoo SA se compromete a:
 - (a) Solo procesar los datos personales cuando y como lo indique el Cliente, y para elp ropósito
   de realizar uno de los Servicios en virtud de este Acuerdo, a menos que sea requerido por la
   ley, en cuyo caso, Odoo SA proporcionará un aviso previo al Cliente, a menos que la ley lo prohíba;
-- (b) garantizar que todas las personas dentro de Odoo SA” autorizadas para procesar los Datos
+- (b) garantizar que todas las personas dentro de Odoo SA" autorizadas para procesar los Datos
   personales estén comprometidos con la confidencialidad;
 - (c) implementar y mantener medidas técnicas y organizativas adecuadas para proteger los datos
   personales contra el procesamiento no autorizado o ilegal y contra la pérdida accidental,
@@ -473,7 +473,7 @@ Sub procesadores
 ~~~~~~~~~~~~~~~~
 
 El Cliente reconoce y acepta que, para proporcionar los Servicios, Odoo SA puede utilizar a terceros
-como proveedores de servicios para procesar Datos Personales (en adelante “Sub-procesadores”).
+como proveedores de servicios para procesar Datos Personales (en adelante "Sub-procesadores").
 Odoo SA se compromete a utilizar Sub-procesadores únicamente de conformidad con la Legislación de
 Protección de Datos. Este uso estará amparado bajo un contrato entre Odoo SA y el Sub-procesador que
 de garantías para estos servicios.
@@ -497,7 +497,7 @@ obligación de pago del Servicio dentro de los 21 días siguientes a la fecha de
 facturación, y después de haber emitido al menos 3 recordatorios de pago.
 
 Disposiciones supervivientes: Las secciones ":ref:`confidentiality_es`",
-“:ref:`disclaimers_es`",“:ref:`liability_es`", y “:ref:`general_provisions_es`” estarán vigentes
+":ref:`disclaimers_es`",":ref:`liability_es`", y ":ref:`general_provisions_es`" estarán vigentes
 incluso después de cualquier terminación o vencimiento del presente Acuerdo.
 
 .. _warranties_disclaimers_es:

--- a/content/legal/terms/i18n/enterprise_fr.rst
+++ b/content/legal/terms/i18n/enterprise_fr.rst
@@ -8,10 +8,10 @@ Odoo Enterprise Subscription Agreement (FR)
 
     `Download PDF <odoo_enterprise_agreement_fr.pdf>`_
 .. warning::
-    Ceci est une traduction en français du contrat “Odoo Enterprise Subscription Agreement”.
-    Cette traduction est fournie dans l’espoir qu’elle facilitera sa compréhension, mais elle
+    Ceci est une traduction en français du contrat "Odoo Enterprise Subscription Agreement".
+    Cette traduction est fournie dans l'espoir qu'elle facilitera sa compréhension, mais elle
     n'a aucune valeur légale.
-    La seule référence officielle des termes du contrat “Odoo Enterprise Subscription Agreement”
+    La seule référence officielle des termes du contrat "Odoo Enterprise Subscription Agreement"
     est la :ref:`version originale en anglais <enterprise_agreement>`.
 
 .. note:: Version 10a - 2022-10-27
@@ -44,7 +44,7 @@ En vous abonnant aux services de Odoo Enterprise (les "Services") fournis par Od
 
 La durée du présent Contrat (la "Durée") sera spécifiée par
 écrit à la conclusion du Contrat, à compter de la date de la conclusion. Celui-ci est automatiquement
-reconduit pour une même durée, à moins que l'une des parties n’envoie à l'autre partie un préavis
+reconduit pour une même durée, à moins que l'une des parties n'envoie à l'autre partie un préavis
 écrit de résiliation, et au moins 30 jours avant la date d'échéance du contrat.
 
 .. _definitions_fr:
@@ -211,7 +211,7 @@ base de données du Client et les données associées (généralement obtenues �
 Backup du Logiciel).
 
 Ce service est fourni par le biais d'une plate-forme automatisée, afin de permettre au Client
-d'effectuer des migrations sans intervention humaine, dès lors qu’une version précédente de la
+d'effectuer des migrations sans intervention humaine, dès lors qu'une version précédente de la
 base de données du Client a été migrée avec succès pour une Version Couverte donnée.
 
 Le service de migration est limité à la conversion et à l'adaptation techniques de la base
@@ -504,7 +504,7 @@ Odoo SA pour l'exécution des Services.
 ---------------
 
 Dans le cas où l'une des parties ne remplit pas ses obligations découlant du
-présent contrat, et si une telle violation n’est pas résolue dans les 30 jours
+présent contrat, et si une telle violation n'est pas résolue dans les 30 jours
 civils à compter de la notification écrite de cette violation, le présent
 contrat peut être résilié immédiatement par la partie qui n'a pas commis la
 violation.
@@ -514,8 +514,8 @@ Client ne paie pas les frais applicables pour les services dans les 21 jours sui
 indiquée sur la facture correspondante, après minimum 3 rappels.
 
 Durée de l'applicabilité des dispositions:
-  Les sections ":ref:`confidentiality_fr`", “:ref:`disclaimers_fr`",   “:ref:`liability_fr`",
-  et “:ref:`general_provisions_fr`" survivront la résiliation ou l'expiration du présent contrat.
+  Les sections ":ref:`confidentiality_fr`", ":ref:`disclaimers_fr`",   ":ref:`liability_fr`",
+  et ":ref:`general_provisions_fr`" survivront la résiliation ou l'expiration du présent contrat.
 
 
 .. _warranties_disclaimers_fr:
@@ -578,7 +578,7 @@ donnant lieu à une telle réclamation. Des réclamations multiples n'augmentero
 
 Les parties et leurs filiales ne pourront en aucun cas être tenues responsables des dommages
 indirects, spéciaux, punitifs, accessoires ou consécutifs de quelque nature que ce soit,
-y compris, mais sans s'y limiter, la perte de revenus, perte de profits, perte d’économies,
+y compris, mais sans s'y limiter, la perte de revenus, perte de profits, perte d'économies,
 perte commerciale ou toute autre perte financière, les coûts relatifs à l'arrêt ou au retard,
 la perte ou altération des données, découlant ou en relation avec le présent Contrat, quelle que
 soit la forme de l'action, qu'elle soit fondée sur une obligation contractuelle, délictuelle
@@ -596,7 +596,7 @@ d'exécution en vertu du présent Contrat, si ce manquement ou retard trouve sa 
 une règlementation gouvernementale, un incendie, une grève, une guerre, une inondation,
 un accident, une épidémie, un embargo, la saisie d'une usine ou d'un produit dans son intégralité
 ou en partie par un gouvernement ou une autorité publique, ou toute (s) autre (s) cause (s),
-qu’elle (s) soit (soient) de nature similaire ou différente, pour autant que cette cause soit
+qu'elle (s) soit (soient) de nature similaire ou différente, pour autant que cette cause soit
 hors du contrôle raisonnable de la partie concernée, et tant qu'une telle cause existe.
 
 .. _general_provisions_fr:
@@ -611,7 +611,7 @@ hors du contrôle raisonnable de la partie concernée, et tant qu'une telle caus
 
 Le présent contrat et les commandes passées par le client sont exclusivement régis par le droit belge.
 Tout différend relatif au présent contrat ou à une commande passée par le Client relève de la
-compétence exclusive du tribunal de l’entreprise de Nivelles.
+compétence exclusive du tribunal de l'entreprise de Nivelles.
 
 .. _severability_fr:
 
@@ -634,17 +634,17 @@ Odoo Enterprise Edition est publié sous la licence Odoo Enterprise Edition Lice
 définie ci-dessous.
 
 .. warning::
-    Ceci est une traduction en français de la licence “Odoo Enterprise Edition License”.
-    Cette traduction est fournie dans l’espoir qu’elle facilitera sa compréhension, mais elle
+    Ceci est une traduction en français de la licence "Odoo Enterprise Edition License".
+    Cette traduction est fournie dans l'espoir qu'elle facilitera sa compréhension, mais elle
     n'a aucune valeur légale.
-    La seule référence officielle des termes de la licence “Odoo Enterprise Edition License”
+    La seule référence officielle des termes de la licence "Odoo Enterprise Edition License"
     est la :ref:`version originale <odoo_enterprise_license>`.
 
-    This is a french translation of the "Odoo Enterprise Edition License”.
+    This is a french translation of the "Odoo Enterprise Edition License".
     This translation is provided in the hope that it will facilitate understanding, but it has
     no legal value.
-    The only official reference of the terms of the “Odoo Enterprise Edition
-    License” is the :ref:`original english version <odoo_enterprise_license>`.
+    The only official reference of the terms of the "Odoo Enterprise Edition
+    License" is the :ref:`original english version <odoo_enterprise_license>`.
 
 .. raw:: html
 

--- a/content/legal/terms/i18n/enterprise_nl.rst
+++ b/content/legal/terms/i18n/enterprise_nl.rst
@@ -30,12 +30,12 @@ Odoo Enterprise Subscription Agreement (NL)
 
 .. note:: Version 10a - 2022-10-27
 
-Door u op de Odoo Enterprise-diensten (de “Diensten”) te abonneren die door
-Odoo NV en haar dochterondernemingen (gezamenlijk “Odoo NV”) worden verleend
+Door u op de Odoo Enterprise-diensten (de "Diensten") te abonneren die door
+Odoo NV en haar dochterondernemingen (gezamenlijk "Odoo NV") worden verleend
 met betrekking tot de Odoo Enterprise Edition of de Odoo Community Edition (de
-“Software”) gehost op de Cloudplatforms van Odoo NV (het "Cloudplatform") of
+"Software") gehost op de Cloudplatforms van Odoo NV (het "Cloudplatform") of
 op locatie ("Self-Hosting"), gaat u (de "Klant") ermee akkoord om gebonden te zijn door de
-volgende algemene voorwaarden (de “Overeenkomst”).
+volgende algemene voorwaarden (de "Overeenkomst").
 
 .. _term_nl:
 
@@ -55,7 +55,7 @@ in kennis stelt van de beëindiging.
 
 Gebruiker
     Elke actieve gebruikersaccount met toegang tot de Software in de
-    creatie- en/of bewerkingsmodus. Gedeactiveerde gebruikersaccounts en
+    creatie- en/of bewerkingsmodus. Gedeactiveerde gebruikersaccounts en
     accounts die worden gebruikt door externe personen (of systemen) die slechts
     beperkte toegang hebben tot de Software via de portaalfaciliteiten
     ("Portaalgebruikers") tellen niet mee als Gebruikers.
@@ -535,8 +535,8 @@ na de vervaldatum die op de desbetreffende factuur vermeld wordt, en na minstens
 2 herinneringen.
 
 Overlevende bepalingen:
-    De secties ":ref:`confidentiality_nl`”, ":ref:`disclaimers_nl`”,
-    ":ref:`liability_nl`” en ":ref:`general_provisions_nl`”
+    De secties ":ref:`confidentiality_nl`", ":ref:`disclaimers_nl`",
+    ":ref:`liability_nl`" en ":ref:`general_provisions_nl`"
     blijven geldig na de beëindiging of het afloop van deze
     Overeenkomst.
 

--- a/content/legal/terms/i18n/partnership_es.rst
+++ b/content/legal/terms/i18n/partnership_es.rst
@@ -29,13 +29,13 @@ Odoo Partnership Agreement (ES)
 
 | ENTRE:
 |  Odoo S.A., una empresa que tiene su sede social en Chaussée de Namur, 40, 1367 Grand-Rosière,
-|  Bélgica, y sus filiales (en adelante denominados conjuntamente “ODOO”)
+|  Bélgica, y sus filiales (en adelante denominados conjuntamente "ODOO")
 | Y:
 |  _____________________________________________, una empresa que tiene su domicilio social en
 |  _____________________________________________________________________________________.
-|  (en adelante denominado “EL COLABORADOR”)
+|  (en adelante denominado "EL COLABORADOR")
 
-ODOO y EL COLABORADOR se denominan individualmente “Parte” y conjuntamente “las Partes”.
+ODOO y EL COLABORADOR se denominan individualmente "Parte" y conjuntamente "las Partes".
 
 1 Objeto
 ========
@@ -44,13 +44,13 @@ a EL COLABORADOR, acceso al software Odoo Enterprise Edition, y bajo las cuales 
 cumple con las obligaciones establecidas a continuación.
 
 Por la presente ODOO nombra a EL COLABORADOR, y EL COLABORADOR acepta ser nombrado, socio no
-exclusivo para promover y vender “Odoo Enterprise Edition” a los clientes.
+exclusivo para promover y vender "Odoo Enterprise Edition" a los clientes.
 
 EL COLABORADOR se compromete a hacer su mejor esfuerzo para vender contratos de Odoo Enterprise a
 sus clientes. En apoyo a esta afirmación, EL COLABORADOR dará prioridad a la comercialización
-de la versión “Odoo Enterprise Edition” a clientes potenciales y clientes.
+de la versión "Odoo Enterprise Edition" a clientes potenciales y clientes.
 EL COLABORADOR siempre tiene la posibilidad de vender servicios con otras versiones del software,
-como “Odoo Community Edition”, en caso de ser necesario.
+como "Odoo Community Edition", en caso de ser necesario.
 
 2 Duración del Contrato
 =======================
@@ -64,7 +64,7 @@ por escrito a la otra parte su terminación como mínimo 30 días antes del fina
 3.1 Acceso a la plataforma del proyecto
 ---------------------------------------
 Para ayudar a EL COLABORADOR a promover Odoo Enterprise Edition, ODOO otorga a EL COLABORADOR
-acceso a su repositorio de código del proyecto para todas las “Aplicaciones Odoo Enterprise Edition”,
+acceso a su repositorio de código del proyecto para todas las "Aplicaciones Odoo Enterprise Edition",
 en los términos establecidos en :ref:`appendix_p_a_es` y las condiciones restringidas del presente
 Contrato.
 
@@ -153,7 +153,7 @@ En la tabla siguiente se describen los detalles de las ventajas para cada nivel 
 | Visibilidad en odoo.com               | No               | "Ready Partner"    | "Silver Partner"   | "Gold Partner"     |
 +---------------------------------------+------------------+--------------------+--------------------+--------------------+
 | Derechos de uso de la marca registrada| Sí               | Sí                 | Sí                 | Sí                 |
-| “Odoo” y logotipos                    |                  |                    |                    |                    |
+| "Odoo" y logotipos                    |                  |                    |                    |                    |
 +---------------------------------------+------------------+--------------------+--------------------+--------------------+
 | **Ventajas de la formación**          |                  |                    |                    |                    |
 +---------------------------------------+------------------+--------------------+--------------------+--------------------+
@@ -197,7 +197,7 @@ En la tabla siguiente se describen los detalles de las ventajas para cada nivel 
 ODOO promocionará EL COLABORADOR como socio oficial en el sitio web oficial (odoo.com).
 
 ODOO concede a EL COLABORADOR, de forma no exclusiva, el derecho a usar y reproducir el logotipo
-de socio de ODOO del nivel de colaboración correspondiente y el nombre “Odoo” en relación con este
+de socio de ODOO del nivel de colaboración correspondiente y el nombre "Odoo" en relación con este
 contrato de colaboración.
 
 Cada Parte se compromete a respetar todos los derechos de la otra Parte en todos los elementos
@@ -242,7 +242,7 @@ naturales a partir de la notificación por escrito de dicho incumplimiento, la P
 incumplió sus obligaciones puede rescindir este contrato inmediatamente.
 
 Disposiciones subsistentes:
-  Las secciones « :ref:`restrictions_es` », « :ref:`p_liability_es` », y « :ref:`gov_law_es` »
+  Las secciones ":ref:`restrictions_es`", ":ref:`p_liability_es`", y ":ref:`gov_law_es`"
   mantendrán su vigencia tras cualquier resolución o expiración de este contrato.
 
 6.1 Consecuencia de la resolución

--- a/content/legal/terms/i18n/partnership_fr.rst
+++ b/content/legal/terms/i18n/partnership_fr.rst
@@ -8,10 +8,10 @@ Odoo Partnership Agreement (FR)
 
     `Download PDF <odoo_partnership_agreement_fr.pdf>`_
 .. warning::
-    Ceci est une traduction en français du contrat “Odoo Partnership Agreement”.
-    Cette traduction est fournie dans l’espoir qu’elle facilitera sa compréhension, mais elle
+    Ceci est une traduction en français du contrat "Odoo Partnership Agreement".
+    Cette traduction est fournie dans l'espoir qu'elle facilitera sa compréhension, mais elle
     n'a aucune valeur légale.
-    La seule référence officielle des termes du contrat “Odoo Partnership Agreement”
+    La seule référence officielle des termes du contrat "Odoo Partnership Agreement"
     est la :ref:`version originale en anglais <partnership_agreement>`.
 
 .. v8: simplified parts, clarified others, added trademark use restrictions, updated benefits
@@ -25,35 +25,35 @@ Odoo Partnership Agreement (FR)
 
 | ENTRE:
 |  Odoo S.A., une entreprise dont le siège social se situe Chaussée de Namur, 40,
-|  1367 Grand-Rosière, Belgique, et ses filialies (désignées collectivement « ODOO »)
+|  1367 Grand-Rosière, Belgique, et ses filialies (désignées collectivement "ODOO")
 | ET:
 |  _____________________________________________, une entreprise dont le siège social se situe à
 |  _____________________________________________________________________________________.
-|  (ci-après dénommée « PARTENAIRE »)
+|  (ci-après dénommée "PARTENAIRE")
 
 
-ODOO et PARTENAIRE sont désignées individuellement par le terme « Partie » et collectivement par
-le terme « les Parties ».
+ODOO et PARTENAIRE sont désignées individuellement par le terme "Partie" et collectivement par
+le terme "les Parties".
 
 1 Objectif
 ==========
-L’objectif de ce Contrat est de présenter les conditions auxquelles ODOO fournit des services au
-PARTENAIRE et l’accès au logiciel Odoo Enterprise Edition, et en vertu desquelles le PARTENAIRE
+L'objectif de ce Contrat est de présenter les conditions auxquelles ODOO fournit des services au
+PARTENAIRE et l'accès au logiciel Odoo Enterprise Edition, et en vertu desquelles le PARTENAIRE
 se plie aux obligations énoncées ci-après.
 
 Par le présent accord, ODOO désigne le PARTENAIRE, désignation acceptée par le PARTENAIRE,
-comme partenaire non exclusif pour promouvoir et vendre « Odoo Enterprise Edition » à des clients.
+comme partenaire non exclusif pour promouvoir et vendre "Odoo Enterprise Edition" à des clients.
 
-Le PARTENAIRE s’engage à faire tous les efforts possibles pour vendre des contrats Odoo Enterprise
+Le PARTENAIRE s'engage à faire tous les efforts possibles pour vendre des contrats Odoo Enterprise
 à ses clients. Pour étayer ces efforts, le PARTENAIRE commercialisera en priorité la version
-« Odoo Enterprise Edition » aux prospects et clients. Si nécessaire, le PARTENAIRE peut vendre des
-services sur d’autres versions du logiciel, comme « Odoo Community Edition ».
+"Odoo Enterprise Edition" aux prospects et clients. Si nécessaire, le PARTENAIRE peut vendre des
+services sur d'autres versions du logiciel, comme "Odoo Community Edition".
 
 2 Durée du Contrat
 ==================
-Ce Contrat restera en vigueur pendant un an (la « Durée ») à compter de la date de la signature.
-Il est automatiquement renouvelé pour une Durée équivalente, à moins qu’une partie transmette
-à l’autre partie une dénonciation écrite au moins 30 jours avant la fin de la Durée.
+Ce Contrat restera en vigueur pendant un an (la "Durée") à compter de la date de la signature.
+Il est automatiquement renouvelé pour une Durée équivalente, à moins qu'une partie transmette
+à l'autre partie une dénonciation écrite au moins 30 jours avant la fin de la Durée.
 
 
 3 Accès à Odoo Enterprise Edition
@@ -61,8 +61,8 @@ Il est automatiquement renouvelé pour une Durée équivalente, à moins qu’un
 
 3.1 Accès à la plate-forme projet
 ---------------------------------
-Pour aider le PARTENAIRE à promouvoir Odoo Enterprise Edition, ODOO octroie au PARTENAIRE l’accès
-à son dépôt de code pour toutes les « Apps Odoo Enterprise Edition » sous les conditions
+Pour aider le PARTENAIRE à promouvoir Odoo Enterprise Edition, ODOO octroie au PARTENAIRE l'accès
+à son dépôt de code pour toutes les "Apps Odoo Enterprise Edition" sous les conditions
 présentées dans :ref:`appendix_p_a_fr` et les conditions reprises dans ce Contrat.
 
 ODOO accorde aussi au PARTENAIRE un accès gratuit à la plate-forme ODOO.SH, exclusivement dans un
@@ -72,16 +72,16 @@ but de test et de développement.
 
 3.2 Restrictions
 ----------------
-Le PARTENAIRE s’engage à maintenir la confidentialité du code source des Apps Odoo Enterprise
-Edition au sein de son personnel. L’accès au code source d’Odoo Enterprise Edition pour les clients
+Le PARTENAIRE s'engage à maintenir la confidentialité du code source des Apps Odoo Enterprise
+Edition au sein de son personnel. L'accès au code source d'Odoo Enterprise Edition pour les clients
 est régi par l'Odoo Enterprise Subscription Agreement.
-Le PARTENAIRE s'engage à ne PAS redistribuer ce code à un tiers sans l’autorisation écrite d’ODOO.
+Le PARTENAIRE s'engage à ne PAS redistribuer ce code à un tiers sans l'autorisation écrite d'ODOO.
 
 Le PARTENAIRE s'engage à n'offrir des services relatifs à Odoo Enterprise Edition qu'aux
 clients qui disposent d'un contrat Odoo Enterprise valide, et ce même pendant la phase d'implémentation.
 
-Nonobstant ce qui précède, le PARTENAIRE s’engage à préserver totalement l’intégrité du code
-d’Odoo Enterprise Edition requis pour vérifier la validité de l’utilisation d’Odoo Enterprise Edition
+Nonobstant ce qui précède, le PARTENAIRE s'engage à préserver totalement l'intégrité du code
+d'Odoo Enterprise Edition requis pour vérifier la validité de l'utilisation d'Odoo Enterprise Edition
 et recueillir les données statistiques nécessaires à cette fin.
 
 4 Services du partenariat
@@ -89,8 +89,8 @@ et recueillir les données statistiques nécessaires à cette fin.
 
 4.1 Niveaux de partenariat
 --------------------------
-Le programme partenaire d’Odoo consiste en deux types de partenariat et quatre niveaux.
-Le type “Learning Partners” est prévu les sociétés souhaitent démarrer la
+Le programme partenaire d'Odoo consiste en deux types de partenariat et quatre niveaux.
+Le type "Learning Partners" est prévu les sociétés souhaitent démarrer la
 mise en oeuvre d'Odoo, mais sans la visibilité d'un partenaire officiel, en attendant d'acquérir
 l'expérience requise; tandis qu' "Official Partners" est prévu pour les sociétés qui veulent la visibilité
 en tant que partenaire Ready, Silver ou Gold, suivant leur niveau d'expérience.
@@ -99,7 +99,7 @@ Le niveau de partenariat accordé au PARTENAIRE dépend des nouvelles recettes a
 générées par le PARTENAIRE pour ODOO (en terme du nombre de nouveaux utilisateur Odoo Enterprise vendus),
 du nombre de ressources internes certifiées, et du taux de rétention de clients.
 Les renouvellements de contrats existants
-n’entrent pas en ligne de compte pour le nombre de nouveaux utilisateurs vendus, mais le PARTENAIRE
+n'entrent pas en ligne de compte pour le nombre de nouveaux utilisateurs vendus, mais le PARTENAIRE
 reçoit tout de même une commission sur ces contrats, comme indiqué dans la section :ref:`benefits_fr`.
 
 Le tableau ci-dessous résume les exigences pour chaque niveau de partenariat.
@@ -119,13 +119,13 @@ Le Taux de Rétention est défini comme le rapport entre le nombre de contrats O
 toujours en cours, et le nombre de contrats Odoo Enterprise qui ont été actifs à un moment au cours
 des 12 derniers mois.
 
-Les certifications sont personnelles, donc lorsqu’un membre du personnel quitte ou rejoint l’entreprise,
+Les certifications sont personnelles, donc lorsqu'un membre du personnel quitte ou rejoint l'entreprise,
 le PARTENAIRE doit en informer ODOO.
 
 Le niveau de partenariat du PARTENAIRE sera revu trimestriellement par ODOO, et ajusté au plus haut
 niveau pour lequel les 3 exigences sont atteintes.
 
-Cependant les "Official Partners" pourront monter de niveau de partenariat dès qu’ils répondent
+Cependant les "Official Partners" pourront monter de niveau de partenariat dès qu'ils répondent
 aux 3 exigences pour ce niveau.
 
 
@@ -134,7 +134,7 @@ aux 3 exigences pour ce niveau.
 4.2 Avantages
 -------------
 
-Les avantages de chaque niveau de partenariat sont détaillés dans le tableau ci-dessous :
+Les avantages de chaque niveau de partenariat sont détaillés dans le tableau ci-dessous :
 
 .. only:: latex
 
@@ -147,7 +147,7 @@ Les avantages de chaque niveau de partenariat sont détaillés dans le tableau c
 +---------------------------------------+------------------+--------------------+--------------------+--------------------+
 | Visibilité sur odoo.com               | Non              | "Ready Partner"    | "Silver Partner"   | "Gold Partner"     |
 +---------------------------------------+------------------+--------------------+--------------------+--------------------+
-| Droit d’utiliser la marque déposée et | Oui              | Oui                | Oui                | Oui                |
+| Droit d'utiliser la marque déposée et | Oui              | Oui                | Oui                | Oui                |
 | les logos                             |                  |                    |                    |                    |
 +---------------------------------------+------------------+--------------------+--------------------+--------------------+
 | **Avantages formation**               |                  |                    |                    |                    |
@@ -193,19 +193,19 @@ Les avantages de chaque niveau de partenariat sont détaillés dans le tableau c
 --------------------------------
 ODOO promouvra les "Official Partners" dans la liste des partenaires Odoo sur odoo.com.
 
-ODOO octroie au PARTENAIRE, sur une base non exclusive, le droit d’utiliser et de reproduire
-le logo partenaire d’ODOO du niveau de partenariat correspondant et le nom « Odoo » en relation
+ODOO octroie au PARTENAIRE, sur une base non exclusive, le droit d'utiliser et de reproduire
+le logo partenaire d'ODOO du niveau de partenariat correspondant et le nom "Odoo" en relation
 avec ce Contrat de partenariat.
 
-Chacune des Parties s’engage à respecter les droits de l’autre Partie pour tous les éléments repris
-dans le paragraphe précédent et s’abstiendra plus particulièrement de créer des analogies ou
-une confusion entre leurs entreprises respectives dans l’esprit du grand public, pour quelque
+Chacune des Parties s'engage à respecter les droits de l'autre Partie pour tous les éléments repris
+dans le paragraphe précédent et s'abstiendra plus particulièrement de créer des analogies ou
+une confusion entre leurs entreprises respectives dans l'esprit du grand public, pour quelque
 raison et par quelque moyen que ce soit.
 
 4.4 Avantages formation
 -----------------------
-Le PARTENAIRE a accès à la base de connaissances d’ODOO pour toute la durée de ce Contrat.
-La base de connaissance d’ODOO est une plateforme en ligne reprenant une série de documents
+Le PARTENAIRE a accès à la base de connaissances d'ODOO pour toute la durée de ce Contrat.
+La base de connaissance d'ODOO est une plateforme en ligne reprenant une série de documents
 commerciaux, marketing et de documentation sur les fonctionnalités, pour aider le PARTENAIRE
 à engranger et exploiter des connaissances Odoo, étendre son entreprise, attirer davantage
 de clients et augmenter la visibilité de sa marque.
@@ -238,13 +238,13 @@ que pour autant que le client ne signale pas à ODOO sa volonté d'arrêter de C
 PARTENAIRE.
 
 
-.. [#pcom_fr1] “Collaborer avec un Partenaire Odoo” et “Modules Supplémentaires Couverts” sont
+.. [#pcom_fr1] "Collaborer avec un Partenaire Odoo" et "Modules Supplémentaires Couverts" sont
    définis dans le contrat "Odoo Enterprise Subscription Agreement" entre ODOO et le client.
 
 
 5 Frais
 =======
-Le PARTENAIRE s’engage à payer les frais annuels de Partenariat à la réception de la facture
+Le PARTENAIRE s'engage à payer les frais annuels de Partenariat à la réception de la facture
 annuelle envoyée par ODOO. Ces frais seront spécifiés par écrit au moment de la signature de ce
 Contrat.
 
@@ -253,20 +253,20 @@ Le PARTENAIRE accepte que les frais de partenariat susmentionnés ne soient pas 
 
 6 Résiliation
 =============
-Dans le cas où l’une des Parties ne remplirait pas l’une des obligations mentionnées ici et qu’un
+Dans le cas où l'une des Parties ne remplirait pas l'une des obligations mentionnées ici et qu'un
 tel manquement ne serait remédié dans les 30 jours calendrier suivant la communication écrite
-d’un tel manquement, la Partie non fautive peut mettre un terme immédiat à ce Contrat.
+d'un tel manquement, la Partie non fautive peut mettre un terme immédiat à ce Contrat.
 
 Maintien des dispositions:
-  Les sections « :ref:`restrictions_fr` », « :ref:`p_liability_fr` », et « :ref:`gov_law_fr` »
+  Les sections ":ref:`restrictions_fr`", ":ref:`p_liability_fr`", et ":ref:`gov_law_fr`"
   seront maintenues après expiration ou résiliation de ce Contrat.
 
 6.1 Conséquences de la résiliation
 ----------------------------------
-À l’expiration ou la résiliation de ce Contrat, le PARTENAIRE :
- - n’utilisera plus le matériel et le nom de marque d’Odoo et ses marques déposées, et ne revendiquera plus l’existence
-   d’un partenariat ou d’une relation quelconque avec ODOO ;
- - respectera ses engagements pendant toute période de préavis précédant une telle résiliation ;
+À l'expiration ou la résiliation de ce Contrat, le PARTENAIRE :
+ - n'utilisera plus le matériel et le nom de marque d'Odoo et ses marques déposées, et ne revendiquera plus l'existence
+   d'un partenariat ou d'une relation quelconque avec ODOO ;
+ - respectera ses engagements pendant toute période de préavis précédant une telle résiliation ;
  - ne pourra plus utiliser Odoo Enterprise, que ce soit à des fins de développement,
    de test ou de production.
 
@@ -274,24 +274,24 @@ Maintien des dispositions:
 
 7 Responsabilité et Indemnités
 ==============================
-Les deux Parties sont liées par l’obligation de moyens ci-après.
+Les deux Parties sont liées par l'obligation de moyens ci-après.
 
-Dans les limites autorisées par la loi, la responsabilité d’ODOO pour quelque réclamation, perte,
-dommage ou dépense que ce soit découlant de n’importe quelle cause et survenant de quelque manière
+Dans les limites autorisées par la loi, la responsabilité d'ODOO pour quelque réclamation, perte,
+dommage ou dépense que ce soit découlant de n'importe quelle cause et survenant de quelque manière
 que ce soit dans le cadre de ce Contrat sera limitée aux dommages directs prouvés, mais ne dépassera
-en aucun cas, pour tous les événements ou séries d’événements connexes entraînant des dommages,
+en aucun cas, pour tous les événements ou séries d'événements connexes entraînant des dommages,
 le montant total des frais payés par le PARTENAIRE au cours de six (6) mois précédant immédiatement
-la date de l’événement donnant naissance à une telle plainte.
+la date de l'événement donnant naissance à une telle plainte.
 
 En aucun cas, ODOO ne sera responsable pour tout dommage indirect ou consécutif, y compris, mais
-sans s’y restreindre, aux plaintes, pertes de revenu, de recettes, d’économies, d’entreprise ou
-autre perte financière, coûts d’arrêt ou de retard, pertes de données ou données corrompues
-de tiers ou de clients résultant de ou en lien avec l’exécution de ses obligations dans le cadre
+sans s'y restreindre, aux plaintes, pertes de revenu, de recettes, d'économies, d'entreprise ou
+autre perte financière, coûts d'arrêt ou de retard, pertes de données ou données corrompues
+de tiers ou de clients résultant de ou en lien avec l'exécution de ses obligations dans le cadre
 de ce Contrat.
 
-Le PARTENAIRE comprend qu’il n’a aucune attente et n’a reçu aucune assurance qu’un investissement
-effectué dans l’exécution de ce Contrat et du Programme de partenariat d’Odoo sera récupéré ou
-recouvert ou qu’il obtiendra un quelconque montant de bénéfices anticipé en vertu de ce Contrat.
+Le PARTENAIRE comprend qu'il n'a aucune attente et n'a reçu aucune assurance qu'un investissement
+effectué dans l'exécution de ce Contrat et du Programme de partenariat d'Odoo sera récupéré ou
+recouvert ou qu'il obtiendra un quelconque montant de bénéfices anticipé en vertu de ce Contrat.
 
 
 8 Image de marque
@@ -308,45 +308,45 @@ pour la Durée de ce Contrat seulement, et tant que les conditions suivantes son
 - Le PARTENAIRE n'utilise pas la marque "Odoo" dans un nom d'entreprise, un nom de produit, ou un
   nom de domaine, et ne dépose aucune marque qui la contienne.
 
-Les Parties s’abstiendront de nuire à l’image de marque et à la réputation de l’autre Partie
-de quelque façon que ce soit, dans l’exécution de ce Contrat.
+Les Parties s'abstiendront de nuire à l'image de marque et à la réputation de l'autre Partie
+de quelque façon que ce soit, dans l'exécution de ce Contrat.
 
 Le non-respect des dispositions de cette section sera une cause de résiliation du Contrat.
 
 
 8.1 Publicité
 -------------
-Le PARTENAIRE octroie à ODOO un droit non exclusif d’utilisation du nom ou de la marque déposée
+Le PARTENAIRE octroie à ODOO un droit non exclusif d'utilisation du nom ou de la marque déposée
 du PARTENAIRE dans des communiqués de presse, annonces publicitaires ou autres annonces publiques.
 
-Le PARTENAIRE accepte en particulier d’être mentionné dans la liste officielle des
+Le PARTENAIRE accepte en particulier d'être mentionné dans la liste officielle des
 partenaires ODOO et que son logo ou sa marque déposée soient utilisés à cette fin uniquement.
 
-8.2 Pas de candidature ou d’engagement
+8.2 Pas de candidature ou d'engagement
 --------------------------------------
 
-À moins que l’autre Partie ne donne son consentement écrit, chaque Partie, ses filiales et ses
-représentants acceptent de ne pas solliciter ou proposer un emploi à un travailleur de l’autre
-Partie impliqué dans l’exécution ou l’utilisation des Services repris dans ce Contrat,
-pour toute la durée de l’accord et une période de 12 mois suivant la date de résiliation ou
-d’expiration de ce Contrat. En cas de non-respect des conditions de cette section qui mène à la
-résiliation dudit travailleur à cet effet, la Partie fautive accepte de payer à l’autre Partie
-la somme de 30 000,00 (trente mille) euros (€).
+À moins que l'autre Partie ne donne son consentement écrit, chaque Partie, ses filiales et ses
+représentants acceptent de ne pas solliciter ou proposer un emploi à un travailleur de l'autre
+Partie impliqué dans l'exécution ou l'utilisation des Services repris dans ce Contrat,
+pour toute la durée de l'accord et une période de 12 mois suivant la date de résiliation ou
+d'expiration de ce Contrat. En cas de non-respect des conditions de cette section qui mène à la
+résiliation dudit travailleur à cet effet, la Partie fautive accepte de payer à l'autre Partie
+la somme de 30 000,00 (trente mille) euros (€).
 
 8.3 Contracteurs indépendants
 -----------------------------
 Les Parties sont des contracteurs indépendants et ce Contrat ne sera pas interprété comme
-constituant une Partie comme partenaire, joint-venture ou fiduciaire de l’autre ni créant tout
-autre forme d’association légale qui imposerait à l’une des Parties la responsabilité pour
-l’action ou l’inaction de l’autre ou fournissant à l’une des Parties le droit, le pouvoir ou
-l’autorité (expresse ou implicite) de créer quelque devoir ou obligation que ce soit.
+constituant une Partie comme partenaire, joint-venture ou fiduciaire de l'autre ni créant tout
+autre forme d'association légale qui imposerait à l'une des Parties la responsabilité pour
+l'action ou l'inaction de l'autre ou fournissant à l'une des Parties le droit, le pouvoir ou
+l'autorité (expresse ou implicite) de créer quelque devoir ou obligation que ce soit.
 
 .. _gov_law_fr:
 
 9 Loi applicable et compétence
 ==============================
 Ce Contrat sera gouverné par et interprété en accord avec la loi belge. Tout litige naissant
-en lien avec le Contrat et pour lequel aucun règlement à l’amiable ne peut être trouvé sera
+en lien avec le Contrat et pour lequel aucun règlement à l'amiable ne peut être trouvé sera
 finalement réglé par les Tribunaux de Belgique à Nivelles.
 
 
@@ -384,17 +384,17 @@ finalement réglé par les Tribunaux de Belgique à Nivelles.
 
 .. _appendix_p_a_fr:
 
-10 Annexe A : Licence Odoo Enterprise Edition
+10 Annexe A : Licence Odoo Enterprise Edition
 =============================================
 
 Odoo Enterprise Edition est publié sous la licence Odoo Enterprise Edition License v1.0,
 définie ci-dessous.
 
 .. warning::
-    Ceci est une traduction en français de la licence “Odoo Enterprise Edition License”.
-    Cette traduction est fournie dans l’espoir qu’elle facilitera sa compréhension, mais elle
+    Ceci est une traduction en français de la licence "Odoo Enterprise Edition License".
+    Cette traduction est fournie dans l'espoir qu'elle facilitera sa compréhension, mais elle
     n'a aucune valeur légale.
-    La seule référence officielle des termes de la licence “Odoo Enterprise Edition License”
+    La seule référence officielle des termes de la licence "Odoo Enterprise Edition License"
     est la :ref:`version originale <odoo_enterprise_license>`.
 
 .. raw:: html

--- a/content/legal/terms/odoo_sh_terms.rst
+++ b/content/legal/terms/odoo_sh_terms.rst
@@ -8,8 +8,8 @@ Odoo.sh Beta Program
 
 TERMS & CONDITIONS OF THE ODOO.SH BETA PROGRAM
 
-You understand and acknowledge that the Service is being provided as a “Public Beta”,
-and is made available on an “AS IS” and “AS AVAILABLE” basis for the purpose of providing
+You understand and acknowledge that the Service is being provided as a "Public Beta",
+and is made available on an "AS IS" and "AS AVAILABLE" basis for the purpose of providing
 Odoo S.A. and its affiliates with feedback on the quality and usability of the Service.
 
 The Service may contain errors or inaccuracies that could cause failures, corruption or

--- a/content/legal/terms/partnership.rst
+++ b/content/legal/terms/partnership.rst
@@ -21,11 +21,11 @@ Odoo Partnership Agreement
 
 | BETWEEN:
 |  Odoo S.A., having its registered office at Chaussée de Namur, 40, 1367 Grand-Rosière,
-|  Belgium, and its affiliates (collectively referred to as “ODOO”)
+|  Belgium, and its affiliates (collectively referred to as "ODOO")
 | AND:
 |  _____________________________________________, a company having its registered office at
 |  _____________________________________________________________________________________.
-|  (hereinafter referred to as “PARTNER”)
+|  (hereinafter referred to as "PARTNER")
 
 ODOO and PARTNER are individually referred to as a "Party" and collectively referred to as
 "the Parties".
@@ -46,7 +46,7 @@ like "Odoo Community Edition", should it be needed.
 
 2 Term of the Agreement
 =======================
-The duration of this Agreement (the “Term”) shall be one year beginning on the date of the signature.
+The duration of this Agreement (the "Term") shall be one year beginning on the date of the signature.
 It is automatically renewed for an equal Term unless either party provides written notice of
 termination minimum 30 days before the end of the Term to the other party.
 
@@ -86,9 +86,9 @@ Edition and to collect statistics that are needed for that purpose.
 4.1 Partnership levels
 ----------------------
 The Odoo partner program consists of two types of partnerships and four levels;
-“Learning Partners” is for companies who want everything necessary to start implementing Odoo,
+"Learning Partners" is for companies who want everything necessary to start implementing Odoo,
 without visibility as an official partner until they get the required experience;
-“Official Partners” is for companies who want the visibility as Ready, Silver, and Gold,
+"Official Partners" is for companies who want the visibility as Ready, Silver, and Gold,
 according to their experience with Odoo.
 
 Partnership level granted to PARTNER depends on the annual new Odoo Enterprise revenue generated
@@ -229,7 +229,7 @@ of contact of the customer.
 PARTNER shall only receive the commission for the Maintenance of Covered Extra Modules
 as long as the customer does not notify ODOO that they want to stop Working with PARTNER.
 
-.. [#pcom1] “Working with an Odoo Partner” and “Covered Extra Modules” are defined in the Odoo
+.. [#pcom1] "Working with an Odoo Partner" and "Covered Extra Modules" are defined in the Odoo
    Enterprise Subscription Agreement between ODOO and customers.
 
 5 Fees
@@ -248,7 +248,7 @@ a breach has not been remedied within 30 calendar days from the written notice o
 breach, this Agreement may be terminated immediately by the non-breaching Party.
 
 Surviving Provisions:
-  The sections ":ref:`restrictions`”, “:ref:`p_liability`”, and “:ref:`gov_law`” will survive
+  The sections ":ref:`restrictions`", ":ref:`p_liability`", and ":ref:`gov_law`" will survive
   any termination or expiration of this Agreement.
 
 6.1 Consequence of termination
@@ -265,7 +265,7 @@ On expiry or termination of this Agreement, PARTNER:
 ===========================
 Both Parties are bound by a best endeavours obligation hereunder.
 
-To the maximum extent permitted by law, ODOO’s liability for any and all claims, losses, damages or
+To the maximum extent permitted by law, ODOO's liability for any and all claims, losses, damages or
 expenses from any cause whatsoever and howsoever arising under this Agreement will be limited to
 the direct damages proved, but will in no event exceed for all damage-causing event or series of
 connected events causing damages the total amount for the fees paid by PARTNER in the course of the
@@ -291,7 +291,7 @@ ODOO authorizes PARTNER to use the "Odoo" mark to promote its products and servi
 for the duration of this agreement only, as long as:
 
 - There is no possible confusion that the service is provided by PARTNER, not ODOO;
-- PARTNER does not use the word “Odoo” in their company name, product name, domain name,
+- PARTNER does not use the word "Odoo" in their company name, product name, domain name,
   and does not register any trademark that includes it.
 
 Both Parties shall refrain from harming the brand image and reputation of the other Party,


### PR DESCRIPTION
This commit replaces all apostrophes with the character ' and quotation marks with the character ".

Currently, the RST code seems to be a mix of text copy-pasted from external text editors, and edits made directly in RST. As a result, the pages display a mix of symbols, sometimes in the same sentence.

This phenomenon is emphasized when the user browses the documentation in another language than English as the rendering in html of ' and " varies according to the language selected.

Examples from the current html build:
- The sections « 3.2 Restrictions”
- Le type “Learning Partners” est (...) tandis qu” « Official Partners »

-------------------

Also, some mistakes are copied by translators as they use the existing content as a reference.
I'm aware this fix introduces a lot of noise. Let me know if it's worth it or not.