### PR TITLE
Update Qweb Reports Documentation - How to add assets to your report

### DIFF
--- a/content/developer/reference/backend/reports.rst
+++ b/content/developer/reference/backend/reports.rst
@@ -279,16 +279,18 @@ the template, such as data from additional models:
 Custom fonts
 ============
 
-If you want to use custom fonts you will need to add your custom font and the related less/CSS to the ``web.reports_assets_common`` assets bundle.
-Adding your custom font(s) to ``web.assets_common`` or ``web.assets_backend`` will not make your font available in QWeb reports.
+If you want to use custom fonts you will need to add your custom font and the related less/CSS to the ``web.reports_assets_common`` assets bundle, which is defined in your module's __manifest__.py. Adding your custom font(s) to ``web.assets_common`` or ``web.assets_backend`` will not make your font available in QWeb reports.
 
 Example::
 
-    <template id="report_assets_common_custom_fonts" name="Custom QWeb fonts" inherit_id="web.report_assets_common">
-        <xpath expr="." position="inside">
-            <link href="/your_module/static/src/less/fonts.less" rel="stylesheet" type="text/less"/>
-        </xpath>
-    </template>
+.. code-block:: python
+
+    'assets': {
+        'web.report_assets_common': [
+            '/your_module/static/src/less/fonts.less',
+        ]
+    },
+
 
 You will need to define your ``@font-face`` within this less file, even if you've used in another assets bundle (other than ``web.reports_assets_common``).
 


### PR DESCRIPTION
The described way of adding Qweb reports assets is depricated, The assets should be added to the assets object in manifest.