### PR TITLE
[IMP] payment: Remove `_compute_view_configuration_fields` docs

### DIFF
--- a/content/developer/reference/standard_modules/payment/payment_provider.rst
+++ b/content/developer/reference/standard_modules/payment/payment_provider.rst
@@ -7,7 +7,6 @@ Payment Provider
 .. autoclass:: odoo.addons.payment.models.payment_provider.PaymentProvider()
 
    .. automethod:: _compute_feature_support_fields
-   .. automethod:: _compute_view_configuration_fields
    .. automethod:: _get_compatible_providers
    .. automethod:: _get_redirect_form_view
    .. automethod:: _get_validation_amount


### PR DESCRIPTION
Following the removal of explicit view configuration fields and the `_compute_view_configuration_fields` method in the payment module, this commit updates the documentation accordingly. It removes all references and instructions related to `_compute_view_configuration_fields`, ensuring the documentation reflects the current implementation that leverages XPath for view customization.

task-3679393

See odoo/odoo#152517
See odoo/enterprise#56181
See odoo/upgrade#5667