### PR TITLE
[FIX] odoo_theme/switchers: fallback to the original target URL

### DIFF
--- a/extensions/odoo_theme/static/js/switchers.js
+++ b/extensions/odoo_theme/static/js/switchers.js
@@ -19,7 +19,7 @@
                     if (!targetUrl.startsWith('/')) {  // Don't test for valid URLs if in localhost.
                         event.preventDefault();
                         const fallbackUrls = await _generateFallbackUrls(targetUrl);
-                        const fallbackUrl = await _getFirstValidUrl(fallbackUrls);
+                        const fallbackUrl = await _getFirstValidUrl(fallbackUrls) ?? targetUrl;
                         window.location.href = fallbackUrl;
                     }
                 }

--- a/extensions/odoo_theme/static/js/utils.js
+++ b/extensions/odoo_theme/static/js/utils.js
@@ -134,7 +134,7 @@ const _generateFallbackUrls = async (targetUrl) => {
     const [urlBase, version, language, originalPathParts] = _deconstructUrl(targetUrlObject);
 
     // Generate the fallback URLs.
-    const fallbackUrls = [];
+    const fallbackUrls = [targetUrl]; // Start with the original URL in case we rebuild it wrong.
     for (let i = originalPathParts.length; i >= 0; i--) {
         const fallbackPathParts = originalPathParts.slice(0, i);
 
@@ -168,7 +168,7 @@ const _generateFallbackUrls = async (targetUrl) => {
 };
 
 /**
- * Iterate over the provided URLs and return the first one that points to a valid resource.
+ * Iterate over the provided URLs and return the first one that points to a valid resource, if any.
  *
  * Since URLs don't have a protocol and cannot be fetched when the documentation is built locally
  * without the `ROOT` and `IS_REMOTE_BUILD` Make arguments, the URLs that don't have the protocol
@@ -183,5 +183,5 @@ const _getFirstValidUrl = async (urls) => {
             }
         }
     }
-    return urls[0]; // No valid URL found, return the first one.
+    return null; // No valid URL found.
 };


### PR DESCRIPTION
Attempting to switch from one version to another when navigating <old_version>/applications/hr/employees.html led to the user being redirected to /applications/documentation/<new_version>/hr/employees.html because `hr` was interpreted as a version string, and thus the generated target URLs of the version switcher were all wrong.

This commit ensures the redirection now falls back onto the original target URL when all the generated ones point to a 404.