### PR TITLE
[FIX] inventory: fix sn doc typos

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/management/lots_serial_numbers/serial_numbers.rst
+++ b/content/applications/inventory_and_mrp/inventory/management/lots_serial_numbers/serial_numbers.rst
@@ -92,9 +92,9 @@ serial number.
 Manage serial numbers for shipping and receiving
 ================================================
 
-Serial numbers can be assigned for both **incoming** and **outgoing** goods. For incoming goods, lot
-numbers are assigned directly on the purchase order form. For outgoing goods, lot numbers are
-assigned directly on the sales order form.
+Serial numbers can be assigned for both **incoming** and **outgoing** goods. For incoming goods,
+serial numbers are assigned directly on the purchase order form. For outgoing goods, serial numbers
+are assigned directly on the sales order form.
 
 Manage serial numbers on receipts
 ---------------------------------


### PR DESCRIPTION
This PR is a [FIX] targeting two typos in the `serial_numbers` doc. This PR corresponds with project task [#3346124](https://www.odoo.com/web#id=3346124&cids=3&model=project.task&view_type=form).

The lines affected/changed by the fix are lines **95-97**.

To be fwd-ported to all versions