### PR TITLE
[FIX] microsoft_outlook: redirect URL error if not matching

### DIFF
--- a/content/applications/general/email_communication/azure_oauth.rst
+++ b/content/applications/general/email_communication/azure_oauth.rst
@@ -34,14 +34,14 @@ registration`. On the :guilabel:`Register an application` screen, rename the :gu
 and personal Microsoft accounts (e.g. Skype, Xbox)`.
 
 Under the :guilabel:`Redirect URL` section, select :guilabel:`Web` as the platform, and then input
-`https://<odoo base url>/microsoft_outlook/confirm` in the :guilabel:`URL` field. The Odoo base URL
-is the canonical domain at which your Odoo instance can be reached in the URL field.
+`https://<web base url>/microsoft_outlook/confirm` in the :guilabel:`URL` field. The `web.base.url`
+is subject to change depending on the URL used to log in to the database.
 
-.. example::
-   *mydatabase.odoo.com*, where *mydatabase* is the actual prefix of the database's subdomain,
-   assuming it's hosted on Odoo.com
+.. note::
+   The documentation about the :ref:`web.base.url <domain-name/web-base-url>` explains how to freeze
+   a unique URL. It is also possible to add different redirect URLs on the Microsoft app.
 
-After the URL has been added to the field, :guilabel:`Register` the application so it is created.
+After the URL has been added to the field, :guilabel:`Register` the application, so it is created.
 
 API permissions
 ---------------


### PR DESCRIPTION
_compute_outlook_uri is using get_base_url, 
providing the web.base.url of the database 
that is subject to changed as stated 
on the website documentation: 
if the user logging-in is using another URL to connect to the db, 
and has the Administration/Settings 
access right (res.groups: base.group_system)

opw-4056377