### PR TITLE
[FIX] deploy: nginx forwarded-host with tcp port

### DIFF
--- a/content/administration/install/deploy.rst
+++ b/content/administration/install/deploy.rst
@@ -310,7 +310,7 @@ in ``/etc/nginx/sites-enabled/odoo.conf`` set:
     proxy_send_timeout 720s;
 
     # Add Headers for odoo proxy mode
-    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Install nginx using the nginx configuration found in the documentation and changes the `listen` port to 8080. Start Odoo in `--proxy-mode`.

    listen 8080;
    server_name mycompany.odoo.com;
    proxy_set_header X-Forwarded-Host $host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Real-IP $remote_addr;
    location / {
            proxy_pass http://127.0.0.1:8069;
    }

Inside your browser, access "http://mycompany.odoo.com:8080" you are wrongly redirected to "http://mycompany.odoo.com:80".

Odoo uses the `X-Forwarded-Host` http header value to generate new URls, in this configuration `$host` only contains the domain (=hostname using the urllib terminology) instead of the domain+port (=netloc). The variable that contains both the domain and the port is actually `$http_host`.

Closes: odoo/odoo#64643