### PR TITLE
[FIX] upgrade: remove empty toctree

### DIFF
--- a/content/administration/upgrade.rst
+++ b/content/administration/upgrade.rst
@@ -8,9 +8,6 @@ An upgrade is the process of moving your database from an older version to a new
 version <maintain/supported_versions>` (e.g., Odoo 14.0 to Odoo 16.0). Frequently upgrading is
 essential as each version comes with new and improved features, bug fixes, and security patches.
 
-.. toctree::
-   :titlesonly:
-
 .. _upgrade_faq/rolling_release:
 
 .. spoiler:: Automatic upgrades: Odoo Online's Rolling Release process


### PR DESCRIPTION
This PR fixes `upgrade.rst` by removing an empty toctree from the doc that was added in https://github.com/odoo/documentation/pull/6266. 

This PR should **NOT** be FWP past `saas-16.4`: `16.0`, `saas-16.1`, `saas-16.2`, `saas-16.3`, `saas-16.4` only.

C.C. @hojo-odoo @StraubCreative 