### PR TITLE
[IMP] orm : add info about boolean default

### DIFF
--- a/content/developer/tutorials/backend.rst
+++ b/content/developer/tutorials/backend.rst
@@ -729,6 +729,8 @@ float, string), or a function taking a recordset and returning a value::
     user_id = fields.Many2one('res.users', default=lambda self: self.env.user)
 
 .. note::
+   For existing records, a boolean field defaulting to False signifies a null boolean state.
+   So sql constraints needs to use `is not True` instead of `is False`.
    The object ``self.env`` gives access to request parameters and other useful things:
 
     - ``self.env.cr`` or ``self._cr`` is the database *cursor* object; it is


### PR DESCRIPTION
When a default value for boolean is set as `False`, the values of new column for existing records is set to `NULL`. In python, `FALSE` and `NULL` might mean same thing in certain contexts but its not the case for Sql(we allow to add sql constraints). 