### PR TITLE
[IMP] base, account: `refs` for multiple records retrieval

### DIFF
--- a/content/developer/reference/backend/orm/changelog.rst
+++ b/content/developer/reference/backend/orm/changelog.rst
@@ -10,6 +10,9 @@ Odoo Online version 18.1
 - Declare constraints and indexes as model attributes with `#175783 <https://github.com/odoo/odoo/pull/175783>`_.
 - The `json` controllers have been renamed to `jsonrpc`. They are called the same, only the
   `type` in the python files changed. See `#183636 <https://github.com/odoo/odoo/pull/183636>`_.
+- Method :meth:`~odoo.api.Environment.ref` now accepts a variadic sequence of arguments `xml_ids`,
+  and argument `raise_if_not_found` now is a keyword-only argument. See `#179692 <https://github.com/odoo/odoo/pull/179692>`_.
+
 
 Odoo version 18.0
 =================


### PR DESCRIPTION
The `ref` method both in Environment and in ChartTemplate can now accept multiple `xml_ids`, reducing the number of queries necessary. The `xml_ids` must all refer to the same model, or `ValueError` is raised.
`raise_if_not_found` argument is made a keyword-only argument so now it's mandatory for the function calls to include the argument name.


Community PR: odoo/odoo#179692
Enterprise PR: odoo/enterprise#69800

![immagine](https://github.com/user-attachments/assets/24516bc5-107a-43e7-ab17-9a46902b2ea3)
![immagine](https://github.com/user-attachments/assets/7c1ca329-f844-4bdb-9c2b-b1bc0688dea2)
