### PR TITLE
[FIX] dev/assets: typo

### DIFF
--- a/content/developer/reference/frontend/assets.rst
+++ b/content/developer/reference/frontend/assets.rst
@@ -286,7 +286,7 @@ provides a few helper functions, located in :file:`@web/core/assets`.
     :param Object assets: a description of various assets that should be loaded
     :returns: Promise<void>
 
-    Load the assets described py the `assets` parameter. It is an object that
+    Load the assets described by the `assets` parameter. It is an object that
     may contain the following keys:
 
     .. list-table::


### PR DESCRIPTION
the "py" letter should be "by" to make the syntax correct and understood.