### PR TITLE
[IMP] payment: render /payment/status entirely from the server

### DIFF
--- a/content/developer/reference/standard_modules/payment/payment_transaction.rst
+++ b/content/developer/reference/standard_modules/payment/payment_transaction.rst
@@ -8,7 +8,6 @@ Payment Transaction
 
    .. automethod:: _compute_reference
    .. automethod:: _compute_reference_prefix
-   .. automethod:: _get_post_processing_values
    .. automethod:: _get_specific_create_values
    .. automethod:: _get_specific_processing_values
    .. automethod:: _get_specific_rendering_values


### PR DESCRIPTION
Previously, /payment/status would render a template on the server-side, and a JS widget would render subtemplates on the client-side and insert them in the server-side rendered template.

However, mixing server-side and client-side templates causes issues because the context is not properly communicated between client and server. It also makes the code more complex.

This change assumes that no new information returned by /payment/status is worth re-rendering part of the template. If the transaction moves from a pending ('draft', 'pending') state to a final state, the customer should be redirected to the final route that will display the updated information on the transaction.

task-3340354
Community PR: https://github.com/odoo/odoo/pull/149821
Enterprise PR: https://github.com/odoo/enterprise/pull/58822
Upgrade PR: https://github.com/odoo/upgrade/pull/5829