### PR TITLE
[IMP] developer: added "--shell-file" CLI option

### DIFF
--- a/content/developer/reference/cli.rst
+++ b/content/developer/reference/cli.rst
@@ -695,10 +695,16 @@ interaction with the :ref:`orm <reference/orm>` and its functionalities.
       By default, the shell is running in transaction mode. This means that any change made to the
       database is rolled back when exiting the shell. To commit changes, use `env.cr.commit()`.
 
+
+.. option:: --shell-file <init_script.py>
+
+   Specify a Python script to be run after the start of the shell. Overrides the environment
+   variable `PYTHONSTARTUP`.
+
 .. option:: --shell-interface (ipython|ptpython|bpython|python)
 
-   Specify a preferred REPL to use in shell mode. This shell is started with the `env` variable
-   already initialized to be able to access the ORM and other Odoo modules.
+   Specify a preferred `REPL` to use in shell mode. This shell is started with the `env` variable
+   already initialized to be able to access the `ORM` and other Odoo modules.
 
 .. seealso::
    :ref:`reference/orm/environment`


### PR DESCRIPTION
Added the description for the new `--shell-file` option, which overrides the the `$PYTHONSTARTUP` env variable to initialize the shell session with a startup Python script.

Related docs: https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSTARTUP

Community PR: odoo/odoo#185075
Task [link](https://www.odoo.com/odoo/project/967/tasks/4306704)
task-4306704