### PR TITLE
[IMP] surveys: add cards and links/intros

### DIFF
--- a/content/applications/marketing/surveys.rst
+++ b/content/applications/marketing/surveys.rst
@@ -15,6 +15,33 @@ shifting market trends.
 .. seealso::
    `Odoo Tutorials: Surveys <https://www.odoo.com/slides/surveys-62>`_
 
+.. cards::
+
+   .. card:: Create surveys
+      :target: surveys/create
+
+      Discover how to create surveys with Odoo.
+
+   .. card:: Scoring surveys
+      :target: surveys/scoring
+
+      Learn how to create and analyze survey scores with Odoo.
+
+   .. card:: Create questions
+      :target: surveys/questions
+
+      See how to create, configure, and customize all types of survey questions with Odoo.
+
+   .. card:: Live Session surveys
+      :target: surveys/live_session
+
+      Find out everything there is to know about Odoo's unique Live Session surveys.
+
+   .. card:: Survey analysis
+      :target: surveys/analysis
+
+      Explore the various ways to analyze surveys using Odoo's in-depth reporting pages.
+
 Dashboard
 =========
 
@@ -184,6 +211,53 @@ and the columns depict the various activity types.
 .. note::
    A new survey cannot be created in this view, as it is solely for the purpose of creating and
    viewing scheduled activities.
+
+Create surveys
+==============
+
+Learn about all the different options and configurations that can be utilized when creating a survey
+in Odoo.
+
+.. seealso::
+   :doc:`surveys/create`
+
+Scoring surveys
+===============
+
+Discover how to measure a survey participant's performance, or overall satisfaction, with Odoo's
+detailed (and fully customizable) survey scoring options.
+
+.. seealso::
+   :doc:`surveys/scoring`
+
+Create questions
+================
+
+With Odoo *Surveys*, there are many question types and options to choose from, providing the ability
+to create any kind of unique survey, questionnarire, and/or certification.
+
+.. seealso::
+   :doc:`surveys/questions`
+
+Live Session surveys
+====================
+
+The *Live Session* survey option available in Odoo can enhance in-person demonstrations and
+presentations, where participants' real-time responses can be used to dictate where the conversation
+goes next.
+
+.. seealso::
+   :doc:`surveys/live_session`
+
+Survey analysis
+===============
+
+Once the surveys start to come in, it is time to analyze the responses from your participants.
+Fortuantely, the in-depth reporting pages and options available in Odoo *Surveys* provide countless
+ways to examine everything related to surveys, and their submitted responses.
+
+.. seealso::
+   :doc:`surveys/analysis`
 
 .. toctree::
    :titlesonly:

--- a/redirects/17.0.txt
+++ b/redirects/17.0.txt
@@ -85,7 +85,6 @@ applications/marketing/marketing_automation/getting_started/first_campaign.rst a
 applications/marketing/marketing_automation/getting_started/target_audience.rst applications/marketing/marketing_automation/target_audience.rst           # getting_started/* --> marketing_automation/*
 applications/marketing/marketing_automation/getting_started/testing_running.rst applications/marketing/marketing_automation/testing_running.rst           # getting_started/* --> marketing_automation/*
 applications/marketing/marketing_automation/getting_started/workflow_activities.rst applications/marketing/marketing_automation/workflow_activities.rst   # getting_started/* --> marketing_automation/*
-applications/marketing/surveys/time_random.rst applications/marketing/surveys/questions.rst   # time_random --> questions
 applications/marketing/social_marketing/essentials.rst applications/marketing/social_marketing.rst                                                        # /marketing/social_marketing/essentials --> /marketing/social_marketing
 applications/marketing/social_marketing/essentials/social_posts.rst applications/marketing/social_marketing/social_posts.rst                              # /marketing/social_marketing/essentials --> /marketing/social_marketing
 applications/marketing/social_marketing/essentials/social_campaigns.rst applications/marketing/social_marketing/social_campaigns.rst                      # /marketing/social_marketing/essentials --> /marketing/social_marketing
@@ -95,6 +94,8 @@ applications/marketing/sms_marketing/essentials/sms_campaign_settings.rst applic
 applications/marketing/sms_marketing/essentials/mailing_lists_blacklists.rst applications/marketing/sms_marketing/mailing_lists_blacklists.rst            # /marketing/sms_marketing/essentials --> /marketing/sms_marketing
 applications/marketing/sms_marketing/pricing.rst applications/marketing/sms_marketing/pricing_and_faq.rst                                                 # /marketing/sms_marketing/pricing --> /marketing/sms_marketing
 applications/marketing/sms_marketing/pricing/pricing_and_faq.rst applications/marketing/sms_marketing/pricing_and_faq.rst                                 # /marketing/sms_marketing/pricing --> /marketing/sms_marketing
+applications/marketing/surveys/essentials.rst applications/marketing/surveys.rst 									  #/marketing/surveys/essentials --> /marketing/surveys
+applications/marketing/surveys/time_random.rst applications/marketing/surveys/questions.rst   # time_random --> questions
 
 # applications/sales
 


### PR DESCRIPTION
In an effort to clean up the look (and feel) of the Marketing scope of applications, I am creating this PR to add some linked cards to the main Surveys documentation page (like Email Marketing, Events, etc.). 

Not only does this help everything appear uniform, but adds a much-needed level of organization and eases the navigability of the documentation.

And, just like the Events doc, I am *also* adding individual sections (w/ accompanying explanations and links) to the other pages in the scope.

PROJECT TASK: https://www.odoo.com/odoo/project/3835/tasks/4056787?cids=3