### PR TITLE
[IMP] sales: added important admonition to amazon docs

### DIFF
--- a/content/applications/sales/sales/amazon_connector/features.rst
+++ b/content/applications/sales/sales/amazon_connector/features.rst
@@ -60,6 +60,18 @@ The following table lists capabilities provided by Odoo when using the Amazon Co
 |                           |                            | status synchronized from Odoo.      |
 +---------------------------+----------------------------+-------------------------------------+
 
+.. important::
+   The stock synchronization does **not** currently support selling the same product as :abbr:`FBM
+   (Fulfilled By Merchant)` *and* :abbr:`FBA (Fulfilled By Amazon)`.
+
+   At times, when stock is sent for all products, it triggers a stock problem with Amazon, where
+   Amazon incorrectly thinks the :abbr:`FBM (Fulfilled By Merchant)` product has some quantity in
+   :abbr:`FBM (Fulfilled By Merchant)`.
+
+   As a result, Amazon then sells it as :abbr:`FBM (Fulfilled By Merchant)`, instead of taking from
+   their own warehouse. Odoo developers are currently working on resolving this issue to avoid
+   future discrepancies.
+
 .. note::
    The Amazon Connector is designed to synchronize the data of sales orders. Other actions, such as
    downloading monthly fees reports, handling disputes, or issuing refunds, **must** be managed from

--- a/content/applications/sales/sales/amazon_connector/manage.rst
+++ b/content/applications/sales/sales/amazon_connector/manage.rst
@@ -16,6 +16,18 @@ For *FBM* (Fulfilled by Merchant), the same is done for *Unshipped* and *Cancele
 synchronized order, a sales order and customer are created in Odoo (if the customer is not already
 registered in the database).
 
+.. important::
+   The stock synchronization does **not** currently support selling the same product as :abbr:`FBM
+   (Fulfilled By Merchant)` *and* :abbr:`FBA (Fulfilled By Amazon)`.
+
+   At times, when stock is sent for all products, it triggers a stock problem with Amazon, where
+   Amazon incorrectly thinks the :abbr:`FBM (Fulfilled By Merchant)` product has some quantity in
+   :abbr:`FBM (Fulfilled By Merchant)`.
+
+   As a result, Amazon then sells it as :abbr:`FBM (Fulfilled By Merchant)`, instead of taking from
+   their own warehouse. Odoo developers are currently working on resolving this issue to avoid
+   future discrepancies.
+
 .. note::
    When an order is canceled in Amazon, and was already synchronized in Odoo, the corresponding
    sales order is automatically canceled in Odoo.


### PR DESCRIPTION
PROJECT TASK (request for adjustment): https://www.odoo.com/odoo/project.task/3983555?cids=3

Issue: *Odoo limitation, can't sell the same product in FBA and FBM (will set 0 as the quantity)*

Added IMPORTANT admonition blocks to the 2 Amazon Connector docs (in the Sales app section) that cover FBA and FBM concepts/topics. The admonition alerts the reader of the issue, and informs users that a correction to the issue should be happening in the near future.

This should be Forward-Ported through the latest version of 17...