### PR TITLE
[IMP] emphasize how csv data files should be named

### DIFF
--- a/content/developer/reference/backend/data.rst
+++ b/content/developer/reference/backend/data.rst
@@ -268,7 +268,8 @@ creating a number of simple records of the same model in bulk.
 For this case, data files can also use csv_, this is often the case for
 :ref:`access rights <reference/security/acl>`:
 
-* the file name is :file:`{model_name}.csv`
+* the file name is :file:`{model.name}.csv` (use the exact content of
+  the variable ``_name``)
 * the first row lists the fields to write, with the special field ``id``
   for :term:`external identifiers` (used for creation or update)
 * each row thereafter creates a new record

--- a/content/developer/tutorials/define_module_data.rst
+++ b/content/developer/tutorials/define_module_data.rst
@@ -146,6 +146,10 @@ of features: use it for long lists of simple models, but prefer XML otherwise.
 .. exercise:: Add some standard Real Estate Property Types for the `estate` module: Residential,
   Commercial, Industrial and Land. These should always be installed.
 
+.. warning:: Make sure your file is named exactly as the content of the variable ``_name`` in your
+  target model. For example, if the model you're creating data for is ``res.partner``, then your
+  CSV file must be named :file:`res.partner.csv` (mind the . instead of underscores).
+
 XML
 ---
 


### PR DESCRIPTION
After running the tutorial "Define module data" (under developer/tutorials), I ran into an issue which turned out to be due to bad CSV file naming.

As the error message was not too explicit, I turned towards the web and after a loooong time of searching, finally found my mistake.

In an attempt to save future generations of devs who might go through the same path, I propose the modifications of this commit. All in all, it emphasizes how the csv file should be named.