### PR TITLE
[FIX] reference/user_interface: filter element name is mandatory

### DIFF
--- a/content/developer/reference/user_interface/view_architectures.rst
+++ b/content/developer/reference/user_interface/view_architectures.rst
@@ -1871,6 +1871,16 @@ searching/filtering`, or appending new sections to the search filter.
 
 The `filter` element can have the following attributes:
 
+.. attribute:: name
+   :noindex:
+
+   The technical name of the filter. It can be used to :ref:`enable it by default
+   <reference/view_architectures/search/defaults>` or as an :ref:`inheritance hook
+   <reference/view_records/inheritance>`.
+
+   :requirement: Mandatory
+   :type: str
+
 .. attribute:: string
    :noindex:
 
@@ -1883,17 +1893,6 @@ The `filter` element can have the following attributes:
    :noindex:
 
    The tooltip displayed when hovering the filter.
-
-   :requirement: Optional
-   :type: str
-   :default: `''`
-
-.. attribute:: name
-   :noindex:
-
-   The technical name of the filter. It can be used to :ref:`enable it by default
-   <reference/view_architectures/search/defaults>` or as an :ref:`inheritance hook
-   <reference/view_records/inheritance>`.
 
    :requirement: Optional
    :type: str


### PR DESCRIPTION
The filter element attribute 'name' is now required since https://github.com/odoo/odoo/commit/4ddc3231

![image](https://github.com/odoo/documentation/assets/77900800/34e06eab-ff29-48e4-a357-5bffd7a01063)
