### PR TITLE
[IMP] sales: invoice status on SOs

### DIFF
--- a/content/applications/sales/sales/send_quotations/create_quotations.rst
+++ b/content/applications/sales/sales/send_quotations/create_quotations.rst
@@ -253,6 +253,25 @@ fields that can be configured.
   confirmation window appears, as well.
 - :guilabel:`Analytic Account`: Select an analytic account to apply to this customer/quotation.
 
+When :doc:`Debug mode is enabled <../../../general/developer_mode>`, additional fields appear in
+this section:
+
+- :guilabel:`Invoicing Journal`: The sales order invoices in the journal selected. When no selection
+  is made, the sales journal with the lowest sequence is used.
+- :guilabel:`Invoice Status`: This field **only** appears when the quotation is confirmed, and
+  becomes a sales order. One of the following options appear in this field, depending on its status:
+
+  - :guilabel:`Nothing to Invoice`: default value if other conditions are not met, or if the sales
+    order is still a quotation. For example, when the ordered quantity is more than the invoiced
+    quantity, but the *Invoicing Policy* of the product is set to *Based on Delivered Quantity
+    (Manual)* or *Delivered quantities*, and it has not been delivered yet.
+  - :guilabel:`To Invoice`: if invoiced quantity is not equal to what should be invoiced, which
+    depends on the *Invoicing Policy* set on the product form. For example, when the ordered
+    quantity is more than the invoiced quantity, or vice versa.
+  - :guilabel:`Upselling Opportunity`: **only** possible for a product with an *Invoicing Policy*
+    set to *Ordered quantities*, and more than the expected amount was delivered.
+  - :guilabel:`Fully Invoiced`: the quantity invoiced is equal to the ordered quantity.
+
 Tracking section
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
PROJECT TASK: https://www.odoo.com/odoo/project.task/4001061?cids=3

As requested in the Project Task, this PR adds information about the Invoice Status field on a Sales Order, which only appears in Debug mode. 

It also adds an explanation about the Invoicing Journal field that appears in Debug Mode, as well. 

Felt obligated to add the Invoicing Journal information because that is the only other field that appears in the Invoicing section of the Other Info tab (with Debug mode on)