### PR TITLE
[FIX] change the display name of Korean to KR in the switcher

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -232,7 +232,7 @@ languages_names = {
     'es': 'ES',
     'fr': 'FR',
     'it': 'IT',
-    'ko': 'KO',
+    'ko': 'KR',
     'nl': 'NL',
     'pt_BR': 'PT',
     'ro': 'RO',


### PR DESCRIPTION
According to feedback from our Korean translator,the abbreviation for Korean is usually KR instead of KO.

This commit updates the name of the language as displayed in the language switcher.