### PR TITLE
Update assets.rst

### DIFF
--- a/content/developer/reference/frontend/assets.rst
+++ b/content/developer/reference/frontend/assets.rst
@@ -287,7 +287,7 @@ provides a few helper functions, located in :file:`@web/core/assets`.
     :param Object assets: a description of various assets that should be loaded
     :returns: Promise<void>
 
-    Load the assets described py the `assets` parameter. It is an object that
+    Load the assets described by the `assets` parameter. It is an object that
     may contain the following keys:
 
     .. list-table::


### PR DESCRIPTION
same error I found in v16 and I made a pull request for which.

the sentence need "by" letter not "py" which only refers to Python and it does not make sense to mention here.