### PR TITLE
[IMP] administration/install: wkhtmltopdf 0.12.6

### DIFF
--- a/content/administration/install/packages.rst
+++ b/content/administration/install/packages.rst
@@ -54,8 +54,9 @@ Odoo needs a `PostgreSQL <https://www.postgresql.org/>`_ server to run properly.
          $ sudo systemctl start postgresql
 
 .. warning::
-   `wkhtmltopdf` is not installed through **pip** and must be installed manually in `version 0.12.5
-   <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5>`_ for it to support headers and
+   `wkhtmltopdf` is not installed through **pip** and must be installed manually in version `0.12.5
+   <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5>`_ (systems older than 2016) or
+   `0.12.6 <https://wkhtmltopdf.org/downloads.html>`_ (newer systems) for it to support headers and
    footers. Check out the `wkhtmltopdf wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for
    more details on the various versions.
 

--- a/content/administration/install/source.rst
+++ b/content/administration/install/source.rst
@@ -409,8 +409,9 @@ Dependencies
                $ sudo npm install -g rtlcss
 
 .. warning::
-   `wkhtmltopdf` is not installed through **pip** and must be installed manually in `version 0.12.5
-   <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5>`_ for it to support headers and
+   `wkhtmltopdf` is not installed through **pip** and must be installed manually in version `0.12.5
+   <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5>`_ (systems older than 2016) or
+   `0.12.6 <https://wkhtmltopdf.org/downloads.html>`_ (newer systems) for it to support headers and
    footers. Check out the `wkhtmltopdf wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for
    more details on the various versions.
 


### PR DESCRIPTION
Official packages for wkhtmltopdf 0.12.5 are no more released since the release of wkhtmltopdf 0.12.6 in 2020. Debian 10 "Buster" and Ubuntu 20.04 "Focal" were the last system for which 0.12.5 was built[^1].

Installing 0.12.5 on a Ubuntu 22.04 "Jammy" (using the Focal package) fails for outdated dependencies, we expect installing the 0.12.5 Buster package on Debian 11 "Bullseyes" or Debian 12 "Bookwork" won't work for similar reasons.

With the release of wkhtmltopdf 0.12.6, the team behind this tool also revamped their [official download page] which is regulary updated[^2] to include new builds as new systems are released. This page notably includes 0.12.6 builds for Ubuntu 22.04 and for Debian 11, both of which don't have 0.12.5 counterparts.

[official download page]: https://wkhtmltopdf.org/downloads.html
[^1]: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5
[^2]: https://github.com/wkhtmltopdf/wkhtmltopdf/commits/master/docs/downloads.md