### PR TITLE
[FIX] reference/owl_components: fix typo

### DIFF
--- a/content/developer/reference/frontend/owl_components.rst
+++ b/content/developer/reference/frontend/owl_components.rst
@@ -647,8 +647,8 @@ Example: Multi-level Dropdown (nested)
     <DropdownItem onSelected="() => this.onItemSelected('file-save')">Save</DropdownItem>
     <Dropdown>
       <t t-set-slot="toggler">Save as...</t>
-      <DropdownItem onSelected="() => this.onItemSelected('file-save-)as-csv'">CSV</DropdownItem>
-      <DropdownItem onSelected="() => this.onItemSelected('file-save-)as-pdf'">PDF</DropdownItem>
+      <DropdownItem onSelected="() => this.onItemSelected('file-save-as-csv')">CSV</DropdownItem>
+      <DropdownItem onSelected="() => this.onItemSelected('file-save-as-pdf')">PDF</DropdownItem>
     </Dropdown>
   </Dropdown>
 


### PR DESCRIPTION
Making edits for Owl Components Doc : [Link](https://www.odoo.com/documentation/16.0/developer/reference/frontend/owl_components.html#example-multi-level-dropdown-nested)

![image](https://github.com/odoo/documentation/assets/35231827/b2dd4b87-941c-4241-b0f5-e91ca69b3633)