### PR TITLE
[FIX] accounting: fix broken OCR tutorial link

### DIFF
--- a/content/applications/finance/accounting/vendor_bills/invoice_digitization.rst
+++ b/content/applications/finance/accounting/vendor_bills/invoice_digitization.rst
@@ -11,8 +11,8 @@ created and populated based on the scanned invoices.
 
 .. seealso::
    - `Test Odoo's invoice digitization <https://www.odoo.com/app/invoice-automation>`_
-   - `Odoo Tutorials: Invoice Digitization with OCR
-     <https://www.odoo.com/slides/slide/digitize-bills-with-ocr-1712>`_
+   - `Odoo Tutorials: Vendor Bill Digitization
+     <https://www.odoo.com/slides/slide/vendor-bill-digitization-7065>`_
 
 Configuration
 =============


### PR DESCRIPTION
Fixes broken link on [AI-powered document digitization doc](https://www.odoo.com/documentation/16.0/applications/finance/accounting/vendor_bills/invoice_digitization.html), starting at 16.0, to be forward-ported all the way to master.

![image](https://github.com/user-attachments/assets/4687314c-d2ef-43a4-91a8-efea82d0cca3)
