### PR TITLE
[IMP] point_of_sale: Setup all Ingenico terminals

### DIFF
--- a/content/applications/sales/point_of_sale/payment_methods/terminals/ingenico.rst
+++ b/content/applications/sales/point_of_sale/payment_methods/terminals/ingenico.rst
@@ -6,8 +6,8 @@ Connecting a payment terminal allows you to offer a fluid payment flow to your c
 the work of your cashiers.
 
 .. important::
-   - Worldline payment terminals require an :doc:`IoT Box </applications/general/iot>`.
-   - Worldline is currently only available in Belgium, the Netherlands and Luxembourg.
+   - Ingenico payment terminals require an :doc:`IoT Box </applications/general/iot>`.
+   - Ingenico is currently only available in Belgium, the Netherlands and Luxembourg.
    - Odoo works with the Ingenico Lane/, Desk/, and Move/ payment terminals as they support the TLV
      communication protocol through TCP/IP.
 
@@ -17,21 +17,22 @@ Configuration
 Connect an IoT Box
 ------------------
 
-Connecting an Ingenico Payment Terminal to Odoo is a feature that
-requires an IoT Box. For more information on how to connect an IoT Box
-to your database, please refer to the :doc:`IoT documentation
-</applications/general/iot/config/connect>`.
+Connecting an Ingenico payment terminal to Odoo is a feature that requires an IoT Box. For more
+information on how to connect an IoT Box to your database, please refer to the :doc:`IoT
+documentation </applications/general/iot/config/connect>`.
 
-Configure the Lane/5000 for Ingenico BENELUX
---------------------------------------------
+Configure the Lane/Desk/Move 5000 terminals for Ingenico BENELUX
+----------------------------------------------------------------
 
-Click on the F button of the terminal, then go in the
-:menuselection:`PoS Menu --> Settings` and enter the settings password.
+#. Press the function button (:guilabel:`F` on Lane/5000, :guilabel:`⦿` on Desk/5000 and
+   Move/5000).
+#. Go to :menuselection:`Kassa menu --> Settings Menu` and enter the settings password.
+#. Select :guilabel:`Change Connection` and press :guilabel:`OK` on the next screen.
+#. Select :guilabel:`TCP/IP` and :guilabel:`IP-address`.
+#. On the next screen, enter the IP address of your IoT Box.
+#. Enter `9000` as port number and press :guilabel:`OK` on the next screen.
 
-Now, click on connection change and TCP/IP. Type the IP of your *IoT
-Box* (you can find it on the form view of your IoT Box). Then, enter
-9000 as port. The terminal will restart. Once it is done, go on your
-*IoT Box* form in Odoo and verify that the terminal has been found.
+At this point, the terminal restarts and should be displayed in your IoT Box form in Odoo.
 
 .. image:: ingenico/payment_terminal_02.png
    :align: center


### PR DESCRIPTION
Currently we only tell how to setup Ingenico Lane/5000 terminal. Actually, Lane/5000 and Move/5000 can be set up in almost the same way, only the button to enter settings is different.

This PR adds a more generic configutation guide applicable  to all the Ingenico Lane/Desk/Move terminals

Also, it replaces erroneous Worldline mention in the top by Ingenico

task-3879038