### PR TITLE
[ADD] rpc: Go examples

### DIFF
--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -74,9 +74,9 @@ If you already have an Odoo server installed, you can just use its parameters.
 
    .. code-tab:: go
 
-       const (
-           url      = <insert server URL>
-           db       = <insert database name>
+       var (
+           url = <insert server URL>
+           db = <insert database name>
            username = "admin"
            password = <insert password for your admin user (default: admin)>
        )
@@ -196,10 +196,10 @@ database:
          client, _ := xmlrpc.NewClient("https://demo.odoo.com/start", nil)
          info := map[string]string{}
          client.Call("start", nil, &info)
-         url := info["host"].(string)
-         db := info["database"].(string)
-         username := info["user"].(string)
-         password := info["password"].(string)
+         url = info["host"].(string)
+         db = info["database"].(string)
+         username = info["user"].(string)
+         password = info["password"].(string)
 
       .. note::
          These examples use the `github.com/kolo/xmlrpc library <https://github.com/kolo/xmlrpc>`_.

--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -283,7 +283,7 @@ Result:
    .. code-tab:: go
 
       var uid int64
-      client.Call("authenticate", []any{db, username, password, []any{}}, &uid)
+      client.Call("authenticate", []any{db, username, password, map[string]any{}}, &uid)
 
 .. _api/external_api/calling_methods:
 

--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -197,26 +197,26 @@ database:
          if err != nil {
              log.Fatalln(err)
          }
-         
+
          info := struct {
              Url      string `xmlrpc:"url"`
              Db       string `xmlrpc:"db"`
              Username string `xmlrpc:"username"`
              Password string `xmlrpc:"password"`
          }{}
-         
+
          if err := client.Call("start", nil, &info); err != nil {
              log.Fatalln(err)
          }
-         
+
          url := info.Url
          db := info.Db
          username := info.Username
          password := info.Password 
 
-	       if err := client.Close(); err != nil {
+         if err := client.Close(); err != nil {
              log.Fatalln(err)
-	       }
+         }
 
       .. note::
          These examples use the `github.com/kolo/xmlrpc library <https://github.com/kolo/xmlrpc>`_.
@@ -262,7 +262,7 @@ the login.
       client.execute(common_config, "version", emptyList());
 
    .. code-tab:: go
-   
+
       client, err := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/common", url), nil)
       if err != nil {
           log.Fatalln(err)
@@ -278,13 +278,13 @@ the login.
       if err := client.Call("version", nil, &common); err != nil {
           log.Fatalln(err)
       }
-      
+
       json, err := json.MarshalIndent(common, "", "    ")
       if err != nil {
           log.Fatalln(err)
       }
       fmt.Println(string(json))
-  
+
       if err := client.Close(); err != nil {
           log.Fatalln(err)
       }
@@ -318,9 +318,9 @@ Result:
    .. code-tab:: java
 
       int uid = (int)client.execute(common_config, "authenticate", asList(db, username, password, emptyMap()));
-      
+
    .. code-tab:: go
-   
+
       var uid int64
 
       if err := client.Call("authenticate", []any{
@@ -330,7 +330,7 @@ Result:
           log.Fatalln(err)
       }
       fmt.Println(uid)
-           
+
       if err := client.Close(); err != nil {
           log.Fatalln(err)
       }
@@ -390,9 +390,9 @@ Each call to ``execute_kw`` takes the following parameters:
              asList("read"),
              new HashMap() {{ put("raise_exception", false); }}
          ));
-         
+
       .. code-tab:: go
-      
+
          models, err := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/object", url), nil)
          if err != nil {
              log.Fatalln(err)
@@ -410,7 +410,7 @@ Each call to ``execute_kw`` takes the following parameters:
              log.Fatalln(err)
          }
          fmt.Println(result)
-  
+
          if err := models.Close(); err != nil {
              log.Fatalln(err)
          }
@@ -456,9 +456,9 @@ database identifiers of all records matching the filter.
              asList(asList(
                  asList("is_company", "=", true)))
          )));
-         
+
       .. code-tab:: go
-      
+
          var records []int64
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -512,9 +512,9 @@ available to only retrieve a subset of all matched records.
                  asList("is_company", "=", true))),
              new HashMap() {{ put("offset", 10); put("limit", 5); }}
          )));
-         
+
       .. code-tab:: go
-               
+
          var records []int64
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -705,7 +705,7 @@ which tends to be a huge amount.
          )));
 
       .. code-tab:: go
-      
+
          var recordFields []map[string]any
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -717,7 +717,7 @@ which tends to be a huge amount.
          }, &recordFields); err != nil {
              log.Fatalln(err)
          }
-         
+
          json, err := json.MarshalIndent(recordFields, "", "    ")
          if err != nil {
              log.Fatalln(err)
@@ -771,7 +771,7 @@ updating a record).
                    put("attributes", asList("string", "help", "type"));
                }}
            ));
-           
+
        .. code-tab:: go
 
            recordFields := map[string]struct {
@@ -878,7 +878,7 @@ if that list is not provided it will fetch all fields of matched records).
                  put("limit", 5);
              }}
          )));
-         
+
       .. code-tab:: go
 
          var recordFields []map[string]any
@@ -970,9 +970,9 @@ set through the mapping argument, the default value will be used.
              "res.partner", "create",
              asList(new HashMap() {{ put("name", "New Partner"); }})
          ));
-         
+
       .. code-tab:: go
-      
+
          var id int64
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1054,9 +1054,9 @@ a record).
              "res.partner", "name_get",
              asList(asList(id))
          )));
-         
+
       .. code-tab:: go
-      
+
          var result bool
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1137,9 +1137,9 @@ Records can be deleted in bulk by providing their ids to
              "res.partner", "search",
              asList(asList(asList("id", "=", 78)))
          )));
-         
+
       .. code-tab:: go
-      
+
          var result bool
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1491,7 +1491,7 @@ custom fields without using Python code.
          ));
 
       .. code-tab:: go
-      
+
          var id int64
          if err := models.Call("execute_kw", []any{
              db, uid, password,

--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -212,7 +212,7 @@ database:
          url := info.Url
          db := info.Db
          username := info.Username
-         password := info.Password 
+         password := info.Password
 
          if err := client.Close(); err != nil {
              log.Fatalln(err)

--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -197,26 +197,19 @@ database:
          if err != nil {
              log.Fatalln(err)
          }
-
          info := struct {
              Url      string `xmlrpc:"url"`
              Db       string `xmlrpc:"db"`
              Username string `xmlrpc:"username"`
              Password string `xmlrpc:"password"`
          }{}
-
          if err := client.Call("start", nil, &info); err != nil {
              log.Fatalln(err)
          }
-
          url := info.Url
          db := info.Db
          username := info.Username
          password := info.Password
-
-         if err := client.Close(); err != nil {
-             log.Fatalln(err)
-         }
 
       .. note::
          These examples use the `github.com/kolo/xmlrpc library <https://github.com/kolo/xmlrpc>`_.
@@ -267,25 +260,13 @@ the login.
       if err != nil {
           log.Fatalln(err)
       }
-
       common := struct {
           ProtocolVersion   int    `xmlrpc:"protocol_version"`
           ServerSerie       string `xmlrpc:"server_serie"`
           ServerVersion     string `xmlrpc:"server_version"`
           ServerVersionInfo []any  `xmlrpc:"server_version_info"`
       }{}
-
       if err := client.Call("version", nil, &common); err != nil {
-          log.Fatalln(err)
-      }
-
-      json, err := json.MarshalIndent(common, "", "    ")
-      if err != nil {
-          log.Fatalln(err)
-      }
-      fmt.Println(string(json))
-
-      if err := client.Close(); err != nil {
           log.Fatalln(err)
       }
 
@@ -322,16 +303,10 @@ Result:
    .. code-tab:: go
 
       var uid int64
-
       if err := client.Call("authenticate", []any{
           db, username, password,
           []any{},
       }, &uid); err != nil {
-          log.Fatalln(err)
-      }
-      fmt.Println(uid)
-
-      if err := client.Close(); err != nil {
           log.Fatalln(err)
       }
 
@@ -397,7 +372,6 @@ Each call to ``execute_kw`` takes the following parameters:
          if err != nil {
              log.Fatalln(err)
          }
-
          var result bool
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -407,11 +381,6 @@ Each call to ``execute_kw`` takes the following parameters:
                  "raise_exception": false,
              },
          }, &result); err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(result)
