### PR TITLE
[FIX] install: do not create superuser for postgres

### DIFF
--- a/content/administration/install/source.rst
+++ b/content/administration/install/source.rst
@@ -225,7 +225,7 @@ PostgreSQL user.
 
       .. code-block:: console
 
-         $ sudo -u postgres createuser -s $USER
+         $ sudo -u postgres createuser -d -R -S $USER
          $ createdb $USER
 
       .. note::
@@ -250,7 +250,7 @@ PostgreSQL user.
 
       .. code-block:: console
 
-         $ sudo -u postgres createuser -s $USER
+         $ sudo -u postgres createuser -d -R -S $USER
          $ createdb $USER
 
       .. note::


### PR DESCRIPTION
The preferred/safe way of running Odoo is with a standard user, with only the right to create a database.
See https://github.com/odoo/odoo/commit/b6b73551dbbb3079f043920f21554b945fa4870e