### PR TITLE
[IMP] fiscal_localizations: HMRC format improved

### DIFF
--- a/content/applications/finance/fiscal_localizations/united_kingdom.rst
+++ b/content/applications/finance/fiscal_localizations/united_kingdom.rst
@@ -90,9 +90,6 @@ Go to :menuselection:`Accounting --> Reporting --> Tax report` and click on
 :guilabel:`Connect to HMRC`. Enter your company information on the HMRC platform. You only need to
 do it once.
 
-.. Note::
-   When entering your VAT number, do not add the GB country code. Only the 9 digits are required.
-
 Periodic submission to HMRC
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/locale/sources/finance.pot
+++ b/locale/sources/finance.pot
@@ -20345,10 +20345,6 @@ msgstr ""
 msgid "Go to :menuselection:`Accounting --> Reporting --> Tax report` and click on :guilabel:`Connect to HMRC`. Enter your company information on the HMRC platform. You only need to do it once."
 msgstr ""
 
-#: ../../content/applications/finance/fiscal_localizations/united_kingdom.rst:94
-msgid "When entering your VAT number, do not add the GB country code. Only the 9 digits are required."
-msgstr ""
-
 #: ../../content/applications/finance/fiscal_localizations/united_kingdom.rst:97
 msgid "Periodic submission to HMRC"
 msgstr ""


### PR DESCRIPTION
Before, when entering the company's VAT, the user had to leave out the 'GB' prefix. This is no longer needed after odoo/enterprise/pull/57570

task-3765235