### PR TITLE
[IMP] remove references to owl template tagging

### DIFF
--- a/content/developer/howtos/javascript_client_action.rst
+++ b/content/developer/howtos/javascript_client_action.rst
@@ -40,7 +40,7 @@ framework and use services, core components, hooks,...
 
       <?xml version="1.0" encoding="UTF-8" ?>
       <templates xml:space="preserve">
-          <t t-name="awesome_tshirt.clientaction" owl="1">
+          <t t-name="awesome_tshirt.clientaction">
               Hello world
           </t>
       </templates>

--- a/content/developer/howtos/javascript_field.rst
+++ b/content/developer/howtos/javascript_field.rst
@@ -33,7 +33,7 @@ displaying "Late!" in red whenever the checkbox is checked.
 
       <?xml version="1.0" encoding="UTF-8" ?>
       <templates xml:space="preserve">
-          <t t-name="my_module.LateOrderBooleanField" t-inherit="web.BooleanField" owl="1">
+          <t t-name="my_module.LateOrderBooleanField" t-inherit="web.BooleanField">
               <xpath expr="//CheckBox" position="after">
                     <span t-if="props.value" class="text-danger"> Late! </span>
               </xpath>

--- a/content/developer/howtos/javascript_view.rst
+++ b/content/developer/howtos/javascript_view.rst
@@ -44,7 +44,7 @@ can be done in a few steps:
 
       <?xml version="1.0" encoding="UTF-8" ?>
       <templates>
-          <t t-name="my_module.CustomKanbanView" t-inherit="web.KanbanView" owl="1">
+          <t t-name="my_module.CustomKanbanView" t-inherit="web.KanbanView">
               <xpath expr="//Layout" position="before">
                   <div>
                       Hello world !
@@ -121,7 +121,7 @@ Creating a new view is an advanced topic. This guide highlight only the essentia
 
       <?xml version="1.0" encoding="UTF-8"?>
       <templates xml:space="preserve">
-          <t t-name="my_module.View" owl="1">
+          <t t-name="my_module.View">
               <Layout display="props.display" className="'h-100 overflow-auto'">
                   <t t-component="props.Renderer" records="model.records" propsYouWant="'Hello world'"/>
               </Layout>
@@ -146,7 +146,7 @@ Creating a new view is an advanced topic. This guide highlight only the essentia
 
       <?xml version="1.0" encoding="UTF-8"?>
       <templates xml:space="preserve">
-          <t t-name="my_module.Renderer" owl="1">
+          <t t-name="my_module.Renderer">
               <t t-esc="props.propsYouWant"/>
               <t t-foreach="props.records" t-as="record" t-key="record.id">
                   // Show records

--- a/content/developer/reference/frontend/framework_overview.rst
+++ b/content/developer/reference/frontend/framework_overview.rst
@@ -69,7 +69,7 @@ simplified version of its template:
 
 .. code-block:: xml
 
-    <t t-name="web.WebClient" owl="1">
+    <t t-name="web.WebClient">
         <body class="o_web_client">
             <NavBar/>
             <ActionContainer/>

--- a/content/developer/reference/frontend/hooks.rst
+++ b/content/developer/reference/frontend/hooks.rst
@@ -79,7 +79,7 @@ soon as it appears in the DOM and if it was not displayed before.
 
 .. code-block:: xml
 
-    <t t-name="Comp" owl="1">
+    <t t-name="Comp">
       <input t-ref="autofocus" type="text"/>
     </t>
 
@@ -328,7 +328,7 @@ spellcheck completely on elements that might be enabled by the hook, set explici
 
    .. code-block:: xml
 
-       <t t-name="Comp" owl="1">
+       <t t-name="Comp">
          <input t-ref="spellcheck" type="text"/>
          <textarea t-ref="custom"/>
          <div t-ref="container">

--- a/content/developer/reference/frontend/owl_components.rst
+++ b/content/developer/reference/frontend/owl_components.rst
@@ -81,22 +81,13 @@ And the template is now located in the corresponding xml file:
     <?xml version="1.0" encoding="UTF-8" ?>
     <templates xml:space="preserve">
 
