### PR TITLE
[FIX] administration/install: wkhtmltopdf 0.12.6

### DIFF
--- a/content/administration/install/packages.rst
+++ b/content/administration/install/packages.rst
@@ -54,10 +54,10 @@ Odoo needs a `PostgreSQL <https://www.postgresql.org/>`_ server to run properly.
          $ sudo systemctl start postgresql
 
 .. warning::
-   `wkhtmltopdf` is not installed through **pip** and must be installed manually in `version 0.12.5
-   <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5>`_ for it to support headers and
-   footers. Check out the `wkhtmltopdf wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for
-   more details on the various versions.
+   `wkhtmltopdf` is not installed through **pip** and must be installed manually in `version 0.12.6
+   <https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3>`_ for it to support headers
+   and footers. Check out the `wkhtmltopdf wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_
+   for more details on the various versions.
 
 Repository
 ----------

--- a/content/administration/install/source.rst
+++ b/content/administration/install/source.rst
@@ -409,10 +409,10 @@ Dependencies
                $ sudo npm install -g rtlcss
 
 .. warning::
-   `wkhtmltopdf` is not installed through **pip** and must be installed manually in `version 0.12.5
-   <https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5>`_ for it to support headers and
-   footers. Check out the `wkhtmltopdf wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_ for
-   more details on the various versions.
+   `wkhtmltopdf` is not installed through **pip** and must be installed manually in `version 0.12.6
+   <https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3>`_ for it to support headers
+   and footers. Check out the `wkhtmltopdf wiki <https://github.com/odoo/odoo/wiki/Wkhtmltopdf>`_
+   for more details on the various versions.
 
 .. _install/source/running_odoo:
 


### PR DESCRIPTION
Official packages for wkhtmltopdf 0.12.5 are no more released since the release of wkhtmltopdf 0.12.6 in 2020. Debian 10 "Buster" and Ubuntu 20.04 "Focal" were the last system for which 0.12.5 was built[^1]. Installing 0.12.5 on a Ubuntu 22.04 "Jammy" (using the Focal package) fails for outdated dependencies.

Official packages for wkhtmltopdf 0.12.6 are published on another repository[^2] than 0.12.5 used to, it includes packages for 0.12.6 for both Debian 11 "Bullseye" and Ubuntu 22.04 "Jammy". Version 0.12.6.1-r3 is compatible out-of-the-box with Odoo and has been used by runbot to test all 16.x, 17.x and master branches for the past month.

This work makes it official that [wkhtmltopdf 0.12.6.1-r3](https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3) must be used for Odoo 16.0 and onward.

[^1]: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5
[^2]: https://github.com/wkhtmltopdf/packaging/releases