### PR TITLE
[IMP] point_of_sale: add Ingenico details

### DIFF
--- a/content/applications/sales/point_of_sale/payment_methods/terminals/ingenico.rst
+++ b/content/applications/sales/point_of_sale/payment_methods/terminals/ingenico.rst
@@ -5,8 +5,11 @@ Ingenico
 Connecting a payment terminal allows you to offer a fluid payment flow to your customers and ease
 the work of your cashiers.
 
-Please note that Ingenico is currently only available for customers in the
-Benelux.
+.. important::
+   - Worldline payment terminals require an :doc:`IoT Box </applications/general/iot>`.
+   - Worldline is currently only available in Belgium, the Netherlands and Luxembourg.
+   - Odoo works with the Ingenico Lane/, Desk/, and Move/ payment terminals as they support the TLV
+     communication protocol through TCP/IP.
 
 Configuration
 =============


### PR DESCRIPTION
This PR adds the very much necessary details about the Ingenico terminals we support, the communication protocol and the countries coverage.
- We support only Ingenico terminals in Benelux
- The terminals must support TLV as communication protocol
- We contact terminals through TCP/IP only, not the serial port
- According to our contact in Ingenico (now Axepta) this is the case for all the Lane/Desk/Move payment terminals

task-3865904