### PR TITLE
Fix typo in reports.rst

### DIFF
--- a/content/developer/reference/backend/reports.rst
+++ b/content/developer/reference/backend/reports.rst
@@ -279,7 +279,7 @@ the template, such as data from additional models:
 Custom fonts
 ============
 
-If you want to use custom fonts you will need to add your custom font and the related less/CSS to the ``web.reports_assets_common`` assets bundle.
+If you want to use custom fonts you will need to add your custom font and the related less/CSS to the ``web.report_assets_common`` assets bundle.
 Adding your custom font(s) to ``web.assets_common`` or ``web.assets_backend`` will not make your font available in QWeb reports.
 
 Example::


### PR DESCRIPTION
Fix the spelling of `web.report_assets_common`