### PR TITLE
Make absence of rate limits explicit

### DIFF
--- a/content/developer/api/external_api.rst
+++ b/content/developer/api/external_api.rst
@@ -118,6 +118,11 @@ Once you have keys configured on your account, they will appear above the
 **A deleted API key can not be undeleted or re-set**. You will have to generate
 a new key and update all the places where you used the old one.
 
+Rate limits
+~~~~~~~~~~~
+
+The Odoo API has no rate limits.
+
 Test database
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
Many cloud platforms use rate limits in various ways (per minute, per hour, per day, per company, per database, per table, whatever) to limit loads. Odoo online currently does not seem to apply those. This change makes that explicit.