### PR TITLE
[IMP] accounting/electronic_invoicing: add SG einvoicing format

### DIFF
--- a/content/applications/finance/accounting/receivables/customer_invoices/electronic_invoicing.rst
+++ b/content/applications/finance/accounting/receivables/customer_invoices/electronic_invoicing.rst
@@ -47,6 +47,8 @@ Odoo supports, among others, the following formats.
      - For Dutch companies
    * - EHF 3.0
      - For Norwegian companies
+   * - SG BIS Billing 3.0
+     - For Singaporean companies
 
 .. seealso::
    :ref:`fiscal_localizations/packages`


### PR DESCRIPTION
Since commit
https://github.com/odoo/odoo/commit/bd06decccfffa5629c21c41a80280b6f84884bae, the 'SG BIS Billing 3.0' format is available for singaporean companies.