### PR TITLE
[FIX] getting_started: invalid addon-path and useless lambda

### DIFF
--- a/content/developer/tutorials/getting_started/02_setup.rst
+++ b/content/developer/tutorials/getting_started/02_setup.rst
@@ -74,7 +74,7 @@ interface of the server.
 .. code-block:: console
 
     $ cd $HOME/src/odoo/
-    $ ./odoo-bin --addons-path="addons/,../enterprise/,../technical-training-sandbox" -d rd-demo
+    $ ./odoo-bin --addons-path="addons/,../enterprise/" -d rd-demo
 
 There are multiple :ref:`command-line arguments <reference/cmdline/server>` that you can use to run
 the server. In this training you will only need some of them.
@@ -117,6 +117,10 @@ the server. In this training you will only need some of them.
        (comma-separated list).
      - :option:`-u <odoo-bin --update>`: Update some modules before running the server
        (comma-separated list).
+
+.. note::
+   For now you cannot add `../technical-training-sandbox` to your `addons-path` as it is empty
+   and will result into an invalid addons-path folder error, but you will have to add it back later on !
 
 Log in to Odoo
 --------------

--- a/content/developer/tutorials/getting_started/06_firstui.rst
+++ b/content/developer/tutorials/getting_started/06_firstui.rst
@@ -232,7 +232,7 @@ Any field can be given a default value. In the field definition, add the option
 float, string) or a function taking a model and returning a value::
 
     name = fields.Char(default="Unknown")
-    last_seen = fields.Datetime("Last Seen", default=lambda self: fields.Datetime.now())
+    last_seen = fields.Datetime("Last Seen", default=fields.Datetime.now)
 
 The ``name`` field will have the value 'Unknown' by default while the ``last_seen`` field will be
 set as the current time.


### PR DESCRIPTION
- First commit: the addons-path adds `/technical-training-sandbox` before it becomes a valid addons folder.
- Second commit: remove a useless lambda that caused some incomprehension from newdooers.