### PR TITLE
[FIX] legal: fix broken PDF link

### DIFF
--- a/content/legal/terms/i18n/terms_of_sale_fr.rst
+++ b/content/legal/terms/i18n/terms_of_sale_fr.rst
@@ -6,7 +6,8 @@ Conditions Générales de Vente
 
 .. only:: html
 
-    `Download PDF <terms_of_sale_fr.pdf>`_
+   `Download PDF <https://www.odoo.com/documentation/{CURRENT_BRANCH}/terms_of_sale_fr.pdf>`_
+
 .. note:: Dernière modification: 20 octobre 2021.
 
 Ces conditions régissent la vente de produits et services entre

--- a/content/legal/terms/terms_of_sale.rst
+++ b/content/legal/terms/terms_of_sale.rst
@@ -6,7 +6,7 @@ General Terms of Sale
 
 .. only:: html
 
-    `Download PDF <../../terms_of_sale.pdf>`_
+   `Download PDF <https://www.odoo.com/documentation/{CURRENT_BRANCH}/terms_of_sale.pdf>`_
 
 .. note:: Last revision: October 20, 2021.
 


### PR DESCRIPTION
Apply the fix of e6aa5dd0 to `terms_of_sale.rst` and `terms_of_sale_fr.rst` that were forgotten.