### PR TITLE
[FIX] developer/reference/data: fix typo in data file example

### DIFF
--- a/content/developer/reference/backend/data.rst
+++ b/content/developer/reference/backend/data.rst
@@ -175,7 +175,7 @@ values).
 
   <odoo>
       <data noupdate="1">
-          <record name="partner_1" model="res.partner">
+          <record id="partner_1" model="res.partner">
               <field name="name">Odude</field>
           </record>
 


### PR DESCRIPTION
The attribute of `record` data operations should be `id` and not `name`.