### PR TITLE
[I18N] theme: remove reference to translation

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -51,11 +51,6 @@ file_filter = locale/<lang>/LC_MESSAGES/services.po
 source_file = locale/sources/services.pot
 source_lang = en
 
-[o:odoo:p:odoo-16-doc:r:theme]
-file_filter = locale/<lang>/LC_MESSAGES/sphinx.po
-source_file = locale/sources/sphinx.pot
-source_lang = en
-
 [o:odoo:p:odoo-16-doc:r:user_settings]
 file_filter = locale/<lang>/LC_MESSAGES/settings.po
 source_file = locale/sources/settings.pot


### PR DESCRIPTION
It does not exists and was never present, making the synchronisation crash