### PR TITLE
[IMP] tutorials/getting_started: disambiguate example model name

### DIFF
--- a/content/developer/tutorials/getting_started/04_basicmodel.rst
+++ b/content/developer/tutorials/getting_started/04_basicmodel.rst
@@ -57,12 +57,11 @@ model::
     from odoo import models
 
     class TestModel(models.Model):
-        _name = "test.model"
+        _name = "test_model"
 
-This definition is enough for the ORM to generate a database table named ``test_model``. The
-``.`` in the model ``_name`` is automatically converted into a ``_`` by the ORM. By convention all
-models are located in a ``models`` directory and each model is defined in its own Python
-file.
+This definition is enough for the ORM to generate a database table named `test_model`. By
+convention all models are located in a `models` directory and each model is defined in its own
+Python file.
 
 Take a look at how the ``crm_recurring_plan`` table is defined and how the corresponding Python
 file is imported:
@@ -123,7 +122,7 @@ defined as attributes in the model class::
     from odoo import fields, models
 
     class TestModel(models.Model):
-        _name = "test.model"
+        _name = "test_model"
         _description = "Test Model"
 
         name = fields.Char()


### PR DESCRIPTION
I removed the dot notation in the  "_name" variable for the example model. AKA, "test.model" is now named "test_model". 

Dot notation implies a data structure relationship between a <model> and it's parent (or class etc) <test> (like test.model() or Test.model).  There is no relationship like this between a <test> and <model> - it's just one thing: a <test model>.

The seeming "benefit" of the ORM translating dots to underscores doesn't justify this naming convention.  Yes, I know it's a string, but still, this seems confusing for newbies and adds unnecessary complexity (why name the same thing differently in different places?)