### PR TITLE
[FIX] reference/view_architectures/*: remove `nosearch` meta directives

### DIFF
--- a/content/developer/reference/user_interface/view_architectures/button_attribute_context.rst
+++ b/content/developer/reference/user_interface/view_architectures/button_attribute_context.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: context
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/button_attribute_help.rst
+++ b/content/developer/reference/user_interface/view_architectures/button_attribute_help.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: help
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/button_attribute_icon.rst
+++ b/content/developer/reference/user_interface/view_architectures/button_attribute_icon.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: icon
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/button_attribute_name.rst
+++ b/content/developer/reference/user_interface/view_architectures/button_attribute_name.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: name
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/button_attribute_string.rst
+++ b/content/developer/reference/user_interface/view_architectures/button_attribute_string.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: string
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/button_attribute_type.rst
+++ b/content/developer/reference/user_interface/view_architectures/button_attribute_type.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: type
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/field_attribute_name.rst
+++ b/content/developer/reference/user_interface/view_architectures/field_attribute_name.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: name
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/field_attribute_readonly.rst
+++ b/content/developer/reference/user_interface/view_architectures/field_attribute_readonly.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: readonly
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/field_attribute_required.rst
+++ b/content/developer/reference/user_interface/view_architectures/field_attribute_required.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: required
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/field_attribute_string.rst
+++ b/content/developer/reference/user_interface/view_architectures/field_attribute_string.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: string
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/field_attribute_widget.rst
+++ b/content/developer/reference/user_interface/view_architectures/field_attribute_widget.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: widget
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/generic_attribute_class.rst
+++ b/content/developer/reference/user_interface/view_architectures/generic_attribute_class.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: class
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/generic_attribute_column_invisible.rst
+++ b/content/developer/reference/user_interface/view_architectures/generic_attribute_column_invisible.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: column_invisible
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/generic_attribute_groups.rst
+++ b/content/developer/reference/user_interface/view_architectures/generic_attribute_groups.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: groups
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/generic_attribute_invisible.rst
+++ b/content/developer/reference/user_interface/view_architectures/generic_attribute_invisible.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: invisible
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_banner_route.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_banner_route.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: banner_route
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_create.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_create.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: create
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_default_group_by.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_default_group_by.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: default_group_by
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_default_order.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_default_order.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: default_order
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_delete.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_delete.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: delete
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_edit.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_edit.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: edit
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_sample.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_sample.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: sample
    :noindex:
 

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_string.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_string.rst
@@ -1,5 +1,3 @@
-:nosearch:
-
 .. attribute:: string
    :noindex:
 


### PR DESCRIPTION
The `nosearch` meta directive is not fully supported in included files: the generated file is excluded from search results, but the "nosearch" term is present in the included content.