### PR TITLE
[IMP] iot: add connect printer note

### DIFF
--- a/content/applications/general/iot/devices/printer.rst
+++ b/content/applications/general/iot/devices/printer.rst
@@ -10,6 +10,13 @@ labels, orders, or even reports from the different Odoo apps. In addition, print
 assigned as an *action on a trigger* during the manufacturing process, or added onto a quality
 control point or a quality check.
 
+.. warning::
+   The **only** way to connect a printer directly to an Odoo database is through the use of an |iot|
+   box.
+
+   Without an |iot| box, printing can still occur, but it is managed through the printer itself,
+   which is not the recommended process.
+
 Connection
 ==========
 


### PR DESCRIPTION
Docs task: https://www.odoo.com/mail/view?model=project.task&res_id=4077635&access_token=e5b1e080-0c72-4177-b833-b94a859d545a

Adding a warning admonition to the Connect a Printer doc to clarify that printers can only be connected directly to Odoo through an Iot box. This is in response to a support ticket that prompted some questions about connecting printers out of the box.

