### PR TITLE
[IMP] developer: add notes on entity references & fix illegal XML

### DIFF
--- a/content/developer/reference/backend/views.rst
+++ b/content/developer/reference/backend/views.rst
@@ -2185,10 +2185,13 @@ Possible children elements of the search view are:
 
           <filter domain="[('state', '=', 'draft')]"/>
           <separator/>
-          <filter domain="[('delay', '<', 15)]"/>
+          <filter domain="[('delay', '&lt;', 15)]"/>
 
        if both filters are selected, will select the records whose ``state``
        is ``draft`` **and** ``delay`` is below 15.
+
+       .. note:: XML does not allow ``<`` to be used within XML elements,
+          an entity reference (``&lt;``) should be used instead.
 
 ``separator``
     can be used to separates groups of filters in simple search views

--- a/content/developer/tutorials/getting_started/07_basicviews.rst
+++ b/content/developer/tutorials/getting_started/07_basicviews.rst
@@ -218,6 +218,11 @@ services *OR* have a unit price which is *NOT* between 1000 and 2000'::
             ('unit_price', '>=', 1000),
             ('unit_price', '<', 2000)]
 
+.. note:: XML does not allow ``<`` and ``&`` to be used inside XML
+    elements. To avoid parsing errors, entity references should be used:
+    ``&lt;`` for ``<`` and ``&amp;`` for ``&``. Other entity references
+    (``&gt;``, ``&apos;`` & ``&quot;``) are optional.
+
 .. exercise:: Add filter and Group By.
 
     The following should be added to the previously created search view:


### PR DESCRIPTION
Using `<` inside XML elements will result in a parsing error, an entity reference should be used instead: `&lt;`.