### PR TITLE
Updates the default From email address configuration instruction

### DIFF
--- a/content/applications/general/email_communication/email_servers.rst
+++ b/content/applications/general/email_communication/email_servers.rst
@@ -131,6 +131,19 @@ If the `from_filter` contains a full email address, and if the `mail.default.fro
 this address, then all of the email addresses that are different from `mail.default.from` will be
 encapsulated in `mail.default.from`.
 
+If the following configuration won't work configure the following settings:
+
+1. Go to the :menuselection:`Settings --> Discuss --> Alias Domain` and click on the arrow near the text field.
+
+2. Type a domain name from which you want to send your E-Mails into the `Domain` field (like `example.com`).
+
+3. Into the `Default From Alias` field type an e-mail sender user name (like `donotreply`).
+
+Now all mails will be send from the e-mail: `donotreply@example.com`. 
+
+Remember to add the whole e-mail address the the `FROM Filtering` field in the outgoing email server's configuration. 
+
+
 .. _email_communication/from_filter:
 
 Utilizing the "From" filter on an outgoing email server


### PR DESCRIPTION
I tried to force the e-mail address from which e-mails in Odoo are sent. 

I added `mail.default.from` and `mail.default.from_filter` parameters to my configuration as the current version of the documentation says. Unfortunately, it did not changed anything. 

Real change happened when I changed the "Default From Alias" field in  General Settings > Discuss > Alias Domain > Arrow near the text field. 
![image](https://github.com/odoo/documentation/assets/22113075/dcfef366-cbc1-45f0-8880-d41bef64b27c)

I think the current version of documentation is misleading. It says how to "force the email address from which emails are sent" but provides the wrong steps to do it. 

Probably this [instruction](https://odoo-documentation.oeerp.com/applications/general/email_communication/email_domain.html#use-a-default-email-address) is wrong as well. 

BR, Kajetan. 