### PR TITLE
[IMP] accounting: wrong line break in customer_invoices

### DIFF
--- a/content/applications/finance/accounting/customer_invoices.rst
+++ b/content/applications/finance/accounting/customer_invoices.rst
@@ -47,9 +47,7 @@ Draft invoices
 --------------
 
 The system generates invoice which are initially set to the Draft state.
-While these invoices
-
-remain unvalidated, they have no accounting impact within the system.
+While these invoices remain unvalidated, they have no accounting impact within the system.
 There is nothing to stop users from creating their own draft invoices.
 
 Let's create a customer invoice with following information:


### PR DESCRIPTION
Removed line break

From #8005 