### PR TITLE
[FIX] developer/howto: correct theme prefix

### DIFF
--- a/content/developer/howtos/website_themes/theming.rst
+++ b/content/developer/howtos/website_themes/theming.rst
@@ -29,7 +29,7 @@ The first step is to create a new directory.
    website_airproof
 
 .. note::
-   Prefix it with `website_` and use only lowercase ASCII alphanumeric characters and underscores.
+   Prefix it with `theme_` and use only lowercase ASCII alphanumeric characters and underscores.
 
    In this documentation, we will use **Airproof** (a fictional project) as an example.
 


### PR DESCRIPTION
before this commit, in the theme doc, expected
prefix for the theme module is written as website_ , but it is theme_

after this commit, the website_ is changed to theme_

issue: https://github.com/odoo/documentation/issues/4767