### PR TITLE
[IMP] l10n_pe : Export Invoice section

### DIFF
--- a/content/applications/finance/fiscal_localizations/peru.rst
+++ b/content/applications/finance/fiscal_localizations/peru.rst
@@ -524,7 +524,7 @@ chatter indicating the correct Government validation.
 .. warning::
    One credit is consumed on each cancellation request.
 
-Cancellation process
+Export invoices
 ********************
 
 When creating exportation invoices, take into account the next considerations:


### PR DESCRIPTION
- Correct the **tittle** of the _exporting invoicing section_
- Current: the section is using with the wrong tittle (and a duplicate keyword on the user doc )