-
-         if err := models.Close(); err != nil {
              log.Fatalln(err)
          }
 
@@ -468,12 +437,6 @@ database identifiers of all records matching the filter.
              log.Fatalln(err)
          }
 
-         json, err := json.MarshalIndent(records, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
-
    Result:
 
    .. code-block:: json
@@ -525,12 +488,6 @@ available to only retrieve a subset of all matched records.
              log.Fatalln(err)
          }
 
-         json, err := json.MarshalIndent(records, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
-
    Result:
 
    .. code-block:: json
@@ -581,7 +538,6 @@ only the number of records matching the query. It takes the same
          }, &counter); err != nil {
              log.Fatalln(err)
          }
-         fmt.Println(counter)
 
    Result:
 
@@ -658,7 +614,6 @@ which tends to be a huge amount.
          }, &ids); err != nil {
              log.Fatalln(err)
          }
-
          var records []any
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -667,9 +622,8 @@ which tends to be a huge amount.
          }, &records); err != nil {
              log.Fatalln(err)
          }
-
          // count the number of fields fetched by default
-         fmt.Println(len(records))
+         count := len(records)
 
    Result:
 
@@ -717,12 +671,6 @@ which tends to be a huge amount.
          }, &recordFields); err != nil {
              log.Fatalln(err)
          }
-
-         json, err := json.MarshalIndent(recordFields, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
 
    Result:
 
@@ -789,12 +737,6 @@ updating a record).
            }, &recordFields); err != nil {
                log.Fatalln(err)
            }
-
-           json, err := json.MarshalIndent(recordFields, "", "    ")
-           if err != nil {
-               log.Fatalln(err)
-           }
-           fmt.Println(string(json))
 
    Result:
 
@@ -894,12 +836,6 @@ if that list is not provided it will fetch all fields of matched records).
              log.Fatalln(err)
          }
 
-         json, err := json.MarshalIndent(recordFields, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
-
    Result:
 
    .. code-block:: json
@@ -984,8 +920,6 @@ set through the mapping argument, the default value will be used.
              log.Fatalln(err)
          }
 
-         fmt.Println(id)
-
    Result:
 
    .. code-block:: json
@@ -1068,10 +1002,7 @@ a record).
          }, &result); err != nil {
              log.Fatalln(err)
          }
-         fmt.Println(result)
-
          // get record name after having changed it
-
          var record []any
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1082,12 +1013,6 @@ a record).
          }, &record); err != nil {
              log.Fatalln(err)
          }
-
-         json, err := json.MarshalIndent(record, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
 
    Result:
 
@@ -1150,10 +1075,7 @@ Records can be deleted in bulk by providing their ids to
          }, &result); err != nil {
              log.Fatalln(err)
          }
-         fmt.Println(result)
-
          // check if the deleted record is still in the database
-
          var record []any
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1166,12 +1088,6 @@ Records can be deleted in bulk by providing their ids to
          }, &record); err != nil {
              log.Fatalln(err)
          }
-
-         json, err := json.MarshalIndent(record, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
 
    Result:
 
@@ -1301,8 +1217,6 @@ Provides information about Odoo models via its various fields.
          }, &id); err != nil {
              log.Fatalln(err)
          }
