### PR TITLE
[IMP] developer/reference/cli: X-Forwarded-Port

### DIFF
--- a/content/developer/reference/cli.rst
+++ b/content/developer/reference/cli.rst
@@ -448,11 +448,11 @@ HTTP
     nginx's `set_real_ip_from <https://nginx.org/en/docs/http/ngx_http_realip_module.html>`_
     in case there are other trusted proxies along the chain that must be ignored.
 
-    ``X-Forwarded-Proto`` and ``X-Forwarded-Host`` are used to update the
-    request root URL, which in turn is used to update the ``web.base.url``
-    system parameter upon a successful admin authentication. This system
-    parameter is used to generate all links for the current database; see
-    :ref:`domain-name/web-base-url`.
+    ``X-Forwarded-Proto``, ``X-Forwarded-Host`` and ``X-Forwarded-Port`` are
+    used to update the request root URL, which in turn is used to update the
+    ``web.base.url`` system parameter upon a successful admin authentication.
+    This system parameter is used to generate all links for the current
+    database; see :ref:`domain-name/web-base-url`.
 
 
     .. warning:: proxy mode *must not* be enabled outside of a reverse proxy


### PR DESCRIPTION
Install nginx, setup it to listen on port 8080 instead of default 80
then setup a regular proxy_pass toward a local odoo listening on port
8069 with all the X-Forwarded- headers set:

        listen 8080;
        server_name mycompany.odoo.com;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Real-IP $remote_addr;
        location / {
                proxy_pass http://127.0.0.1:8069;
        }

Inside your browser, access "http://mycompany.odoo.com:8080" you are
wrongly redirected to "http://mycompany.odoo.com:80".

The `X-Forwarded-Port` header wasn't taken into account by Odoo.

Closes: odoo/odoo#64643
