### PR TITLE
[FIX] contributing: remove smart quotes

### DIFF
--- a/content/contributing/configure_git_authorship.rst
+++ b/content/contributing/configure_git_authorship.rst
@@ -3,5 +3,5 @@ address you used to register on GitHub.
 
 .. code-block:: console
 
-   $ git config --global user.name “Your Name”
-   $ git config --global user.email “youremail@example.com”
+   $ git config --global user.name "Your Name"
+   $ git config --global user.email "youremail@example.com"


### PR DESCRIPTION
There have been several new odooers who've hit legal/cla mismatches, and after investigation their email address would be smart quoted in git (e.g. `<“uid@example.org”>`).

That the documentation itself uses smart quotes is highly suspicious, it would make sense that new developers just pasted the provided command, updated it to match, and didn't even notice the quotes were wrong: `git` is perfectly happy with it, only on reading it back can you realise it's wrong and the guide doesn't say anything about *that*.

So fix the quotes in the doc, and hopefully that'll resolve the issue.