### PR TITLE
[FIX] config: werkzeug 1.0.x docs are no longer online

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -139,7 +139,6 @@ todo_include_todos = False
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'werkzeug': ('https://werkzeug.palletsprojects.com/en/1.0.x/', None),
 }
 
 github_user = 'odoo'


### PR DESCRIPTION
```
❯ curl -sw '%{http_code}\n' -o /dev/null https://werkzeug.palletsprojects.com/en/1.0.x/
404

❯ curl -sw '%{http_code}\n' -o /dev/null https://werkzeug.palletsprojects.com/en/2.0.x/
200
```