-         fmt.Println(id)
-
          recordFields := map[string]struct {
              String string `xmlrpc:"string"`
              Type   string `xmlrpc:"type"`
@@ -1318,12 +1232,6 @@ Provides information about Odoo models via its various fields.
          }, &recordFields); err != nil {
              log.Fatalln(err)
          }
-
-         json, err := json.MarshalIndent(recordFields, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
 
    Result:
 
@@ -1506,7 +1414,6 @@ custom fields without using Python code.
          }, &id); err != nil {
              log.Fatalln(err)
          }
-
          var fieldId int64
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1523,8 +1430,6 @@ custom fields without using Python code.
          }, &fieldId); err != nil {
              log.Fatalln(err)
          }
-         fmt.Println(fieldId)
-
          var recordId int64
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1535,8 +1440,6 @@ custom fields without using Python code.
          }, &recordId); err != nil {
              log.Fatalln(err)
          }
-         fmt.Println(recordId)
-
          var recordFields []map[string]any
          if err := models.Call("execute_kw", []any{
              db, uid, password,
@@ -1545,12 +1448,6 @@ custom fields without using Python code.
          }, recordFields); err != nil {
              log.Fatalln(err)
          }
-
-         json, err := json.MarshalIndent(recordFields, "", "    ")
-         if err != nil {
-             log.Fatalln(err)
-         }
-         fmt.Println(string(json))
 
    Result:
 

--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -193,7 +193,10 @@ database:
 
       .. code-block:: go
 
-         client, _ := xmlrpc.NewClient("https://demo.odoo.com/start", nil)
+         client, err := xmlrpc.NewClient("https://demo.odoo.com/start", nil)
+         if err != nil {
+             log.Fatal(err)
+         }
          info := map[string]string{}
          client.Call("start", nil, &info)
          url = info["host"].(string)
@@ -246,9 +249,14 @@ the login.
 
    .. code-tab:: go
 
-      client, _ := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/common", url), nil)
+      client, err := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/common", url), nil)
+      if err != nil {
+          log.Fatal(err)
+      }
       common := map[string]any{}
-      client.Call("version", nil, &common)
+      if err := client.Call("version", nil, &common); err != nil {
+          log.Fatal(err)
+      }
 
 Result:
 
@@ -283,7 +291,12 @@ Result:
    .. code-tab:: go
 
       var uid int64
-      client.Call("authenticate", []any{db, username, password, map[string]any{}}, &uid)
+      if err := client.Call("authenticate", []any{
+          db, username, password,
+          map[string]any{},
+      }, &uid); err != nil {
+          log.Fatal(err)
+      }
 
 .. _api/external_api/calling_methods:
 
@@ -343,14 +356,19 @@ Each call to ``execute_kw`` takes the following parameters:
 
       .. code-tab:: go
 
-         models, _ := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/object", url), nil)
+         models, err := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/object", url), nil)
+         if err != nil {
+             log.Fatal(err)
+         }
          var result bool
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "check_access_rights",
              []string{"read"},
              map[string]bool{"raise_exception": false},
-         }, &result)
+         }, &result); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -397,13 +415,15 @@ database identifiers of all records matching the filter.
       .. code-tab:: go
 
          var records []int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "search",
              []any{[]any{
                  []any{"is_company", "=", true},
              }},
-         }, &records)
+         }, &records); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -447,14 +467,16 @@ available to only retrieve a subset of all matched records.
       .. code-tab:: go
 
          var records []int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "search",
              []any{[]any{
                  []any{"is_company", "=", true},
              }},
              map[string]int64{"offset": 10, "limit":  5},
-         }, &records)
+         }, &records); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -499,13 +521,15 @@ only the number of records matching the query. It takes the same
       .. code-tab:: go
 
          var counter int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "search_count",
              []any{[]any{
                  []any{"is_company", "=", true},
              }},
-         }, &counter)
+         }, &counter); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -574,20 +598,24 @@ which tends to be a huge amount.
       .. code-tab:: go
 
          var ids []int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "search",
              []any{[]any{
                  []any{"is_company", "=", true},
              }},
              map[string]int64{"limit": 1},
