### PR TITLE
[IMP] developer/views: add optional attribute for fields of list views

### DIFF
--- a/content/developer/reference/addons/views.rst
+++ b/content/developer/reference/addons/views.rst
@@ -1569,6 +1569,10 @@ Possible children elements of the list view are:
     ``nolabel``
         if set to "1", the column header will remain empty. Also, the column
         won't be sortable.
+    ``optional``
+        makes the column optional. If set to "hide", the column is hidden by
+        default. If set to "show", the column is visible by default.
+        User visibility choices are stored in the browser local storage.
 
     .. note::
 


### PR DESCRIPTION
The attributes of fields of list views do not mention the `optional` attribute while it is used by chapter 12 of the R&D Training.

This commit describes this `optional` attribute.

task-3380953