### PR TITLE
[FIX] barcode: fix default delay number

### DIFF
--- a/content/applications/inventory_and_mrp/barcode/setup/hardware.rst
+++ b/content/applications/inventory_and_mrp/barcode/setup/hardware.rst
@@ -59,7 +59,7 @@ desired language in the scanner's user manual.
 Automatic carriage return
 -------------------------
 
-Odoo has a default 50-millisecond delay between scans to prevent accidental double scanning. To
+Odoo has a default 100-millisecond delay between scans to prevent accidental double scanning. To
 synchronize with the barcode scanner, set it to include a *carriage return* (:dfn:`character like
 the "Enter" key on a keyboard`) after each scan. Odoo interprets the carriage return as the end of
 the barcode input; so Odoo accepts the scan, and waits for the next one.


### PR DESCRIPTION
This PR is a [FIX] targeting the hardware doc in Odoo's Inventory/Barcode documentation.

Performed fix requested in this [task from SHKE](https://www.odoo.com/web#id=3642891&cids=3&model=project.task&view_type=form) to the number in document for 16.0 to be fwd-ported to 17.0.

@StraubCreative @odoo-shke
cc: @Felicious 