### PR TITLE
Update hosting.rst -- Correct "on-premises" misspellings

### DIFF
--- a/content/administration/hosting.rst
+++ b/content/administration/hosting.rst
@@ -10,7 +10,7 @@ Change hosting solution
 The instructions to change the hosting type of a database depend on the current solution used and to
 which solution the database should be moved.
 
-Transferring an on-premise database
+Transferring an on-premises database
 ===================================
 
 To Odoo Online
@@ -47,7 +47,7 @@ Transferring an Odoo Online database
 
 .. important::
    Odoo Online's :ref:`intermediary versions <supported_versions>` are not supported by Odoo.sh or
-   on-premise. Therefore, if the database to transfer is running an intermediary version, it must be
+   on-premises. Therefore, if the database to transfer is running an intermediary version, it must be
    upgraded first to the next :ref:`major version <supported_versions>`, waiting for its release if
    necessary.
 
@@ -64,7 +64,7 @@ Transferring an Odoo Online database
       the Customer Service Manager or `submit a support ticket <https://www.odoo.com/help>`_  to
       complete the subscription transfer.
 
-To on-premise
+To on-premises
 -------------
 
 #. Sign in to `the Odoo Online database manager <https://www.odoo.com/my/databases/>`_ and click the
@@ -114,7 +114,7 @@ To Odoo Online
      switch from the Odoo.sh server to the Odoo Online servers.
    - Databases are **not reachable** during their migration.
 
-To on-premise
+To on-premises
 -------------
 
 #. Download a :ref:`backup of your Odoo.sh production database <odoo_sh_branches_backups>`.


### PR DESCRIPTION
Hello Odoo team!

"premise" and "premises" are completely different words. Premise is a proposition and premises is a building or location.

"on-premise" doesn't mean anything. The term you want to be using when referring to the concept of self-hosting is "on-premises". This is a very common mistake, and reasonably so, but it should be corrected.

The phrase "on-premise" is used throughout Odoo's marketing and documentation but I'm only able to offer this one pull request.