### PR TITLE
[IMP] inventory: fix typos in shipping table

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration/third_party_shipper.rst
+++ b/content/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration/third_party_shipper.rst
@@ -30,14 +30,14 @@ The following is a list of available shipping connectors in Odoo:
      - Region availability
    * - FedEx
      - All
-   * - :doc:`DHL Express* <dhl_credentials>`
+   * - :doc:`DHL Express <dhl_credentials>`
      - All
    * - :doc:`UPS <ups_credentials>`
      - All
    * - US Postal Service
      - United States of America
    * - :doc:`Sendcloud <sendcloud_shipping>`
-     - :ref:`EU** <inventory/shipping_receiving/sendcloud-eu>`
+     - Some European countries (see details below)
    * - Bpost
      - Belgium
    * - Easypost
@@ -45,13 +45,10 @@ The following is a list of available shipping connectors in Odoo:
    * - Shiprocket
      - India
 
-.. _inventory/shipping_receiving/sendcloud-eu:
-
 .. important::
+   Other services from DHL are **not** supported.
 
-   \* Other services from DHL are **not** supported.
-
-   ** Sendcloud currently supports shipping **from** Austria, Belgium, France, Germany, Italy, the
+   Sendcloud currently supports shipping **from** Austria, Belgium, France, Germany, Italy, the
    Netherlands, Spain, and the United Kingdom, and **to** any European country.
 
 Configuration


### PR DESCRIPTION
Remove EU link.
In versions 17+, also change the spelling of "Australasia" to "Australia and New Zealand" for clarity. (will apply these changes in the fwport)

Fwport: all the way to master