### PR TITLE
[IMP] core: improve manifest's version documentation

### DIFF
--- a/content/developer/reference/addons/module.rst
+++ b/content/developer/reference/addons/module.rst
@@ -42,7 +42,11 @@ Available manifest fields are:
 ``name`` (``str``, required)
     the human-readable name of the module
 ``version`` (``str``)
-    this module's version, should follow `semantic versioning`_ rules
+    this module's version, should follow `semantic versioning`_ rules, it could be prefixed with the target Odoo version in which case it will be stripped to get the actual module version
+
+.. note::
+    If the module version happens to start with the Odoo version, it should be prefixed with the Odoo version to avoid ambiguities. Example: 14.0.14.0.1 for a module with version 14.0.1 running in Odoo 14.0.
+
 ``description`` (``str``)
     extended description for the module, in reStructuredText
 ``author`` (``str``)


### PR DESCRIPTION
Odoo will strip the currently running version from the module version in
the manifest. This behaviour is undocumented and may cause issues for
upgrades.
