### PR TITLE
[IMP] contributing/git: add [PERF] to the valid commit tags

### DIFF
--- a/content/contributing/development/git_guidelines.rst
+++ b/content/contributing/development/git_guidelines.rst
@@ -65,6 +65,7 @@ Tags are used to prefix your commit. They should be one of the following
   main commit for feature involving several separated commits;
 - **[CLA]** for signing the Odoo Individual Contributor License;
 - **[I18N]** for changes in translation files;
+- **[PERF]** for performance patches;
 
 After tag comes the modified module name. Use the technical name as functional
 name may change with time. If several modules are modified, list them or use


### PR DESCRIPTION
The [PERF] commit tag passes the runbot minimal check and has been used in lots of patches. E.g.
 - odoo/odoo@f02bcfadcbb66fb237a5af3a10a35e36355b8b2e
 - odoo/odoo@b30b05989824b82dda18129d38b42c0cd2717b31
 - odoo/odoo@780a2bb601cccd855c5167b07b0fac26ad474957

However this tag was not listed in the documentation yet. This led to confusion for reviewers not accustomed with it. 
This PR fixes that.