### PR TITLE
Update Python tutorial link to the latest version

### DIFF
--- a/content/developer/tutorials/server_framework_101/01_architecture.rst
+++ b/content/developer/tutorials/server_framework_101/01_architecture.rst
@@ -27,7 +27,7 @@ level of Python. Advanced topics will require more knowledge in the other subjec
 plenty of tutorials freely accessible, so we cannot recommend one over another since it depends
 on your background.
 
-For reference this is the official `Python tutorial`_.
+For reference, this is the official `Python tutorial <https://docs.python.org/3/tutorial/index.html>`_.
 
 .. note::
   Since version 15.0, Odoo is actively transitioning to using its own in-house developed `OWL


### PR DESCRIPTION
This pull request updates the Python tutorial link to the latest version available at https://docs.python.org/3/tutorial/index.html. The old link was outdated, and this update ensures that users are directed to the most current tutorial.