-         }, &ids)
+         }, &ids); err != nil {
+             log.Fatal(err)
+         }
          var records []any
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "read",
              ids,
-         }, &records)
+         }, &records); err != nil {
+             log.Fatal(err)
+         }
          // count the number of fields fetched by default
          count := len(records)
 
@@ -627,14 +655,16 @@ which tends to be a huge amount.
       .. code-tab:: go
 
          var recordFields []map[string]any
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "read",
              ids,
              map[string][]string{
                  "fields": {"name", "country_id", "comment"},
              },
-         }, &recordFields)
+         }, &recordFields); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -694,7 +724,9 @@ updating a record).
                map[string][]string{
                    "attributes": {"string", "help", "type"},
                },
-           }, &recordFields)
+           }, &recordFields); err != nil {
+               log.Fatal(err)
+           }
 
    Result:
 
@@ -782,7 +814,7 @@ if that list is not provided it will fetch all fields of matched records).
       .. code-tab:: go
 
          var recordFields []map[string]any
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "search_read",
              []any{[]any{
@@ -792,7 +824,9 @@ if that list is not provided it will fetch all fields of matched records).
                  "fields": []string{"name", "country_id", "comment"},
                  "limit":  5,
              },
-         }, &recordFields)
+         }, &recordFields); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -868,13 +902,15 @@ set through the mapping argument, the default value will be used.
       .. code-tab:: go
 
          var id int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "create",
              []map[string]string{
                  {"name": "New Partner"},
              },
-         }, &id)
+         }, &id); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -948,23 +984,27 @@ a record).
       .. code-tab:: go
 
          var result bool
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "write",
              []any{
                  []int64{id},
                  map[string]string{"name": "Newer partner"},
              },
-         }, &result)
+         }, &result); err != nil {
+             log.Fatal(err)
+         }
          // get record name after having changed it
          var record []any
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "name_get",
              []any{
                  []int64{id},
              },
-         }, &record)
+         }, &record); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -1018,24 +1058,26 @@ Records can be deleted in bulk by providing their ids to
       .. code-tab:: go
 
          var result bool
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "unlink",
              []any{
                  []int64{id},
              },
-         }, &result)
+         }, &result); err != nil {
+             log.Fatal(err)
+         }
          // check if the deleted record is still in the database
          var record []any
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "res.partner", "search",
-             []any{
-                 []any{
-                     []any{"id", "=", id},
-                 },
-             },
-         }, &record)
+             []any{[]any{
+                 []any{"id", "=", id},
+             }},
+         }, &record); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -1152,7 +1194,7 @@ Provides information about Odoo models via its various fields.
       .. code-tab:: go
 
          var id int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "ir.model", "create",
              []map[string]string{
@@ -1162,16 +1204,20 @@ Provides information about Odoo models via its various fields.
                      "state": "manual",
                  },
              },
-         }, &id)
+         }, &id); err != nil {
+             log.Fatal(err)
+         }
          recordFields := map[string]string{}
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "x_custom_model", "fields_get",
              []any{},
              map[string][]string{
                  "attributes": {"string", "help", "type"},
              },
-         }, &recordFields)
+         }, &recordFields); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 
@@ -1341,7 +1387,7 @@ custom fields without using Python code.
       .. code-tab:: go
 
          var id int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "ir.model", "create",
              []map[string]string{
@@ -1351,9 +1397,11 @@ custom fields without using Python code.
                      "state": "manual",
                  },
              },
-         }, &id)
+         }, &id); err != nil {
+             log.Fatal(err)
+         }
          var fieldId int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "ir.model.fields", "create",
              []map[string]any{
@@ -1365,21 +1413,27 @@ custom fields without using Python code.
                      "required": true,
                  },
              },
-         }, &fieldId)
+         }, &fieldId); err != nil {
+             log.Fatal(err)
+         }
          var recordId int64
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "x_custom", "create",
              []map[string]string{
                  {"x_name": "test record"},
              },
