### PR TITLE
[FIX] developer/reference/cli: log on stderr

### DIFF
--- a/content/developer/reference/cli.rst
+++ b/content/developer/reference/cli.rst
@@ -450,14 +450,13 @@ HTTP
 Logging
 ~~~~~~~
 
-By default, Odoo displays all logging of level_ ``info`` except for workflow
-logging (``warning`` only), and log output is sent to ``stdout``. Various
-options are available to redirect logging to other destinations and to
-customize the amount of logging output.
+By default, Odoo displays all logging of level_ ``INFO``, ``WARNING`` and ``ERROR``. All logs
+independently of the level are output on ``stderr``. Various options are available to redirect
+logging to other destinations and to customize the verbosity.
 
 .. option:: --logfile <file>
 
-    sends logging output to the specified file instead of stdout. On Unix, the
+    sends logging output to the specified file instead of ``stderr``. On Unix, the
     file `can be managed by external log rotation programs
     <https://docs.python.org/3/library/logging.handlers.html#watchedfilehandler>`_
     and will automatically be reopened when replaced


### PR DESCRIPTION
Odoo is actually logging on sys.stderr and not sys.stdout[^1][^2][^3].

Remove passage about the workflows, the workflows were an OpenERP feature removed almost a decade ago in odoo/odoo@98cb4719dbe90db.

Fixes: #7210

[^1]: https://github.com/odoo/odoo/blob/b3b9b2b49ef90d30bcce1e27a4ba0b24f888170c/odoo/netsvc.py#L156
[^2]: https://github.com/odoo/odoo/blob/b3b9b2b49ef90d30bcce1e27a4ba0b24f888170c/odoo/netsvc.py#L198
[^3]: https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler