### PR TITLE
[FIX] pos: typo in note (stripe)

### DIFF
--- a/content/applications/sales/point_of_sale/payment_methods/terminals/stripe.rst
+++ b/content/applications/sales/point_of_sale/payment_methods/terminals/stripe.rst
@@ -113,5 +113,5 @@ If the payment terminal is unavailable in your Stripe account, you must add it m
 
 .. note::
    You must provide a **registration code**. To retrieve that code, swipe right on your device,
-   enter the admin PIN code (by default: `07319`), validate, and click :guilabel:`Generate a
+   enter the admin PIN code (by default: `07139`), validate, and click :guilabel:`Generate a
    registration code`.


### PR DESCRIPTION
There was a typo for the admin code of the stripe config
task-3472802