### PR TITLE
[IMP] odoo_theme: fix menu links

### DIFF
--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -299,10 +299,9 @@ header {
 
 .o_main_toc, .o_page_toc_nav {
 
-    a, .o_toc_entry_wrapper {
+    .o_toc_entry_wrapper {
         display: flex;
         align-items: baseline;
-        width: 100%;
         border-radius: $border-radius 0 0 $border-radius;
     }
 
@@ -343,7 +342,6 @@ header {
             &:not(.toctree-l1) .o_toc_entry_wrapper {
                 > i[class^="i-"] {
                     transition: rotate, .3s;
-                    cursor: pointer;
                     font-size: .75rem;
 
                     &[aria-expanded="true"] {
@@ -365,7 +363,9 @@ header {
             }
 
             > a {
+                display: block;
                 padding-left: 1.25rem;
+                border-radius: $border-radius 0 0 $border-radius;
             }
         }
     }


### PR DESCRIPTION
When searching for a word, if that word happens to be in the menu, the `display-flex` on the `a` would remove the space around the word because a `span class=highlight` gets added around it.
Fixed by changing `display-flex` on the `a` to `display-block` (but keeping it for `.o_toc_entry_wrapper`)