### PR TITLE
[FIX] howto/rdtraining: ch.13 adapt reference to salesperson field

### DIFF
--- a/content/developer/tutorials/getting_started/13_inheritance.rst
+++ b/content/developer/tutorials/getting_started/13_inheritance.rst
@@ -145,11 +145,12 @@ By convention, each inherited model is defined in its own Python file. In our ex
 
     - Add the following field to ``res.users``:
 
-    ===================== ======================================================
+    ===================== ================================================================
     Field                 Type
-    ===================== ======================================================
-    property_ids          One2many inverse of ``user_id`` to ``estate.property``
-    ===================== ======================================================
+    ===================== ================================================================
+    property_ids          One2many inverse of the field that references the salesperson in
+                          ``estate.property``
+    ===================== ================================================================
 
     - Add a domain to the field so it only lists the available properties.
 


### PR DESCRIPTION
In chapter 13 the `property_ids` field is defined as the inverse of a `user_id` field. But in chapter 8 when the salesperson field is added, no such name is given to it.

This commit adapts the description to reference the general concept of the field used to link to the salesperson instead of an actual field identifier.

task-3381757