### PR TITLE
[IMP] l10n_br: IAP Free Credits Clarification

### DIFF
--- a/content/applications/finance/fiscal_localizations/brazil.rst
+++ b/content/applications/finance/fiscal_localizations/brazil.rst
@@ -136,6 +136,7 @@ Correction letter, Invalidate invoice number range), an API call is made using c
 .. note::
    - Odoo is a certified partner of Avalara Brazil.
    - You can `buy IAP credit on odoo.com <https://iap.odoo.com/iap/in-app-services/819>`_.
+   - On creation, new databases receive 500 free credits.
 
 Credential configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Odoo gives users 500 free IAP credits when they start with Odoo in BR in production databases. This is an important information that was not clarified.