### PR TITLE
[FIX] developer: fix bad documentation of --unaccent

### DIFF
--- a/content/developer/reference/cli.rst
+++ b/content/developer/reference/cli.rst
@@ -290,7 +290,7 @@ Database
 
 .. option:: --unaccent
 
-   Use the unaccent function provided by the database when available.
+   Try to enable the unaccent extension when creating new databases
 
 .. _reference/cmdline/server/emails:
 


### PR DESCRIPTION
In the CLI, `--unaccent` try to enable PostgreSQL unaccent extention when odoo is responsible to create new database(s).