-         }, &recordId)
+         }, &recordId); err != nil {
+             log.Fatal(err)
+         }
          var recordFields []map[string]any
-         models.Call("execute_kw", []any{
+         if err := models.Call("execute_kw", []any{
              db, uid, password,
              "x_custom", "read",
              [][]int64{{recordId}},
-         }, recordFields)
+         }, recordFields); err != nil {
+             log.Fatal(err)
+         }
 
    Result:
 

--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -72,6 +72,15 @@ If you already have an Odoo server installed, you can just use its parameters.
                username = "admin",
                password = <insert password for your admin user (default: admin)>;
 
+   .. code-tab:: go
+
+       const (
+           url      = <insert server URL>
+           db       = <insert database name>
+           username = "admin"
+           password = <insert password for your admin user (default: admin)>
+       )
+
 .. _api/external_api/keys:
 
 API Keys
@@ -180,6 +189,41 @@ database:
          The examples do not include imports as these imports couldn't be
          pasted in the code.
 
+   .. group-tab:: Go
+
+      .. code-block:: go
+
+         client, err := xmlrpc.NewClient("https://demo.odoo.com/start", nil)
+         if err != nil {
+             log.Fatalln(err)
+         }
+         
+         info := struct {
+             Url      string `xmlrpc:"url"`
+             Db       string `xmlrpc:"db"`
+             Username string `xmlrpc:"username"`
+             Password string `xmlrpc:"password"`
+         }{}
+         
+         if err := client.Call("start", nil, &info); err != nil {
+             log.Fatalln(err)
+         }
+         
+         url := info.Url
+         db := info.Db
+         username := info.Username
+         password := info.Password 
+
+	       if err := client.Close(); err != nil {
+             log.Fatalln(err)
+	       }
+
+      .. note::
+         These examples use the `github.com/kolo/xmlrpc library <https://github.com/kolo/xmlrpc>`_.
+
+         The examples do not include imports as these imports couldn't be
+         pasted in the code.
+
 Logging in
 ----------
 
@@ -217,6 +261,34 @@ the login.
       common_config.setServerURL(new URL(String.format("%s/xmlrpc/2/common", url)));
       client.execute(common_config, "version", emptyList());
 
+   .. code-tab:: go
+   
+      client, err := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/common", url), nil)
+      if err != nil {
+          log.Fatalln(err)
+      }
+
+      common := struct {
+          ProtocolVersion   int    `xmlrpc:"protocol_version"`
+          ServerSerie       string `xmlrpc:"server_serie"`
+          ServerVersion     string `xmlrpc:"server_version"`
+          ServerVersionInfo []any  `xmlrpc:"server_version_info"`
+      }{}
+
+      if err := client.Call("version", nil, &common); err != nil {
+          log.Fatalln(err)
+      }
+      
+      json, err := json.MarshalIndent(common, "", "    ")
+      if err != nil {
+          log.Fatalln(err)
+      }
+      fmt.Println(string(json))
+  
+      if err := client.Close(); err != nil {
+          log.Fatalln(err)
+      }
+
 Result:
 
 .. code-block:: json
@@ -246,6 +318,22 @@ Result:
    .. code-tab:: java
 
       int uid = (int)client.execute(common_config, "authenticate", asList(db, username, password, emptyMap()));
+      
+   .. code-tab:: go
+   
+      var uid int64
+
+      if err := client.Call("authenticate", []any{
+          db, username, password,
+          []any{},
+      }, &uid); err != nil {
+          log.Fatalln(err)
+      }
+      fmt.Println(uid)
+           
+      if err := client.Close(); err != nil {
+          log.Fatalln(err)
+      }
 
 .. _api/external_api/calling_methods:
 
@@ -302,6 +390,30 @@ Each call to ``execute_kw`` takes the following parameters:
              asList("read"),
              new HashMap() {{ put("raise_exception", false); }}
          ));
