### PR TITLE
Update 01_fields_and_views.rst

### DIFF
--- a/content/developer/tutorials/master_odoo_web_framework/01_fields_and_views.rst
+++ b/content/developer/tutorials/master_odoo_web_framework/01_fields_and_views.rst
@@ -354,7 +354,7 @@ There is a service dedicated to calling models methods: `orm_service`, located i
       .. note::
          `print_label` is a mock method; it only displays a message in the logs.
 
-   #. The button should not be disabled if the current order is in `create` mode (i.e., it does not
+   #. The button should be disabled if the current order is in `create` mode (i.e., it does not
       exist yet).
 
       .. tip::


### PR DESCRIPTION
The button should NOT be rendered if the order is still not created, but it is rendered when there is an order record with resId.

![Screenshot from 2024-03-30 22-33-17](https://github.com/odoo/documentation/assets/93363076/d39a9883-82bd-4dd5-92aa-b6669cba4f79)
![Screenshot from 2024-03-30 22-32-19](https://github.com/odoo/documentation/assets/93363076/790ddbb1-9495-4b73-a849-d9900bbc83dc)
![Screenshot from 2024-03-30 22-32-10](https://github.com/odoo/documentation/assets/93363076/af4f71bc-f82b-45a5-8abe-41cd960e3b24)
