### PR TITLE
[IMP] iap: document account deactivation

### DIFF
--- a/content/applications/general/in_app_purchase.rst
+++ b/content/applications/general/in_app_purchase.rst
@@ -22,13 +22,17 @@ Services`.
 IAP accounts
 ============
 
-Credits to use IAP services are stored on IAP accounts, which are specific to each service and
-database. By default, IAP accounts are common to all companies, but can be restricted to specific
+Credits to use IAP services are stored on IAP accounts, which are specific to each service.
+By default, IAP accounts are common to all companies, but can be restricted to specific
 ones. Activate the :ref:`developer mode <developer-mode>`, then go to :menuselection:`Technical
 Settings --> IAP Account`.
 
 .. image:: in_app_purchase/image2.png
    :align: center
+
+.. tip::
+   An IAP account can be disabled by appending `+disabled` to its token.
+   Reverting this change will re-enable the account.
 
 IAP Portal
 ==========


### PR DESCRIPTION
A new way to disable IAP accounts has been introduced recently.

This feature is mostly used in neutralization scripts to prevent customers from accidentaly consuming their credits on their staging/testing databases.

Documenting it will help users re-enable their accounts if they still wish to use it in a testing environment.