### PR TITLE
[IMP] Makefile: print the full traceback for unhandled exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CONFIG_DIR     = .
 SPHINXOPTS     = -D project_root=$(ROOT) -D canonical_version=$(CANONICAL_VERSION) \
                  -D versions=$(VERSIONS) -D languages=$(LANGUAGES) -D language=$(CURRENT_LANG) \
                  -D is_remote_build=$(IS_REMOTE_BUILD) \
+                 -T \
                  -A google_analytics_key=$(GOOGLE_ANALYTICS_KEY) \
                  -A plausible_script=$(PLAUSIBLE_SCRIPT) \
                  -A plausible_domain=$(PLAUSIBLE_DOMAIN) \


### PR DESCRIPTION
This should help reading the traceback on Runbot, where the log files are not always kept.