### PR TITLE
[IMP] surveys: add text/website theme info

### DIFF
--- a/content/applications/marketing/surveys/questions.rst
+++ b/content/applications/marketing/surveys/questions.rst
@@ -331,3 +331,7 @@ Time Limit`.
 
 When the :guilabel:`Question Time Limit` option is enabled, designate how much time (in
 :guilabel:`seconds`) participants have to answer the question during a *Live Session* survey.
+
+.. note::
+   Survey text colors are directly linked to the colors used for the :doc:`website theme
+   <../../websites/website/web_design/themes>`.


### PR DESCRIPTION
PROJECT (request) TASK: https://www.odoo.com/odoo/project.task/4072674

This brief PR adds some requested information (at the end of the questions.rst doc) to let readers/users know about how survey text colors are directly related to the theme colors chosen on the Odoo-built website. As requested by AUVA