### PR TITLE
[FIX][CSS]: ul ol sub-bullet margins

### DIFF
--- a/extensions/odoo_theme/static/scss/_sphinx_basic.scss
+++ b/extensions/odoo_theme/static/scss/_sphinx_basic.scss
@@ -615,6 +615,11 @@ ul.simple p {
     margin-bottom: 0;
 }
 
+ol > li > ol.simple > li:last-child > p,
+ul > li > ul.simple > li:last-child > p {
+    margin-bottom: 1em;
+}
+
 dl.footnote > dt,
 dl.citation > dt {
     float: left;


### PR DESCRIPTION
This PR fixes "simple" bullet list spacing within a non-simple list.

![docs-bullet-spacing-fs8](https://github.com/odoo/documentation/assets/36018073/e2678834-3b5c-4e94-9703-1dfd220cc937)

This issue was discovered in https://github.com/odoo/documentation/pull/7301#discussion_r1462524487.

The added CSS targets ⬇️ to add a bottom margin of 1em to the `<p>` element.
```
<ul or ol>
  <li>
    <ul class="simple">
      <li :last-child>
        <p>
```