### PR TITLE
Update reconciliation.rst

### DIFF
--- a/content/applications/finance/accounting/bank/reconciliation.rst
+++ b/content/applications/finance/accounting/bank/reconciliation.rst
@@ -13,7 +13,7 @@ matching entries automatically.
 
 .. seealso::
    - `Odoo Tutorials: Bank reconciliation
-     <https://www.odoo.com/slides/slide/bank-reconciliation-2724>`_
+     <https://www.odoo.com/slides/slide/bank-reconciliation-6562>`_
    - :doc:`bank_synchronization`
    - :doc:`transactions`
 


### PR DESCRIPTION
The link to the Tutorials is out of date

Because of this, when Users click it, they will be greeted with "You do not have permission to access this course."

This change resolves that with a link to the new Tutorial