### PR TITLE
[FIX] crm: typo in gamification doc

### DIFF
--- a/content/applications/sales/crm/optimize/gamification.rst
+++ b/content/applications/sales/crm/optimize/gamification.rst
@@ -129,7 +129,7 @@ definition.
 
    - :guilabel:`New Leads`
    - :guilabel:`Time to Qualify a Lead`
-   - :guilabel:`Days to Close a Dead`
+   - :guilabel:`Days to Close a Deal`
    - :guilabel:`New Opportunities`
    - :guilabel:`New Sales Orders`
 


### PR DESCRIPTION
PROJECT (request) TASK:https://www.odoo.com/odoo/project.task/3964555?cids=3

- Fixed a simple typo in the CRM Gamification doc to change the word "dead" to "deal"