### PR TITLE
[FIX] developer/tutorials: wrong kanban view example

### DIFF
--- a/content/developer/tutorials/getting_started/15_qwebintro.rst
+++ b/content/developer/tutorials/getting_started/15_qwebintro.rst
@@ -83,9 +83,9 @@ conditionally, we can use the ``t-if`` directive (see :ref:`reference/qweb/condi
             <t t-name="kanban-box">
                 <div class="oe_kanban_global_click">
                     <field name="name"/>
-                </div>
-                <div t-if="record.state.raw_value == 'new'">
-                    This is new!
+                    <div t-if="record.state.raw_value == 'new'">
+                        This is new!
+                    </div>
                 </div>
             </t>
         </templates>


### PR DESCRIPTION
Pretty sure the previous wasnt the intended result as it would show the "this is new" in a new kanban card. This just groups it with the property it belongs to.