### PR TITLE
[FIX] tutorials: explicit translation function example

### DIFF
--- a/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
+++ b/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
@@ -460,8 +460,8 @@ Here is a list of some small improvements you could try to do if you have the ti
 
 .. seealso::
    - `Example: use of env._t function
-     <https://github.com/odoo/odoo/blob/1f4e583ba20a01f4c44b0a4ada42c4d3bb074273/
-     addons/account/static/src/components/bills_upload/bills_upload.js#L64>`_
+     <https://github.com/odoo/odoo/blob/457836d19b865fc2f6b9dc3216c1de715e0d7c31/
+     addons/account/static/src/components/bills_upload/bills_upload.js#L116>`_
    - `Code: translation code in web/
-     <https://github.com/odoo/odoo/blob/1f4e583ba20a01f4c44b0a4ada42c4d3bb074273/
-     addons/web/static/src/core/l10n/translation.js#L16>`_
+     <https://github.com/odoo/odoo/blob/457836d19b865fc2f6b9dc3216c1de715e0d7c31/
+     addons/web/static/src/core/l10n/translation.js#L22>`_


### PR DESCRIPTION
This PR fixes the explicit export translation function example and definition links in the `Chapter 2: Build a dashboard` developer tutorial's `12. Going further` section seealso- currently they lead to a 404 and are outdated.

Please let me know if there is a more relevant / accurate example to link than what I have in this PR :)

Changes:
1. [addons/account/static/src/components/bills_upload/bills_upload.js#L64](https://github.com/odoo/odoo/blob/1f4e583ba20a01f4c44b0a4ada42c4d3bb074273/addons/account/static/src/components/bills_upload/bills_upload.js#L64) ➡️ [addons/account/static/src/components/bills_upload/bills_upload.js#L116](https://github.com/odoo/odoo/blob/457836d19b865fc2f6b9dc3216c1de715e0d7c31/addons/account/static/src/components/bills_upload/bills_upload.js#L116)
2. [addons/web/static/src/core/l10n/translation.js#L16](https://github.com/odoo/odoo/blob/1f4e583ba20a01f4c44b0a4ada42c4d3bb074273/addons/web/static/src/core/l10n/translation.js#L16) ➡️ [addons/web/static/src/core/l10n/translation.js#L22](https://github.com/odoo/odoo/blob/457836d19b865fc2f6b9dc3216c1de715e0d7c31/addons/web/static/src/core/l10n/translation.js#L22)