### PR TITLE
[IMP] orm : add info about boolean default

### DIFF
--- a/content/developer/tutorials/getting_started/04_basicmodel.rst
+++ b/content/developer/tutorials/getting_started/04_basicmodel.rst
@@ -249,6 +249,9 @@ Some attributes are available on all fields, here are the most common ones:
 :attr:`~odoo.fields.Field.required` (``bool``, default: ``False``)
     If ``True``, the field can not be empty. It must either have a default
     value or always be given a value when creating a record.
+..note::
+   For existing records, a boolean field defaulting to ``False`` signifies a null boolean state.
+   So sql constraints needs to use ``is not True`` instead of ``is False``.
 :attr:`~odoo.fields.Field.help` (``str``, default: ``''``)
     Provides long-form help tooltip for users in the UI.
 :attr:`~odoo.fields.Field.index` (``bool``, default: ``False``)


### PR DESCRIPTION
When a default value for boolean is set as False, the values of new column for existing records is set to NULL. In python, FALSE and NULL might mean same thing in certain contexts but its not the case for Sql(we allow to add sql constraints).

concerned code: https://github.com/odoo/odoo/blob/15.0/odoo/models.py#L2767