### PR TITLE
[IMP] accounting/l10n: tell users to install l10n_fr_invoice_addr

### DIFF
--- a/content/applications/finance/fiscal_localizations/france.rst
+++ b/content/applications/finance/fiscal_localizations/france.rst
@@ -2,6 +2,11 @@
 France
 ======
 
+.. important::
+   You must :doc:`install <../../general/apps_modules>` the **France - Adding Mandatory Invoice
+   Mentions (Decree no. 2022-1299)** (`l10n_fr_invoice_addr`) module to comply with the `local
+   legislation <https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046383394>`_.
+
 .. _france/fec:
 
 FEC - Fichier des Écritures Comptables


### PR DESCRIPTION
In Odoo 15.0, an extra module is necessary to conform to the french legislation. This will tell users to install it.

task-3856826

**Community PR:** odoo/odoo#162458

Forward up to 15.4