### PR TITLE
[IMP] reference/views: merge quick_add with quick_create_form_view_id

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -467,12 +467,12 @@ calendar view are:
     open events (or records) in a FormViewDialog. Otherwise, it will open events
     in a new form view (with a do_action)
 ``quick_add``
-    enables quick-event creation on click: only asks the user for a ``name``
-    (the field to which this values is saved can be controlled through
-    ``rec_name``) and tries to create a new event with just that and the clicked
-    event time. Falls back to a full form dialog if the quick creation fails
-``quick_create_form_view_id``
-    view to open when the user tries to quick create a record.
+    When a boolean value is passed, enables quick-event creation on click: only
+    asks the user for a ``name`` (the field to which this values is saved can be
+    controlled through ``rec_name``) and tries to create a new event with just that
+    and the clicked event time. Falls back to a full form dialog if the quick
+    creation fails. This attribute also accepts a form view id, which will be used
+    instead of the quick create default dialog.
 ``create_name_field``
     name of the record's field holding the textual representation of the record,
     this is used when creating records through the 'quick create' mechanism


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/114827 added a new attribute quick_create_form_view_id to the calendar view that would allow showing a form view when clicking on quick_create. This attribute was only used in calendar, however it could be useful for other modules as well. It was decided to merge this new attribute with the quick_add attribute, as they are related. Now, the quick_add attribute accepts either a boolean or a form view id. This commit changes the documentation of this attribute.

task-3286969