### PR TITLE
[FIX] inventory: fix note in inv val config

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/management/reporting/inventory_valuation_config.rst
+++ b/content/applications/inventory_and_mrp/inventory/management/reporting/inventory_valuation_config.rst
@@ -90,11 +90,17 @@ menu (e.g. :guilabel:`Standard`, :guilabel:`Average Cost (AVCO)`, or :guilabel:`
    </applications/inventory_and_mrp/inventory/management/reporting/using_inventory_valuation>`
 
 .. note::
-   When choosing :guilabel:`Average Cost (AVCO)` as the :guilabel:`Costing Method`, the numerical
-   value in the :guilabel:`Cost` field for products in the respective product category will no
-   longer be editable, and will appear grayed out. The :guilabel:`Cost` amount will instead
-   automatically update based on the average purchase price both of inventory on hand and the costs
-   accumulated from validated purchase orders.
+   When choosing :guilabel:`Average Cost (AVCO)` as the :guilabel:`Costing Method`, changing the
+   numerical value in the :guilabel:`Cost` field for products in the respective product category
+   creates a new record in the *Inventory Valuation* report to adjust the value of the product. The
+   :guilabel:`Cost` amount will then automatically update based on the average purchase price both
+   of inventory on hand and the costs accumulated from validated purchase orders.
+
+When the :guilabel:`Costing Method` is changed, products already in stock that were using the
+:guilabel:`Standard` costing method **do not** change value; rather, the existing units keep their
+value, and any product moves from then on affect the average cost, and the cost of the product will
+change. If the value in the :guilabel:`Cost` field on a product form is changed manually, Odoo will
+generate a corresponding record in the *Inventory Valuation* report.
 
 On the same screen, the :guilabel:`Account Stock Properties` fields will appear, as they are now
 required fields given the change to automated inventory valuation. These accounts are defined as


### PR DESCRIPTION
This PR is a [FIX] targeting a `.. note::` in the `inventory_valuation_config` doc. The PR targets the issue raised in ticket [#3340187](https://www.odoo.com/web#id=3340187&cids=3&menu_id=4720&action=333&active_id=49&model=project.task&view_type=form), and corresponds with the project task [#3345736](https://www.odoo.com/web#id=3345736&cids=3&menu_id=4720&action=333&active_id=3835&model=project.task&view_type=form).

The lines affected/changed by the fix are **lines 92-103**.