### PR TITLE
[IMP] elearning: set prerequisite courses

### DIFF
--- a/content/applications/websites/elearning.rst
+++ b/content/applications/websites/elearning.rst
@@ -103,6 +103,8 @@ Communication
 Access rights
 *************
 
+- :guilabel:`Prerequisites`: set one or more courses that users are advised to complete before
+   accessing your course;
 - :guilabel:`Show course to`: define who can access your course and their content between
   :guilabel:`Everyone`, :guilabel:`Signed In` or :guilabel:`Course Attendees`;
 - :guilabel:`Enroll Policy`: define how people enroll in your course. Select:


### PR DESCRIPTION
taskid-3433600 [](https://www.odoo.com/web#id=3433600&cids=1&model=project.task&view_type=form)

New prerequisite feature documented: You can set prerequisite courses to be completed before a course.

This PR targets 16.3