### PR TITLE
[FIX] core: bump requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-docutils==0.16.0  # Compatibility with sphinx-tabs 3.2.0.
+docutils==0.17.0  # Compatibility with sphinx-tabs 3.3 and odoo requirements
 libsass==0.20.1
-pygments~=2.6.1
+pygments~=2.7.4
 pygments-csv-lexer~=0.1
 sphinx==4.3.2
-sphinx-tabs==3.2.0
+sphinx-tabs==3.3


### PR DESCRIPTION
* To follow odoo master requirements (docutils & sphinx-tabs)
* To avoid pygments conflicts with recent pudb versions