### PR TITLE
Update websites.po

### DIFF
--- a/locale/fr/LC_MESSAGES/websites.po
+++ b/locale/fr/LC_MESSAGES/websites.po
@@ -3887,10 +3887,12 @@ msgid ""
 ":guilabel:`Prerequisites`: set one or more courses that users are advised to"
 " complete before"
 msgstr ""
+":guilabel:`Prérequis`: définissez un ou plusieurs cours que les utilisateurs sont invités à"
+" compléter avant"
 
 #: ../../content/applications/websites/elearning.rst:107
 msgid "accessing your course;"
-msgstr ""
+msgstr "d'accéder à votre cours;"
 
 #: ../../content/applications/websites/elearning.rst:108
 msgid ""


### PR DESCRIPTION
![french_translation](https://github.com/user-attachments/assets/02bf05a7-2abc-4867-a46d-ce1817c0cc3a)

Add missing French translation in:
https://www.odoo.com/documentation/17.0/fr/applications/websites/elearning.html#access-rights