### PR TITLE
[IMP] Market Connectors: eBay marketplace edits.

### DIFF
--- a/content/applications/sales/sales/ebay_connector/manage.rst
+++ b/content/applications/sales/sales/ebay_connector/manage.rst
@@ -42,20 +42,27 @@ In order to list a product, select the :guilabel:`Sell on eBay` field on a produ
 name`. Click :guilabel:`Save` if necessary.
 
 .. image:: manage/manage-ebay-template.png
-  :align: center
-  :alt: The eBay template form listed in the product template in Odoo.
+   :align: center
+   :alt: The eBay template form listed in the product template in Odoo.
 
-When the :guilabel:`Use Stock Quantity` field is checked, the quantity set on eBay will be the Odoo
+When the :guilabel:`Use Stock Quantity` field is checked, the quantity set on eBay is the Odoo
 *Forecast Quantity* (Odoo *Inventory* app).
 
+The policies need to be set in order to be able to list on eBay. A value must be selected for the
+following fields :guilabel:`Payment Policy`, :guilabel:`Return Policy`, and :guilabel:`Shipping
+Policy`. The options are imported from the eBay database. If no option appears, they can be imported
+by navigating to :menuselection:`Sales app --> Configuration --> Settings --> eBay`, and clicking on
+the :guilabel:`Policies` button in the :guilabel:`Synchronization` field. This button **only**
+appears once the production and sandbox credentials have been set.
+
 The :guilabel:`Description Template` allows the administrator to use templates in listings. The
-default template only use the :guilabel:`eBay Description` field of the product. HTML can be used
-inside the :guilabel:`Description Template` and in the :guilabel:`eBay Description` in Odoo 14.
+default template only uses the :guilabel:`eBay Description` field of the product. HTML can be used
+inside the :guilabel:`Description Template`, and in the :guilabel:`eBay Description` in Odoo 14.
 Starting in Odoo 15, the powerbox feature is available to use in the template and description.
 Simply type a forward slash `/` to reveal a menu with formatting, layout, and text options. To add
 an image, type `/image`.
 
-To use images in the listing, another option is to add them as *Attachments* on the product
+To use images in the listing, an image needs to be added as one of the *Attachments* on the product
 template.
 
 .. seealso::


### PR DESCRIPTION
Added how to configure the policies of the product in order to prevent the error ```Input data for tag <Item.SellerProfiles.SellerPaymentProfile.PaymentProfileID> is invalid or missing.```from appearing when the user is listing the product. Also changed the section of listing images to indicate that they are necessary to prevent error ```A description is required.(106)Add at least 1 photo. More photos are better! Show off your item from every angle and zoom in on details.(21919136)``` from appearing. The first error is really common when a user is listing products and there have been multiple help tickets opened for the same reason