### PR TITLE
[FIX] deploy: duplicated proxy_set_headers in serve static block

### DIFF
--- a/content/administration/install/deploy.rst
+++ b/content/administration/install/deploy.rst
@@ -428,11 +428,6 @@ by intercepting all requests to :samp:`/{MODULE}/static/{FILE}`, and looking up 
 
        # Serve static files right away
        location ~ ^/[^/]+/static/.+$ {
-           # Add Headers for odoo proxy mode
-           proxy_set_header X-Forwarded-Host $host;
-           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-           proxy_set_header X-Forwarded-Proto $scheme;
-           proxy_set_header X-Real-IP $remote_addr;
            root /usr/lib/python3/dist-packages/odoo/addons;
            try_files $uri @odoo;
            expires 24h;


### PR DESCRIPTION
This commit removes unnecessary `proxy_set_headers` in the serve
static config block.

Indeed, the request will either be served by Nginx in which case
the request won't go to the proxy backend or by the `@odoo` backend
which have its own `proxy_set_headers` set as the user is supposed
to copy/paste the contennt of the `location /` block.

Closes: #3675