### PR TITLE
[IMP]Maintain:Fix typo in Azure Mail

### DIFF
--- a/content/administration/maintain/azure_oauth.rst
+++ b/content/administration/maintain/azure_oauth.rst
@@ -43,7 +43,7 @@ API permissions
 ---------------
 
 The :guilabel:`API permissions` should be set next. Odoo will need specific API permissions to be
-able to read (IMAP) and send (IMAP) emails in the Microsoft 365 setup. First, click the
+able to read (IMAP) and send (SMTP) emails in the Microsoft 365 setup. First, click the
 :guilabel:`API permissions` link, located in the left menu bar. Next, click on the
 :guilabel:`(+) Add a Permission` button and select :guilabel:`Microsoft Graph` under
 :guilabel:`Commonly Used Microsoft APIs`. After, select the :guilabel:`Delegated Permissions`


### PR DESCRIPTION
@StraubCreative This PR is ready for merge. 

Just a simple typo on the Azure Oauth Mail doc- Version Odoo 14- 16

Line 46: able to read (IMAP) and send (**_SMTP_**) emails in the Microsoft 365 setup. First, click the

Replaces IMAP with SMTP in second mention of it. 

Thanks,
Tim
