### PR TITLE
[IMP] developer reference: update t-debug doc

### DIFF
--- a/content/developer/reference/frontend/qweb.rst
+++ b/content/developer/reference/frontend/qweb.rst
@@ -1,4 +1,3 @@
-
 .. highlight:: xml
 
 .. _reference/qweb:
@@ -439,12 +438,12 @@ Debugging
 .. rst-class:: o-definition-list
 
 ``t-debug``
-    invokes a debugger using PDB's ``set_trace`` API. The parameter should
-    be the name of a module, on which a ``set_trace`` method is called::
+    with an empty value, invokes the :func:`breakpoint` builtin
+    function, which usually invokes a debugger (:mod:`pdb` by
+    default).
 
-        <t t-debug="pdb"/>
-
-    is equivalent to ``importlib.import_module("pdb").set_trace()``
+    The behaviour can be configured via :envvar:`PYTHONBREAKPOINT` or
+    :func:`sys.breakpointhook`.
 
 Rendering cache:
 ----------------


### PR DESCRIPTION
The value of `t-debug` is now optional, and leaving it out means the directive just invokes the `breakpoint` builtin, which was added in 3.7 and is configurable via an envvar or a hook callable.