### PR TITLE
"Domains" should not be under "View inheritance"

### DIFF
--- a/content/developer/tutorials/backend.rst
+++ b/content/developer/tutorials/backend.rst
@@ -614,7 +614,7 @@ instead of a single view its ``arch`` field is composed of any number of
    * Using view inheritance, display this fields in the partner form view
 
 Domains
-~~~~~~~
+=======
 
 In Odoo, :ref:`reference/orm/domains` are values that encode conditions on
 records. A domain is a  list of criteria used to select a subset of a model's


### PR DESCRIPTION
Why is "Domain" under "View inheritance"?
Could not find an answer, so I proposed this change.

Let me know if there is some reason that I'm not seeing why "Domains" should be under "View inheritance".


Thanks!