### PR TITLE
[actions.rst] Page names 'Automated' actions while really talking about "Scheduled" actions

### DIFF
--- a/content/developer/reference/backend/actions.rst
+++ b/content/developer/reference/backend/actions.rst
@@ -407,13 +407,13 @@ how the POS interface works.
 
 .. _reference/actions/cron:
 
-Automated Actions (``ir.cron``)
+Scheduled Actions (``ir.cron``)
 ===============================
 
 Actions triggered automatically on a predefined frequency.
 
 ``name``
-    Name of the automated action (Mainly used in log display)
+    Name of the scheduled action (Mainly used in log display)
 
 ``interval_number``
     Number of *interval_type* uom between two executions of the action


### PR DESCRIPTION
The section "Automated Actions" documents what is called "Scheduled Actions" in the UI (ir.con).
"Automated Actions" sadly are not documented at all.
Same thing for v16 and v17 docs.