### PR TITLE
[FIX] add missing language names to the language switcher

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -252,11 +252,13 @@ languages_names = {
     'es': 'ES',
     'fr': 'FR',
     'it': 'IT',
+    'ja': 'JA',
     'ko': 'KO',
     'nl': 'NL',
     'pt_BR': 'PT',
     'ro': 'RO',
     'sv': 'SV',
+    'th': 'TH',
     'uk': 'UA',
     'zh_CN': 'ZH (CN)',
     'zh_TW': 'ZH (TW)'


### PR DESCRIPTION
Even though the Thai documentation has been built and is available, it didn't show up in the language switcher. This is because it needs to be given a "language name" first.

This commis add the language names corresponding to the newly added translations (namely, into Thai and Japanese).