### PR TITLE
[FIX] legal: update license info for v17

### DIFF
--- a/content/legal/licenses.rst
+++ b/content/legal/licenses.rst
@@ -7,10 +7,10 @@ Licenses
 
 .. _odoo_community_license:
 
-Odoo 16 Community Edition
+Odoo 17 Community Edition
 =========================
 
-Odoo 16 Community Edition is licensed under
+Odoo 17 Community Edition is licensed under
 `LGPL version 3 <http://www.gnu.org/licenses/lgpl-3.0.en.html>`_  (also known as LGPLv3).
 See also the `GPL FAQ <http://www.gnu.org/licenses/gpl-faq.en.html>`_ and the
 `compatibility matrix <http://www.gnu.org/licenses/gpl-faq.en.html#AllCompatibility>`_.
@@ -18,10 +18,10 @@ See also the `GPL FAQ <http://www.gnu.org/licenses/gpl-faq.en.html>`_ and the
 
 .. _odoo_enterprise_license:
 
-Odoo 16 Enterprise Edition
+Odoo 17 Enterprise Edition
 ==========================
 
-Odoo 16 Enterprise Edition is licensed under the Odoo Enterprise Edition License v1.0,
+Odoo 17 Enterprise Edition is licensed under the Odoo Enterprise Edition License v1.0,
 defined as follows:
 
 .. use <tt> to avoid default <pre> styling
@@ -86,7 +86,7 @@ DEALINGS IN THE SOFTWARE.
 
 .. _odoo_9_license:
 
-Odoo 9 - Odoo 15
+Odoo 9 - Odoo 16
 ================
 
 The licenses for both Community Edition and Enterprise Edition of all


### PR DESCRIPTION
The current page still refers to Odoo 16 as the latest version.