### PR TITLE
[IMP] accounting: ca_l10n spelling fix

### DIFF
--- a/content/applications/finance/fiscal_localizations/canada.rst
+++ b/content/applications/finance/fiscal_localizations/canada.rst
@@ -139,7 +139,7 @@ Positions`.
 The following fiscal positions are available by default:
 
 - :guilabel:`Alberta (AB)`
-- :guilabel:`British Colombia (BC)`
+- :guilabel:`British Columbia (BC)`
 - :guilabel:`Manitoba (MB)`
 - :guilabel:`New Brunswick (NB)`
 - :guilabel:`Newfoundland and Labrador (NL)`


### PR DESCRIPTION
> Hi! In docs we have "British Colombia" instead of "British Columbia" https://www.odoo.com/documentation/18.0/applications/finance/fiscal_localizations/canada.html