### PR TITLE
[FIX] website: missing redirection for plausible.rst

### DIFF
--- a/redirects/16.0.txt
+++ b/redirects/16.0.txt
@@ -43,6 +43,7 @@ applications/websites/ecommerce/shopper_experience/payment_providers.rst applica
 applications/websites/ecommerce/maximizing_revenue/pricing.rst applications/websites/ecommerce/managing_products/price_management.rst            # /maximizing_revenue/pricing -> /managing_products/price_management
 applications/websites/ecommerce/maximizing_revenue/reviews.rst applications/websites/ecommerce/ecommerce_management/customer_interaction.rst     # /maximizing_revenue/reviews -> /ecommerce_management/customer_interaction
 applications/websites/ecommerce/shopper_experience/portal.rst applications/websites/ecommerce/ecommerce_management/customer_accounts.rst         # /shopper_experience/portal -> /ecommerce_management/customer_accounts
+applications/websites/website/optimize/plausible.rst applications/websites/website/reporting/plausible.rst                                       # /optimize/* -> /reporting/*
 
 # developer/howtos
 


### PR DESCRIPTION
The redirection rule for plausible.rst was missing from the forward-port in PR #4107. Because of that, a link in the app leads to a 404 page instead of the appropriate doc page. This commit fixes it.