-    <t t-name="myaddon.MyComponent" owl="1">
+    <t t-name="myaddon.MyComponent">
       <div t-on-click="increment">
         <t t-esc="state.value"/>
       </div>
     </t>
 
     </templates>
-
-Odoo code is not yet completely made in Owl, so it needs a way to tell the
-difference between Owl templates (new code) and old templates (for components). To
-do that in a backward-compatible way, all new templates should be defined with
-the `owl` attribute set to 1.
-
-.. note::
-
-   Do not forget to set `owl="1"` in your Owl templates!
 
 .. note::
 
@@ -612,7 +603,7 @@ the `New` and `Save as...` sub elements.
 
 .. code-block:: xml
 
-  <t t-name="addon.Dropdown.File" owl="1">
+  <t t-name="addon.Dropdown.File">
     <Dropdown>
       <t t-set-slot="toggler">File</t>
       <DropdownItem onSelected="() => this.onItemSelected('file-open')">Open</DropdownItem>
@@ -622,7 +613,7 @@ the `New` and `Save as...` sub elements.
     </Dropdown>
   </t>
 
-  <t t-name="addon.Dropdown.File.New" owl="1">
+  <t t-name="addon.Dropdown.File.New">
     <Dropdown>
       <t t-set-slot="toggler">New</t>
       <DropdownItem onSelected="() => this.onItemSelected('file-new-document')">Document</DropdownItem>
@@ -630,7 +621,7 @@ the `New` and `Save as...` sub elements.
     </Dropdown>
   </t>
 
-  <t t-name="addon.Dropdown.File.Save.As" owl="1">
+  <t t-name="addon.Dropdown.File.Save.As">
     <Dropdown>
       <t t-set-slot="toggler">Save as...</t>
       <DropdownItem onSelected="() => this.onItemSelected('file-save-as-csv')">CSV</DropdownItem>
@@ -666,7 +657,7 @@ In this example, we recursively call a template to display a tree-like structure
 
 .. code-block:: xml
 
-  <t t-name="addon.MainTemplate" owl="1">
+  <t t-name="addon.MainTemplate">
     <div>
       <t t-call="addon.RecursiveDropdown">
         <t t-set="name" t-value="'Main Menu'" />
@@ -675,7 +666,7 @@ In this example, we recursively call a template to display a tree-like structure
     </div>
   </t>
 
-  <t t-name="addon.RecursiveDropdown" owl="1">
+  <t t-name="addon.RecursiveDropdown">
     <Dropdown>
       <t t-set-slot="toggler"><t t-esc="name"/></t>
         <t t-foreach="items" t-as="item" t-key="item.id">

--- a/content/developer/tutorials/discover_js_framework/01_owl_components.rst
+++ b/content/developer/tutorials/discover_js_framework/01_owl_components.rst
@@ -60,15 +60,12 @@ and defines a part of user interface:
 .. code-block:: xml
 
    <templates xml:space="preserve">
-      <t t-name="my_module.Counter" owl="1">
+      <t t-name="my_module.Counter">
          <p>Counter: <t t-esc="state.value"/></p>
          <button class="btn btn-primary" t-on-click="increment">Increment</button>
       </t>
    </templates>
 
-You maybe noticed the `owl="1"` temporary attribute, it allows Odoo to differentiate Owl
-templates from the old JavaScript framework templates. Note that Owl templates are not the same
-as QWeb templates: they can contain additional directives, such as `t-on-click`.
 
 1. Displaying a counter
 =======================

--- a/content/developer/tutorials/master_odoo_web_framework/01_fields_and_views.rst
+++ b/content/developer/tutorials/master_odoo_web_framework/01_fields_and_views.rst
@@ -31,7 +31,7 @@ Let us discuss a simplified implementation of a `CharField`. First, here is the 
 
 .. code-block:: xml
 
-   <t t-name="web.CharField" owl="1">
+   <t t-name="web.CharField">
        <t t-if="props.readonly">
            <span t-esc="formattedValue" />
        </t>


### PR DESCRIPTION
In odoo/odoo#130467 the necessity to tag owl templates with an owl="1" attribute has been removed, update the docs to reflect that.