### PR TITLE
[IMP] iot: several printers per report

### DIFF
--- a/content/applications/productivity/iot/devices/printer.rst
+++ b/content/applications/productivity/iot/devices/printer.rst
@@ -109,7 +109,11 @@ should be linked to this printer.
    :alt: The printer devices listed in the IoT Devices menu.
 
 Now, each time :guilabel:`Print` is selected in the control panel, instead of downloading a PDF,
-Odoo sends the report to the selected printer, and automatically prints it.
+for the first print, a pop-up will display every printers linked to the report,
+Odoo sends the report to the selected printers, and automatically prints it.
+
+To redo the selection, go to :guilabel:`Clear Selected Devices` and click on the :guilabel:`Unlink` button
+near the reports name. The pop-up will reappear at he next print of this repport
 
 .. seealso::
    :doc:`POS Order Printing <../../../sales/point_of_sale/restaurant/kitchen_printing>`


### PR DESCRIPTION
Before we could only associate one printer per reports,
Now we can associate several, a pop-up will appear for the first print to ask you to select which of the associated printers you want to print on, the selection will stay in memory in the local storage and the pop-up wont appear again.
To change the selection of printers, you can go in Clear Selected Devices to remove the selection from the local storage, doing so, the pop-up will appear the next time you'll print this report