### PR TITLE
[FIX] website: syntax error (fix for translators)

### DIFF
--- a/content/applications/websites/website/publish/multi_website.rst
+++ b/content/applications/websites/website/publish/multi_website.rst
@@ -263,11 +263,11 @@ Pricelists
 To manage specific prices by websites, you can activate *Multiple Sales
 Prices per Product* in Website settings.
 
-Then, go to :menuselection:`Website --> Products --> Pricelists` to create additional
-pricelists. See :doc:`../../ecommerce/maximizing_revenue/pricing`.
+Then, go to :menuselection:`Website --> Products --> Pricelists` to create additional pricelists.
+You can also choose to have a pricelist available *only* on a specific website.
 
-If you need help. Select a website to make a pricelist only available on
-this website.
+.. seealso::
+   :doc:`../../ecommerce/maximizing_revenue/pricing`.
 
 .. image:: multi_website/multi_website07.png
   :align: center


### PR DESCRIPTION
A translator notified me that one of the sentences in English made no sense, so I'm fixing it to 1) make sense now 2) make it easier for the translator.

Small fix, this page will be depecrated when I have time to make a new one.

Forward to master.

taskid: 3211784