### PR TITLE
[FIX] requirements: bump libsass to match odoo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.16.0  # Compatibility with sphinx-tabs 3.2.0.
-libsass==0.18.0
+libsass==0.20.1
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 sphinx==4.3.2


### PR DESCRIPTION
In Odoo, the libsass version was bumped to 0.20.1 in order to match the Jammy version. As a consequence, in the Docker images on the runbot this strange behavior was observed during the image build:

* the debian package is installed -> 0.20.1
* the documentation requirements are installed -> 0.18.0
* the odoo requirements are installed -> 0.20.1

This is useless and moreover, the final version used is the one from pip instead of the Debian package.