+         
+      .. code-tab:: go
+      
+         models, err := xmlrpc.NewClient(fmt.Sprintf("%s/xmlrpc/2/object", url), nil)
+         if err != nil {
+             log.Fatalln(err)
+         }
+
+         var result bool
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "check_access_rights",
+             []string{"read"},
+             map[string]bool{
+                 "raise_exception": false,
+             },
+         }, &result); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(result)
+  
+         if err := models.Close(); err != nil {
+             log.Fatalln(err)
+         }
 
    Result:
 
@@ -344,6 +456,23 @@ database identifiers of all records matching the filter.
              asList(asList(
                  asList("is_company", "=", true)))
          )));
+         
+      .. code-tab:: go
+      
+         var records []int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "search",
+             []any{[]any{[]any{"is_company", "=", true}}},
+         }, &records); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(records, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -383,6 +512,24 @@ available to only retrieve a subset of all matched records.
                  asList("is_company", "=", true))),
              new HashMap() {{ put("offset", 10); put("limit", 5); }}
          )));
+         
+      .. code-tab:: go
+               
+         var records []int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "search",
+             []any{[]any{[]any{"is_company", "=", true}}},
+             map[string]int64{"offset": 10, "limit":  5},
+         }, &records); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(records, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -423,6 +570,18 @@ only the number of records matching the query. It takes the same
              asList(asList(
                  asList("is_company", "=", true)))
          ));
+
+      .. code-tab:: go
+
+         var counter int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "search_count",
+             []any{[]any{[]any{"is_company", "=", true}}},
+         }, &counter); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(counter)
 
    Result:
 
@@ -488,6 +647,30 @@ which tends to be a huge amount.
           // count the number of fields fetched by default
           record.size();
 
+      .. code-tab:: go
+
+         var ids []int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "search",
+             []any{[]any{[]any{"is_company", "=", true}}},
+             map[string]int64{"limit": 1},
+         }, &ids); err != nil {
+             log.Fatalln(err)
+         }
+
+         var records []any
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "read",
+             ids,
+         }, &records); err != nil {
+             log.Fatalln(err)
+         }
+
+         // count the number of fields fetched by default
+         fmt.Println(len(records))
+
    Result:
 
    .. code-block:: json
@@ -520,6 +703,26 @@ which tends to be a huge amount.
                  put("fields", asList("name", "country_id", "comment"));
              }}
          )));
+
+      .. code-tab:: go
+      
+         var recordFields []map[string]any
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "read",
+             ids,
+             map[string][]string{
+                 "fields": {"name", "country_id", "comment"},
+             },
+         }, &recordFields); err != nil {
+             log.Fatalln(err)
+         }
+         
+         json, err := json.MarshalIndent(recordFields, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -568,6 +771,30 @@ updating a record).
                    put("attributes", asList("string", "help", "type"));
                }}
            ));
+           
+       .. code-tab:: go
+
+           recordFields := map[string]struct {
+               String string `xmlrpc:"string"`
+               Type   string `xmlrpc:"type"`
+               Help   string `xmlrpc:"help"`
+           }{}
+           if err := models.Call("execute_kw", []any{
+               db, uid, password,
+               "res.partner", "fields_get",
+               []any{},
+               map[string][]string{
+                   "attributes": {"string", "help", "type"},
+               },
+           }, &recordFields); err != nil {
+               log.Fatalln(err)
+           }
+
+           json, err := json.MarshalIndent(recordFields, "", "    ")
+           if err != nil {
+               log.Fatalln(err)
+           }
+           fmt.Println(string(json))
 
    Result:
 
@@ -651,6 +878,27 @@ if that list is not provided it will fetch all fields of matched records).
                  put("limit", 5);
              }}
          )));
+         
+      .. code-tab:: go
+
+         var recordFields []map[string]any
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "search_read",
+             []any{[]any{[]any{"is_company", "=", true}}},
+             map[string]any{
+                 "fields": []string{"name", "country_id", "comment"},
+                 "limit":  5,
+             },
+         }, &recordFields); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(recordFields, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -722,6 +970,21 @@ set through the mapping argument, the default value will be used.
              "res.partner", "create",
              asList(new HashMap() {{ put("name", "New Partner"); }})
          ));
