### PR TITLE
[FIX] adapt requirements to ubuntu Jammy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docutils==0.16.0  # Compatibility with sphinx-tabs 3.2.0.
+docutils==0.17.0
 libsass==0.20.1
 pygments~=2.6.1
 pygments-csv-lexer~=0.1
@@ -8,4 +8,4 @@ sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-qthelp==1.0.3
-sphinx-tabs==3.2.0
+sphinx-tabs==3.4.5  # Compatibility with docutils==0.17.0


### PR DESCRIPTION
The docutils is pinned to 0.16.0 while the Jammy version should be 0.17

This is the case for a compatibility issue with sphinx-tabs==3.2.0 also official versions in ubuntu Jammy.

The odoo.requirements package contains already a docutils 0.17.0 creating some downgrade when installing requirements, this commit upgrade both dependency to a compatible version.

The proposed solution pins sphinx-tabs to a higher version, compatible with docutils 0.17. Some investigation should still be done to check why the package versions in ubuntu focal are not compatible when installed via pip.

This should avoid installing requirements in all documentation build and hopefully avoid some random errors.


This will also avoid an random error where documentation requirements are installed before odoo ones
https://runbot.odoo.com/runbot/batch/1443963/build/62071320 