### PR TITLE
Update 01_owl_components.rst

### DIFF
--- a/content/developer/tutorials/discover_js_framework/01_owl_components.rst
+++ b/content/developer/tutorials/discover_js_framework/01_owl_components.rst
@@ -46,7 +46,7 @@ button.
        static template = "my_module.Counter";
 
        setup() {
-           state = useState({ value: 0 });
+           this.state = useState({ value: 0 });
        }
 
        increment() {


### PR DESCRIPTION
The keyword `this` is missing in the setup() definition.