### PR TITLE
[IMP] core: remove user_has_groups()

### DIFF
--- a/content/developer/reference/backend/mixins.rst
+++ b/content/developer/reference/backend/mixins.rst
@@ -451,12 +451,12 @@ The urls in the actions list can be generated automatically by calling the
 
                 new_group = (
                     'group_trip_manager',
-                    lambda partner: bool(partner.user_ids) and
-                    any(user.has_group('business.group_trip_manager')
-                    for user in partner.user_ids),
-                    {
-                        'actions': trip_actions,
-                    })
+                    lambda partner: any(
+                        user.sudo().has_group('business.group_trip_manager')
+                        for user in partner.user_ids
+                    ),
+                    {'actions': trip_actions},
+                )
 
                 return [new_group] + groups
 

--- a/content/developer/reference/backend/security.rst
+++ b/content/developer/reference/backend/security.rst
@@ -213,7 +213,7 @@ can not be trusted, ACL being only verified during CRUD operations.
 
     # this method is public and its arguments can not be trusted
     def action_done(self):
-        if self.state == "draft" and self.user_has_groups('base.manager'):
+        if self.state == "draft" and self.env.user.has_group('base.manager'):
             self._set_state("done")
 
     # this method is private and can only be called from other python methods


### PR DESCRIPTION
Simply align the documentation with the new API and usage of method user.has_group().

see: https://github.com/odoo/odoo/pull/151597