+         
+      .. code-tab:: go
+      
+         var id int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "create",
+             []map[string]string{
+                 {"name": "New Partner"},
+             },
+         }, &id); err != nil {
+             log.Fatalln(err)
+         }
+
+         fmt.Println(id)
 
    Result:
 
@@ -791,6 +1054,40 @@ a record).
              "res.partner", "name_get",
              asList(asList(id))
          )));
+         
+      .. code-tab:: go
+      
+         var result bool
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "write",
+             []any{
+                 []int64{id},
+                 map[string]string{"name": "Newer partner"},
+             },
+         }, &result); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(result)
+
+         // get record name after having changed it
+
+         var record []any
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "name_get",
+             []any{
+                 []int64{id},
+             },
+         }, &record); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(record, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -840,6 +1137,41 @@ Records can be deleted in bulk by providing their ids to
              "res.partner", "search",
              asList(asList(asList("id", "=", 78)))
          )));
+         
+      .. code-tab:: go
+      
+         var result bool
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "unlink",
+             []any{
+                 []int64{id},
+             },
+         }, &result); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(result)
+
+         // check if the deleted record is still in the database
+
+         var record []any
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "res.partner", "search",
+             []any{
+                 []any{
+                     []any{"id", "=", id},
+                 },
+             },
+         }, &record); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(record, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -952,6 +1284,46 @@ Provides information about Odoo models via its various fields.
                              "type"));
                  }}
          ));
+
+      .. code-tab:: go
+
+         var id int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "ir.model", "create",
+             []map[string]string{
+                 {
+                     "name":  "Custom Model",
+                     "model": "x_custom_model",
+                     "state": "manual",
+                 },
+             },
+         }, &id); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(id)
+
+         recordFields := map[string]struct {
+             String string `xmlrpc:"string"`
+             Type   string `xmlrpc:"type"`
+             Help   string `xmlrpc:"help"`
+         }{}
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "x_custom_model", "fields_get",
+             []any{},
+             map[string][]string{
+                 "attributes": {"string", "help", "type"},
+             },
+         }, &recordFields); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(recordFields, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 
@@ -1117,6 +1489,68 @@ custom fields without using Python code.
                  "x_custom", "read",
                  asList(asList(record_id))
          ));
+
+      .. code-tab:: go
+      
+         var id int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "ir.model", "create",
+             []map[string]string{
+                 {
+                     "name":  "Custom Model",
+                     "model": "x_custom",
+                     "state": "manual",
+                 },
+             },
+         }, &id); err != nil {
+             log.Fatalln(err)
+         }
+
+         var fieldId int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "ir.model.fields", "create",
+             []map[string]any{
+                 {
+                     "model_id": id,
+                     "name":     "x_name",
+                     "ttype":    "char",
+                     "state":    "manual",
+                     "required": true,
+                 },
+             },
+         }, &fieldId); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(fieldId)
+
+         var recordId int64
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "x_custom", "create",
+             []map[string]string{
+                 {"x_name": "test record"},
+             },
+         }, &recordId); err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(recordId)
+
+         var recordFields []map[string]any
+         if err := models.Call("execute_kw", []any{
+             db, uid, password,
+             "x_custom", "read",
+             [][]int64{{recordId}},
+         }, recordFields); err != nil {
+             log.Fatalln(err)
+         }
+
+         json, err := json.MarshalIndent(recordFields, "", "    ")
+         if err != nil {
+             log.Fatalln(err)
+         }
+         fmt.Println(string(json))
 
    Result:
 


### PR DESCRIPTION
Examples rely on `kolo/xmlrpc` as well as on the standard library package `log` to panic on error, matching snippets in other languages (which tend to raise exceptions).

As with other languages, only the RPC interaction is spelled out.