### PR TITLE
Update 02_setup.rst - Fix the technical training repository address

### DIFF
--- a/content/developer/tutorials/getting_started/02_setup.rst
+++ b/content/developer/tutorials/getting_started/02_setup.rst
@@ -26,31 +26,31 @@ directories containing Odoo modules.
 
 #. Following the same process as with the `odoo/odoo` and `odoo/enterprise` repositories, visit
    `github.com/odoo/technical-training-sandbox
-   <https://github.com/odoo/technical-training-sandbox>`_ and click the :guilabel:`Fork` button to
+   <https://github.com/odoo/technical-training>`_ and click the :guilabel:`Fork` button to
    create a fork of the repository under your account.
 #. Clone the repository on your machine with:
 
    .. code-block:: console
 
-      $ git clone git@github.com:odoo/technical-training-sandbox.git
+      $ git clone git@github.com:odoo/technical-training.git
 
 #. Configure the repository to push changes to your fork:
 
    .. code-block:: console
 
-      $ cd technical-training-sandbox/
-      $ git remote add dev git@github.com:<your_github_account>/technical-training-sandbox.git
+      $ cd technical-training/
+      $ git remote add dev git@github.com:<your_github_account>/technical-training.git
       $ git remote set-url --push origin you_should_not_push_on_this_repository
 
 That's it! Your environment is now prepared to run Odoo from the sources, and you have successfully
 created a repository to serve as an addons directory. This will allow you to push your work to
 GitHub.
 
-Now, make a small change in the `technical-training-sandbox` repository, such as updating the
+Now, make a small change in the `technical-training` repository, such as updating the
 :file:`README.md` file. Then, follow the :ref:`contributing/development/first-contribution` section
 of the contributing guide to push your changes to GitHub and create a :abbr:`PR (Pull Request)`.
 This will enable you to share your upcoming work and receive feedback. Adjust the instructions to
-use the branch `master` and the repository `technical-training-sandbox`.
+use the branch `master` and the repository `technical-training`.
 
 To ensure a continuous feedback loop, we recommend pushing a new commit as soon as you reach a new
 milestone, such as completing a chapter of the tutorial.


### PR DESCRIPTION
The technical training repository changed its address from `git@github.com:odoo/technical-training-sandbox.git` to `git@github.com:odoo/technical-training.git`