### PR TITLE
[IMP] iot: remove connect printer to work center

### DIFF
--- a/content/applications/general/iot/devices/printer.rst
+++ b/content/applications/general/iot/devices/printer.rst
@@ -80,30 +80,6 @@ specific product.
    - :doc:`../../../inventory_and_mrp/quality/quality_management/quality_control_points`
    - :doc:`../../../inventory_and_mrp/quality/quality_management/quality_alerts`
 
-Link a printer to a work center
--------------------------------
-
-To link a printer to an action, it first needs to be configured on a work center. To do that,
-navigate to :menuselection:`Manufacturing app --> Configuration --> Work Centers`. From here, select
-the desired work center in which the printer will be used. Next, add the device in the
-:guilabel:`IoT Triggers` tab, under the :guilabel:`Device` column, by selecting :guilabel:`Add a
-Line`.
-
-Then, the printer can be linked to either of the following options in the :guilabel:`Actions`
-drop-down menu: :guilabel:`Print Labels`, :guilabel:`Print Operation`, or :guilabel:`Print Delivery
-Slip`. A key can also be added to trigger the action.
-
-.. important::
-   The first listed trigger on the form will be chosen first. So, the order matters, and these
-   triggers can be dragged into any order.
-
-.. note::
-   On the :guilabel:`Work Order` screen, a status graphic indicates whether the database is
-   correctly connected to the printer.
-
-.. seealso::
-   :ref:`workcenter_iot`
-
 .. _iot/link-printer:
 
 Link printer to reports


### PR DESCRIPTION
Docs task: ﻿[﻿https://www.odoo.com/mail/view?model=project.task&res_id=4088099&access_token=0b41c57f-694e-4a0c-adb3-b7df71eb3850﻿](https://www.odoo.com/mail/view?model=project.task&res_id=4088099&access_token=0b41c57f-694e-4a0c-adb3-b7df71eb3850)﻿

Removing section that instructs how to connect a printer to a work center in the manufacturing app.