### PR TITLE
[FIX] payroll: add missing show-content metadata

### DIFF
--- a/content/applications/hr/payroll.rst
+++ b/content/applications/hr/payroll.rst
@@ -1,3 +1,5 @@
+:show-content:
+
 =======
 Payroll
 =======


### PR DESCRIPTION
Without the [:show-content: metadata markup](https://www.odoo.com/documentation/17.0/contributing/documentation/rst_cheat_sheet.html#document-metadata), it is not possible to open the page by navigating from the toctree.