### PR TITLE
[FIX] requirements: fix sphinxcontrib-applehelp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,9 @@ libsass==0.20.1
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
 sphinx==4.3.2
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinx-tabs==3.2.0


### PR DESCRIPTION
It seems that the latest version if this lib (1.0.8) needs sphinx 5.0.