### PR TITLE
[FIX] extensions: icon_role fa icons

### DIFF
--- a/extensions/odoo_theme/__init__.py
+++ b/extensions/odoo_theme/__init__.py
@@ -121,6 +121,6 @@ def icon_role(name, rawtext, text, lineno, inliner, options=None, content=None):
             )
             error_node = inliner.problematic(rawtext, rawtext, report_error)
             return [error_node], [report_error]
-    icon_html = f'<i class="{text}"></i>'
+    icon_html = f'<i class="fa {text}"></i>'
     node = nodes.raw('', icon_html, format='html')
     return [node], []

--- a/extensions/odoo_theme/static/scss/_font_awesome.scss
+++ b/extensions/odoo_theme/static/scss/_font_awesome.scss
@@ -4,7 +4,7 @@
  */
 /* FONT PATH
  * -------------------------- */
-[class*="fa-"] {
+.fa {
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;
   font-size: inherit;


### PR DESCRIPTION
Task: [#3912370](https://www.odoo.com/web?debug=1#id=3912370&cids=3&menu_id=4720&action=333&active_id=3835&model=project.task&view_type=form)
[FIX] suggested from https://github.com/odoo/documentation/pull/9065#discussion_r1590702515

This PR fixes the FontAwesome icon_role implementation by automatically including the `fa` main class in the `<i>` class attribute when rendered. This was suggested to match the 16.0 Odoo UI `oi` implementation.

This PR should be merged after #9065.