### PR TITLE
[REF] web: remove allow_group_range_value

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -1720,12 +1720,6 @@ Possible children of the view element are:
   ``name`` (required)
     the name of the field to fetch
 
-  ``allow_group_range_value`` (optional)
-    whether a ``date`` or ``datetime`` field allows a value computed from a
-    group range (which consists of the first and last dates of the group).
-    Enables the 'quick create' and 'drag and drop' features when the kanban
-    view is grouped by that field. Default: false.
-
 .. include:: views/header_buttons.rst
 
 .. note::


### PR DESCRIPTION
The allow_group_range_value option is used in one arch of a kanban in CRM. We therefore believe that this is not standard behaviour. So we decided to move this logic to the custom view that uses it.