### PR TITLE
[FIX] support: noindex what_can_i_expect.rst

### DIFF
--- a/content/services/support/what_can_i_expect.rst
+++ b/content/services/support/what_can_i_expect.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. _support-expectations:
 


### PR DESCRIPTION
The content of this page moved to the support
page at https://www.odoo.com/help. The page hosted in the documentation repository is planned for
deletion. In the meanwhile the page should be
excluded from web search results.