### PR TITLE
Removed "See Also Odoo Tutorial"

### DIFF
--- a/content/applications/finance/accounting/customer_invoices/terms_conditions.rst
+++ b/content/applications/finance/accounting/customer_invoices/terms_conditions.rst
@@ -8,9 +8,6 @@ return and refunds, warranty, and after-sale services.
 You can add default terms and conditions at the bottom of all customer invoices, sales orders, and
 quotations, either as text or a link to a web page.
 
-.. seealso::
-   `Odoo Tutorial: Terms & Conditions <https://www.odoo.com/slides/slide/terms-conditions-1680>`_
-
 Configuration
 =============
 


### PR DESCRIPTION
The linked page yields an error message:
"You do not have permission to access this course." 

The error message is yielded as:
- a guest
- an average joe registered user

My fix proposal is to just remove the link from the docs altogether. Alternatively Odoo could make the linked tutorial publicly accessible if it's part of the public docs.