### PR TITLE
Add Tip in Share Online Section

### DIFF
--- a/content/applications/productivity/knowledge/management.rst
+++ b/content/applications/productivity/knowledge/management.rst
@@ -64,6 +64,9 @@ users who have been granted specific permission.
 
 .. _management/remove:
 
+.. tip::
+   To share articles **online** you first need to enable Knowledge in *Helpdesk team settings and configuration*.
+
 Removal
 -------
 


### PR DESCRIPTION
Add Tip in Documentation Share Online Section

Tip: To share articles online you first need to enable Knowledge in Helpdesk team settings and configuration.