### PR TITLE
[ADD] administration: neutralized databases doc

### DIFF
--- a/content/administration/neutralized_database.rst
+++ b/content/administration/neutralized_database.rst
@@ -21,7 +21,7 @@ turned into a testing environment.
 Deactivated features
 ====================
 
-Here is a non-exhaustive list of the deactivated parameters:
+Here is a non-exhaustive list of the deactivated features:
 
 - all planned actions (e.g., automatic invoicing of subscriptions, mass mailing, etc.)
 - outgoing emails
@@ -29,6 +29,7 @@ Here is a non-exhaustive list of the deactivated parameters:
 - payment providers
 - delivery methods
 - :abbr:`IAP (In-App Purchase)` tokens
+- website visibility (prevent search engines from indexing your site)
 
 .. note::
    **A red banner at the top of the screen is displayed on the neutralized database so that it can


### PR DESCRIPTION
This commit updates the documentation for neutralized databases to include information about how search engine indexing is prevented for these databases.

Related PR:
- https://github.com/odoo/odoo/pull/167963

task-3895772