### PR TITLE
Refactor. XMLParser changed as parseXML.

### DIFF
--- a/content/developer/howtos/javascript_view.rst
+++ b/content/developer/howtos/javascript_view.rst
@@ -201,9 +201,9 @@ Creating a new view is an advanced topic. This guide highlight only the essentia
 
       /** @odoo-module */
 
-      import { XMLParser } from "@web/core/utils/xml";
+      import { parseXML } from "@web/core/utils/xml";
 
-      export class BeautifulArchParser extends XMLParser {
+      export class BeautifulArchParser extends parseXML {
           parse(arch) {
               const xmlDoc = this.parseXML(arch);
               const fieldFromTheArch = xmlDoc.getAttribute("fieldFromTheArch");


### PR DESCRIPTION

In this PR changed the parseXML Instead of XMLParser.

While using the XMLParser , we may face the 
" TypeError: Class extends value undefined is not a constructor or null"

Instead of using the ~XMLParser~ , we can use **parseXML** to avoid the _TypeError_ in OWL.

![image](https://github.com/user-attachments/assets/b0d459ab-30b9-43a3-9c64-2d2aa26fa41f)
