### PR TITLE
[IMP] eCommerce: fix digital file location on portal 

### DIFF
--- a/content/applications/websites/ecommerce/managing_products/products.rst
+++ b/content/applications/websites/ecommerce/managing_products/products.rst
@@ -165,8 +165,8 @@ For the configuration:
 - :guilabel:`Website`: the website on which that file is *available*. If you want it available for
   *all* websites, leave it empty.
 
-The file is then available after checkout in the **purchase order** section found on the customer's
-portal.
+The file is then available after checkout in the :guilabel:`Sales Orders` section, found on the
+customer's portal.
 
 Product configuration
 =====================


### PR DESCRIPTION
Cherry-pick of #9435
> Corrected the part of the Customer Portal where digital products can be found after purchase.