### PR TITLE
[IMP] subscriptions: parent doc restructure

### DIFF
--- a/content/applications/sales/subscriptions.rst
+++ b/content/applications/sales/subscriptions.rst
@@ -4,24 +4,67 @@
 Subscriptions
 =============
 
-Odoo *Subscriptions* is used to run recurring businesses: :ref:`sell new contracts
-<subscriptions/quotations>`, :doc:`upsell customers </applications/sales/subscriptions/upselling>`,
-keep the churn under control, and :doc:`generate reports
-</applications/sales/subscriptions/reports>` on the main :abbr:`KPIs (Key Performance Indicators)`:
-:abbr:`MRR (Monthly Recurring Revenue)`, :abbr:`ARR (Annual Recurring Revenue)`, retention, churn,
-etc.
+Use Odoo **Subscriptions** to manage everything related to recurring businesses: :ref:`sell new
+contracts <subscriptions/quotations>`, :doc:`upsell customers
+</applications/sales/subscriptions/upselling>`, and keep the churn under control.
+
+With Odoo **Subscriptions**, :doc:`generate reports </applications/sales/subscriptions/reports>` on
+the main :abbr:`KPIs (Key Performance Indicators)`: :abbr:`MRR (Monthly Recurring Revenue)`,
+:abbr:`ARR (Annual Recurring Revenue)`, retention, churn, and more.
 
 .. seealso::
    - `Odoo Tutorials: Subscriptions <https://www.odoo.com/slides/subscription-20>`_
-   - :doc:`/applications/sales/subscriptions/products`
-   - :doc:`/applications/sales/subscriptions/ecommerce`
-   - :doc:`/applications/sales/subscriptions/plans`
-   - :doc:`/applications/sales/subscriptions/upselling`
-   - :doc:`/applications/sales/subscriptions/renewals`
-   - :doc:`/applications/sales/subscriptions/closing`
-   - :doc:`/applications/sales/subscriptions/automatic_alerts`
-   - :doc:`/applications/sales/subscriptions/scheduled_actions`
-   - :doc:`/applications/sales/subscriptions/reports`
+
+.. cards::
+
+   .. card:: Subscription products
+      :target: subscriptions/products
+
+      Discover how to create subscription products.
+
+   .. card:: Subscriptions in the eCommerce shop
+      :target: subscriptions/ecommerce
+
+      Learn how to sell subscription products in the Odoo eCommerce shop.
+
+   .. card:: Subscription plans
+      :target: subscriptions/plans
+
+      Apply specific quotation templates are used to preconfigure quotations for subscription
+      products.
+
+   .. card:: Upsell subscriptions
+      :target: subscriptions/upselling
+
+      Explore the various ways to upsell customers on their subscriptions.
+
+   .. card:: Renew subscriptions
+      :target: subscriptions/renewals
+
+      Process subscription renewals automatically or manually, include additional products, upsell,
+      and more.
+
+   .. card:: Close subscriptions
+      :target: subscriptions/closing
+
+      Decide whether customers should self-manage their subscriptions, or restrict their ability to
+      do so.
+
+   .. card:: Automation rules
+      :target: subscriptions/automatic_alerts
+
+      Utilize custom automation rules to set up emails, create tasks for salespeople, and even send
+      satisfaction surveys to evaluate their experience.
+
+   .. card:: Scheduled actions
+      :target: subscriptions/scheduled_actions
+
+      Automate certain tasks within a database using preconfigured processes.
+
+   .. card:: Subscription reports
+      :target: subscriptions/reports
+
+      Analyze subscription performance with reporting pages provided by Odoo.
 
 .. _subscriptions/quotations:
 
@@ -29,18 +72,18 @@ Subscription quotations
 =======================
 
 .. important::
-   Sales orders with a defined recurrence become subscriptions.
+   Sales orders with a defined *Recurring Plan* become subscriptions.
 
-To create a new subscription, click on :guilabel:`New` from the *Subscription* or the :doc:`Sales
-</applications/sales>` app. You can either:
+To create a new subscription, click on :guilabel:`New` from the **Subscriptions** or the :doc:`Sales
+</applications/sales>` app. Then, from the resulting quotation, either:
 
-- Select a :doc:`subscription plan </applications/sales/subscriptions/plans>` to prefill the
-  quotation instantly, or
-- Fill out the quotation normally, making sure to select a recurrence and an end date if necessary
-  and adding :doc:`recurrent products </applications/sales/subscriptions/products>`.
+- Select a :doc:`subscription plan </applications/sales/subscriptions/plans>` to auto-populate the
+  quotation instantly.
+- Or, fill out the quotation normally, making sure to select a recurrence, specify an end date (if
+  necessary), and add :doc:`recurrent products </applications/sales/subscriptions/products>`.
 
 .. tip::
-   You can define different invoice and delivery addresses by enabling the :doc:`Customer Addresses
+   Define different invoice and delivery addresses by enabling the :doc:`Customer Addresses
    </applications/finance/accounting/customer_invoices/customer_addresses>` feature.
 
 .. _subscriptions/confirmation:
@@ -48,32 +91,32 @@ To create a new subscription, click on :guilabel:`New` from the *Subscription* o
 Confirmation
 ============
 
-Send the quotation to the customer for confirmation by clicking on :guilabel:`Send by email`, or
-confirm it immediately by clicking on :guilabel:`Confirm`.
+Send the quotation to the customer for confirmation by clicking :guilabel:`Send by Email`, or
+confirm it immediately by clicking :guilabel:`Confirm`.
 
 .. tip::
-   Click on :guilabel:`Customer Preview` to preview the customer portal where the customer can view
-   their quotation, sign and pay it, and communicate with you.
+   Click :guilabel:`Customer Preview` to preview the quote from the customer's point-of-view. From
+   there, customers can sign and pay, as well as message the company, if needed.
 
 .. _subscriptions/automatic-payments:
 
 Automatic payments
 ==================
 
-You can require the customer to set an automatic payment method and pre-pay the subscription's first
+Require the customer to set up an automatic payment method, and pre-pay the subscription's first
 occurrence before they can confirm their quotation. To do so, go to the :guilabel:`Other Info` tab
-of the quotation and check the :guilabel:`Payment` option in the :guilabel:`Online confirmation`
-field.
+of the quotation form, and tick the :guilabel:`Online payment` checkbox. Then, designate what
+percentage of the total should be paid.
 
-If you leave :guilabel:`Payment` unchecked, the customer doesn't have to pre-pay to start the
-subscription. This means that the payment is not automatic and that the customer must pay each
+If you leave :guilabel:`Online payment` unchecked, the customer does not have to pre-pay to start
+the subscription. This means the payment is *not* automatic, and the customer **must** pay each
 invoice manually.
 
 .. important::
-   If the online confirmation requires a pre-payment, your customer can select only the
+   If the online confirmation requires pre-payment, the customer can **only** select
    :ref:`payment providers <payment_providers/supported_providers>` that have the :ref:`tokenization
-   feature <payment_providers/tokenization>`. This ensures that the customer is automatically
-   charged at each new period.
+   feature <payment_providers/tokenization>`. This ensures the customer is automatically charged at
+   each new period.
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
PROJECT TASK: https://www.odoo.com/odoo/project/3835/tasks/4118666

In an effort to clean up the look (and feel) of the Marketing scope of applications, I am creating this PR to add intro content to the main Subscriptions element on the toctree, add some linked cards

Not only does this help everything appear uniform, but adds a much-needed level of organization and eases the navigability of the documentation. It also sets the table quite nicely for v18.