### PR TITLE
Update sales_order.rst

### DIFF
--- a/content/applications/sales/point_of_sale/shop/sales_order.rst
+++ b/content/applications/sales/point_of_sale/shop/sales_order.rst
@@ -21,6 +21,10 @@ sales application.
    To ease finding the right sales order, you can filter that list on the **customer** or on the
    **order reference**. You can also set the customer before clicking on
    :guilabel:`Quotations/Orders` to reduce the list to one particular customer.
+   
+.. note::
+   When the sale order is at draft state (quotation), all service type sale order lines have quantity set to zero on POS.
+   Quantities are set to correct number after the sale order has been confirmed.
 
 Apply a down payment or settle the order
 ========================================


### PR DESCRIPTION
Added crucial note about service products. This feature caused a lot of headache to us while figuring out why draft orders (quotations) we tried to settle in POS unset the service product quantities.