### PR TITLE
[FIX] tutorials/getting_started: fix typos in example model name

### DIFF
--- a/content/developer/tutorials/getting_started/05_securityintro.rst
+++ b/content/developer/tutorials/getting_started/05_securityintro.rst
@@ -92,7 +92,7 @@ access) and a set of permissions: create, read, write and unlink\ [#unlink]_. Su
 rights are usually defined in a CSV file named
 ``ir.model.access.csv``.
 
-Here is an example for our previous ``test.model``:
+Here is an example for our previous `test_model`:
 
 .. code-block:: text
 

--- a/content/developer/tutorials/getting_started/06_firstui.rst
+++ b/content/developer/tutorials/getting_started/06_firstui.rst
@@ -70,13 +70,13 @@ advanced topic. In our Real Estate example, we would like to link a menu to the 
 model, so we are able to create a new record. The action can be viewed as the link between the menu
 and the model.
 
-A basic action for our ``test.model`` is:
+A basic action for our `test_model` is:
 
 .. code-block:: xml
 
     <record id="test_model_action" model="ir.actions.act_window">
         <field name="name">Test action</field>
-        <field name="res_model">test.model</field>
+        <field name="res_model">test_model</field>
         <field name="view_mode">tree,form</field>
     </record>
 
@@ -135,7 +135,7 @@ A basic menu for our ``test_model_action`` is:
     <menuitem id="test_model_menu_action" action="test_model_action"/>
 
 The menu ``test_model_menu_action`` is linked to the action ``test_model_action``, and the action
-is linked to the model ``test.model``. As previously mentioned, the action can be seen as the link
+is linked to the model `test_model`. As previously mentioned, the action can be seen as the link
 between the menu and the model.
 
 However, menus always follow an architecture, and in practice there are three levels of menus:

--- a/content/developer/tutorials/getting_started/08_relations.rst
+++ b/content/developer/tutorials/getting_started/08_relations.rst
@@ -217,7 +217,7 @@ A one2many is the inverse of a many2one. For example, we defined
 on our test model a link to the ``res.partner`` model thanks to the field ``partner_id``.
 We can define the inverse relation, i.e. the list of test models linked to our partner::
 
-    test_ids = fields.One2many("test.model", "partner_id", string="Tests")
+    test_ids = fields.One2many("test_model", "partner_id", string="Tests")
 
 The first parameter is called the ``comodel`` and the second parameter is the field we want to
 inverse.

--- a/content/developer/tutorials/getting_started/12_sprinkles.rst
+++ b/content/developer/tutorials/getting_started/12_sprinkles.rst
@@ -50,18 +50,18 @@ a form view. For example:
     from odoo import fields, models
 
     class TestModel(models.Model):
-        _name = "test.model"
+        _name = "test_model"
         _description = "Test Model"
 
         description = fields.Char()
-        line_ids = fields.One2many("test.model.line", "model_id")
+        line_ids = fields.One2many("test_model_line", "model_id")
 
 
     class TestModelLine(models.Model):
-        _name = "test.model.line"
+        _name = "test_model_line"
         _description = "Test Model Line"
 
-        model_id = fields.Many2one("test.model")
+        model_id = fields.Many2one("test_model")
         field_1 = fields.Char()
         field_2 = fields.Char()
         field_3 = fields.Char()
@@ -78,7 +78,7 @@ a form view. For example:
         </field>
     </form>
 
-In the form view of the ``test.model``, we define a specific list view for ``test.model.line``
+In the form view of the `test_model`, we define a specific list view for `test_model_line`
 with fields ``field_1`` and ``field_2``.
 
 An example can be found
@@ -166,7 +166,7 @@ It will be converted to an order_by_ clause in SQL. For example:
     from odoo import fields, models
 
     class TestModel(models.Model):
-        _name = "test.model"
+        _name = "test_model"
         _description = "Test Model"
         _order = "id desc"
 

--- a/content/developer/tutorials/getting_started/13_inheritance.rst
+++ b/content/developer/tutorials/getting_started/13_inheritance.rst
@@ -40,7 +40,7 @@ Python inheritance::
     from odoo import fields, models
 
     class TestModel(models.Model):
-        _name = "test.model"
+        _name = "test_model"
         _description = "Test Model"
 
         ...
@@ -55,7 +55,7 @@ specific business logic::
     from odoo import fields, models
 
     class TestModel(models.Model):
-        _name = "test.model"
+        _name = "test_model"
         _description = "Test Model"
 
         ...

--- a/content/developer/tutorials/getting_started/14_other_module.rst
+++ b/content/developer/tutorials/getting_started/14_other_module.rst
@@ -136,10 +136,10 @@ to link a line to an invoice is to include all lines at invoice creation. To do 
 :class:`~odoo.fields.One2many`. One2many and Many2many use special 'commands' described in
 :ref:`reference/orm/models/crud`. This format is a list of triplets executed sequentially, where
 each triplet is a command to execute on the set of records. Here is a simple example to include
-a One2many field ``line_ids`` at creation of a ``test.model``::
+a One2many field ``line_ids`` at creation of a ``test_model``::
 
     def inherited_action(self):
-        self.env["test.model"].create(
+        self.env["test_model"].create(
             {
                 "name": "Test",
                 "line_ids": [


### PR DESCRIPTION
Commit f36c612d13bd40bc6cd06445db05eee6a60bad40 changed the model name in Chapter 4 without updating the other occurences.