### PR TITLE
[FIX] howtos/javascript_view: fix typo

### DIFF
--- a/content/developer/howtos/javascript_view.rst
+++ b/content/developer/howtos/javascript_view.rst
@@ -34,7 +34,7 @@ can be done in a few steps:
       };
 
       // Register it to the views registry
-      registry.category("views").add("custom_kanban", customeKanbanView);
+      registry.category("views").add("custom_kanban", customKanbanView);
 
    In our custom kanban, we defined a new template. We can either inherit the kanban controller
    template and add our template pieces or we can define a completely new template.


### PR DESCRIPTION
A typo was found. The word "customeKanbanView" is misspelled and should be "customKanbanView", which is the constant exported correctly in the code. Therefore, the corrected line would be: