### PR TITLE
[FIX] reference/view_architectures: remove outdated and broken link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -391,6 +391,9 @@ def setup(app):
     app.add_config_value('is_remote_build', None, 'env')  # Whether the build is remotely deployed
     app.add_config_value('source_read_replace_vals', {}, 'env')
     app.connect('source-read', source_read_replace)
+    # TODO uncomment after moving to >= v7.2.5 to also substitute placeholders in included  files.
+    #  See https://github.com/sphinx-doc/sphinx/commit/ff1831
+    #  app.connect('include-read', source_read_replace)
 
     app.add_lexer('json', JsonLexer)
     app.add_lexer('xml', XmlLexer)

--- a/content/developer/reference/user_interface/view_architectures/root_attribute_banner_route.rst
+++ b/content/developer/reference/user_interface/view_architectures/root_attribute_banner_route.rst
@@ -10,13 +10,8 @@
    If the HTML contains a `<link>` tag for a stylesheet, it is removed from its original location
    and appended to the `<head>` section.
 
-   To interact with the backend, use `<a type="action">` tags. For more details, refer to the
-   documentation of the `_onActionClicked` method in `AbstractController
-   <{GITHUB_PATH}/addons/web/static/src/js/views/abstract_controller.js>`_.
-
-   Only views extending `AbstractView` and `AbstractController`, such as
-   :ref:`reference/view_architectures/form`, :ref:`reference/view_architectures/kanban`, and
-   :ref:`reference/view_architectures/list`, can use this attribute.
+   Use `<a type="action">` tags to interact with the backend, like with :ref:`action buttons
+   <reference/view_architectures/form/button>`.
 
    .. example::
       .. code-block:: xml


### PR DESCRIPTION
The external link to `AbstractController` class was broken, both because the placeholder substitution mechanism doesn't work in included RST excerpts and because the class has long been removed.

Since it makes little sense to replace the link with another link to the `useActionLinks` hook in the context of this reference doc, this commit removes the link altogether, as well as the erroneous mention of class limitations.