### PR TITLE
[IMP] tests: make review UX and resource files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,13 @@ static: $(HTML_BUILD_DIR)/_static/style.css
 
 # Called by runbot for the ci/documentation_guideline check.
 test:
-	@python tests/main.py $(SOURCE_DIR)/administration $(SOURCE_DIR)/applications $(SOURCE_DIR)/contributing $(SOURCE_DIR)/developer $(SOURCE_DIR)/services redirects
+	@python tests/main.py $(SOURCE_DIR)/administration $(SOURCE_DIR)/applications $(SOURCE_DIR)/contributing $(SOURCE_DIR)/developer redirects
 
 # Similar as `test`, but called only manually by content reviewers to trigger extra checks.
 review:
-	@read -p "Enter content path: " path; read -p "Enter max line length (default: 100): " line_length; \
+	@read -p "Enter relative content path: " path; read -p "Enter max line length (default: 100): " line_length; \
 	if [ -z "$$path" ]; then echo "Error: Path cannot be empty"; exit 1; fi; \
+	if echo $$path | grep -q 'content/'; then path=`echo $$path | sed 's|content/||'`; fi; \
 	if [ -z "$$line_length" ]; then line_length=100; fi; \
 	export REVIEW=1; \
 	python tests/main.py --max-line-length=$$line_length $(SOURCE_DIR)/$$path

--- a/tests/main.py
+++ b/tests/main.py
@@ -89,4 +89,5 @@ if __name__ == '__main__':
             setattr(sphinxlint.check_line_too_long, 'enabled', True)
             setattr(checkers.rst_style.check_early_line_breaks, 'enabled', True)
             ADDITIONAL_CHECKERS.extend([checkers.resource_files.check_image_color_depth])
+            run_additional_checks()
         sys.exit(sphinxlint.main())


### PR DESCRIPTION
Original Task: [#2801043](https://www.odoo.com/web#id=2801043&cids=3&menu_id=4720&action=333&active_id=3835&model=project.task&view_type=form)

This PR improves the user experience of using the `make review` command by automatically handling whether or not the  path contains the root `content/` or not, and specifies to the user to input a relative path and not an absolute.

Additionally, this PR also adds the `resource_files.py` checker into the `make review` command so that resource files can also be checked locally by the content team.

**Current behavior:**

- When running `make review`, if users enter a path containing `content/`, sphinxlint will try to run `content/content/...`.
- When running `make review`, resource files are not being checked with the `resource_files.py` checker .

**Desired behavior:**

- When running `make review`, if users enter a path containing `content/`, sphinxlint will try to run `content/...`.
- When running `make review`, resource files are checked with the `resource_files.py` checker .