### PR TITLE
[FIX] documentation: Correct typographical error in Azure OAuth setup

### DIFF
--- a/content/administration/maintain/azure_oauth.rst
+++ b/content/administration/maintain/azure_oauth.rst
@@ -52,7 +52,7 @@ able to read (IMAP) and send (SMTP) emails in the Microsoft 365 setup. First, cl
 Add a Permission` button and select :guilabel:`Microsoft Graph` under :guilabel:`Commonly Used
 Microsoft APIs`. After, select the :guilabel:`Delegated Permissions` option.
 
-In the search bar, search for the following :guilabel:`Deregulated permissions` and click
+In the search bar, search for the following :guilabel:`Delegated Permissions` and click
 :guilabel:`Add permissions` for each one:
 
 - :guilabel:`SMTP.Send`

--- a/locale/ar/LC_MESSAGES/administration.po
+++ b/locale/ar/LC_MESSAGES/administration.po
@@ -2165,7 +2165,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/de/LC_MESSAGES/administration.po
+++ b/locale/de/LC_MESSAGES/administration.po
@@ -2967,7 +2967,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 "Suchen Sie in der Suchleiste nach den folgenden :guilabel:`Deregulierte "

--- a/locale/es/LC_MESSAGES/administration.po
+++ b/locale/es/LC_MESSAGES/administration.po
@@ -2940,10 +2940,10 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
-"En la barra de búsqueda, busque :guilabel:`Deregulated permissions` "
+"En la barra de búsqueda, busque :guilabel:`Delegated Permissions` "
 "(permisos no regulados) y haga clic en :guilabel:`Add permissions` (agregar "
 "permisos) para cada uno:"
 

--- a/locale/fr/LC_MESSAGES/administration.po
+++ b/locale/fr/LC_MESSAGES/administration.po
@@ -2960,7 +2960,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 "Dans la barre de recherche, recherchez les :guilabel:`Autorisations "

--- a/locale/he/LC_MESSAGES/administration.po
+++ b/locale/he/LC_MESSAGES/administration.po
@@ -2169,7 +2169,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/id/LC_MESSAGES/administration.po
+++ b/locale/id/LC_MESSAGES/administration.po
@@ -2164,7 +2164,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/it/LC_MESSAGES/administration.po
+++ b/locale/it/LC_MESSAGES/administration.po
@@ -2166,7 +2166,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/ja/LC_MESSAGES/administration.po
+++ b/locale/ja/LC_MESSAGES/administration.po
@@ -2164,7 +2164,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/ko/LC_MESSAGES/administration.po
+++ b/locale/ko/LC_MESSAGES/administration.po
@@ -2176,7 +2176,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/nl/LC_MESSAGES/administration.po
+++ b/locale/nl/LC_MESSAGES/administration.po
@@ -2258,7 +2258,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/pl/LC_MESSAGES/administration.po
+++ b/locale/pl/LC_MESSAGES/administration.po
@@ -2165,7 +2165,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/pt_BR/LC_MESSAGES/administration.po
+++ b/locale/pt_BR/LC_MESSAGES/administration.po
@@ -2174,7 +2174,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/ro/LC_MESSAGES/administration.po
+++ b/locale/ro/LC_MESSAGES/administration.po
@@ -2528,10 +2528,10 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
-"În bara de căutare, căutați următoarele :guilabel:`Deregulated permissions` "
+"În bara de căutare, căutați următoarele :guilabel:`Delegated Permissions` "
 "și faceți clic pe :guilabel:`Add permissions` pentru fiecare dintre ele:"
 
 #: ../../content/administration/maintain/azure_oauth.rst:58

--- a/locale/sl/LC_MESSAGES/administration.po
+++ b/locale/sl/LC_MESSAGES/administration.po
@@ -2168,7 +2168,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/sources/administration.pot
+++ b/locale/sources/administration.pot
@@ -1481,7 +1481,7 @@ msgid "The :guilabel:`API permissions` should be set next. Odoo will need specif
 msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
-msgid "In the search bar, search for the following :guilabel:`Deregulated permissions` and click :guilabel:`Add permissions` for each one:"
+msgid "In the search bar, search for the following :guilabel:`Delegated Permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:58

--- a/locale/uk/LC_MESSAGES/administration.po
+++ b/locale/uk/LC_MESSAGES/administration.po
@@ -2164,7 +2164,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/vi/LC_MESSAGES/administration.po
+++ b/locale/vi/LC_MESSAGES/administration.po
@@ -2172,7 +2172,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/zh_CN/LC_MESSAGES/administration.po
+++ b/locale/zh_CN/LC_MESSAGES/administration.po
@@ -2254,7 +2254,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 

--- a/locale/zh_TW/LC_MESSAGES/administration.po
+++ b/locale/zh_TW/LC_MESSAGES/administration.po
@@ -2164,7 +2164,7 @@ msgstr ""
 
 #: ../../content/administration/maintain/azure_oauth.rst:55
 msgid ""
-"In the search bar, search for the following :guilabel:`Deregulated "
+"In the search bar, search for the following :guilabel:`Delegated "
 "permissions` and click :guilabel:`Add permissions` for each one:"
 msgstr ""
 


### PR DESCRIPTION
---

**Title:** Fix Typographical Error in Azure OAuth Documentation

**Description:**

This pull request corrects a typographical error in the Azure OAuth documentation. The term "Deregulated permissions" has been corrected to "Delegated Permissions".


This correction ensures that the documentation accurately reflects the correct terminology used in Microsoft Azure's OAuth setup.

---

