### PR TITLE
[FIX] website: anchors in analytics hyperlinks

### DIFF
--- a/content/applications/websites/blog.rst
+++ b/content/applications/websites/blog.rst
@@ -126,4 +126,4 @@ Customize posts by opening a blog post and clicking :menuselection:`Edit --> Cus
 :guilabel:`Select To Tweet`: visitors are offered to tweet the text they select.
 
 .. tip::
-   Use :ref:`Plausible <website/analytics/plausible>` to keep track of the traffic on your blog.
+   Use :ref:`Plausible <analytics/plausible>` to keep track of the traffic on your blog.

--- a/content/applications/websites/ecommerce/ecommerce_management/performance.rst
+++ b/content/applications/websites/ecommerce/ecommerce_management/performance.rst
@@ -30,5 +30,5 @@ Other options include **multiple views (Pivot, etc.), comparison** by periods or
 Analytics
 =========
 
-It is possible to link your Odoo website with :ref:`website/analytics/plausible` and
-:ref:`website/analytics/GA`.
+It is possible to link your Odoo website with :ref:`analytics/plausible` and
+:ref:`analytics/google-analytics`.

--- a/content/applications/websites/website/configuration/multi_website.rst
+++ b/content/applications/websites/website/configuration/multi_website.rst
@@ -152,8 +152,8 @@ Reporting
 Analytics
 ---------
 
-Each website has its own :ref:`analytics <website/analytics/plausible>`. To switch between websites,
-click the buttons in the upper right corner.
+Each website has its own :ref:`analytics <analytics/plausible>`. To switch between websites, click
+the buttons in the upper right corner.
 
 .. image:: multi_website/analytics-switch-websites.png
    :alt: Switch websites in analytics

--- a/content/applications/websites/website/reporting/analytics.rst
+++ b/content/applications/websites/website/reporting/analytics.rst
@@ -5,14 +5,14 @@ Website analytics
 Website analytics helps website owners monitor how people use their site. It provides data on
 visitor demographics, behavior, and interactions, helping improve websites and marketing strategies.
 
-You can track your Odoo website's traffic using :ref:`website/analytics/plausible` or
-:ref:`website/analytics/GA`. We recommend using Plausible.io as it is privacy-friendly, lightweight,
-and easy to use.
+You can track your Odoo website's traffic using :ref:`analytics/plausible` or
+:ref:`analytics/google-analytics`. We recommend using Plausible.io as it is privacy-friendly,
+lightweight, and easy to use.
 
 The Plausible analytics dashboard is also integrated into Odoo and can be accessed
 via :menuselection:`Website --> Reporting --> Analytics`.
 
-.. _website/analytics/plausible:
+.. _analytics/plausible:
 
 Plausible.io
 ============
@@ -83,7 +83,7 @@ Plausible.io account, proceed as follows:
 .. seealso::
    `Plausible Analytics documentation <https://plausible.io/docs>`_
 
-.. _website/analytics/GA:
+.. _analytics/google-analytics:
 
 Google Analytics
 ================
@@ -126,6 +126,8 @@ To follow your Odoo website's traffic with Google Analytics:
 
 .. seealso::
    `Google documentation on setting up Analytics for a website <https://support.google.com/analytics/answer/1008015?hl=en/>`_
+
+.. _analytics/google-tag-manager:
 
 Google Tag Manager
 ==================

--- a/content/applications/websites/website/reporting/link_tracker.rst
+++ b/content/applications/websites/website/reporting/link_tracker.rst
@@ -50,7 +50,7 @@ country of origin for those clicks.
    #. You can also access the link tracker on *odoo.com/r* via your browser.
    #. Activate the developer mode (:menuselection:`Settings --> Activate the developer mode`) and
       get access to the *Link Tracker* module and its back-end functionalities.
-   #. Integrated with :ref:`website/analytics/GA`, those trackers allow you to
-      see the number of clicks and visitors to keep you on top of your marketing campaigns.
+   #. Integrated with :ref:`analytics/google-analytics`, those trackers allow you to see the number
+      of clicks and visitors to keep you on top of your marketing campaigns.
    #. The integration with the :doc:`CRM </applications/sales/crm/track_leads/prospect_visits>` application allows
       you to understand where your leads and opportunities are coming from.


### PR DESCRIPTION
Custom anchors can be used as hyperlinks to target a specific heading on the page. However, the google analytics one didn't work well because of the capital letters used.