### PR TITLE
[IMP] tutorials: add warning about mutable global variables

### DIFF
--- a/content/developer/tutorials/getting_started/04_basicmodel.rst
+++ b/content/developer/tutorials/getting_started/04_basicmodel.rst
@@ -13,6 +13,14 @@ tools to facilitate database interactions.
 Before moving forward in the exercise, make sure the ``estate`` module is installed, i.e. it
 must appear as 'Installed' in the Apps list.
 
+.. warning::
+
+   Do not use mutable global variables.
+
+   A single Odoo instance can run several databases in parallel within the same python process.
+   Distinct modules might be installed on each of these databases, therefore we cannot rely on
+   global variables that would be updated depending on installed modules.
+
 Object-Relational Mapping
 =========================
 


### PR DESCRIPTION
The whole concept of multi-tenancy is not really approached within the tutorial.

This commit adds a warning about never using mutable global variables within odoo to seed the idea in the reader's mind.

task-3059110