### PR TITLE
[FIX] accounting: cheat sheet reconcile

### DIFF
--- a/static/js/reconciliation.js
+++ b/static/js/reconciliation.js
@@ -26,7 +26,7 @@
             state = operations[state]();
         }).appendTo($rec);
 
-        var $1 = $rec.find('td:contains("Invoice 1"), td:contains("Payment 1")')
+        var $1 = $rec.find('td:contains("Invoice 1"), td:contains("Partial payment 1/2"), td:contains("Partial payment 2/2")')
             .parent()
             .addClass('invoice1');
         var $2 = $rec.find('td:contains("Invoice 2"), td:contains("Payment 2")')


### PR DESCRIPTION
Before this commit, when doing the reconciliation of the table present in the cheat sheet, the second reconciliation was wrong because the "Invoice 1" should be reconciled with the twos partials payment. This Pr correct that by changing the find parameter to target the partials also.

task: 3633468