### PR TITLE
Update spain.rst

### DIFF
--- a/content/applications/finance/fiscal_localizations/spain.rst
+++ b/content/applications/finance/fiscal_localizations/spain.rst
@@ -10,6 +10,8 @@ Several Spanish charts of accounts are available by default in Odoo:
 - PGCE PYMEs 2008
 - PGCE Completo 2008
 - PGCE Entitades
+- PGC
+-IGIC
 
 To choose the one you want, go to :menuselection:`Accounting --> Configuration --> Settings`,
 then select a package in the :guilabel:`Fiscal localization` section.


### PR DESCRIPTION
La comunidad de Canarias tiene una contabilización distinta respecto al IVA que se sustituye por el IGIC, creo que es necesario añadirlas, para los empresarios de Canaria
[GRUPO-CUENTA-IGIC.txt](https://github.com/odoo/documentation/files/14006981/GRUPO-CUENTA-IGIC.txt)
[articulo_36_120_marzo_1993.pdf](https://github.com/odoo/documentation/files/14006997/articulo_36_120_marzo_1993.pdf)
