### PR TITLE
[FIX] administration/on-premise: Incorrect ports

### DIFF
--- a/content/administration/on_premise.rst
+++ b/content/administration/on_premise.rst
@@ -61,8 +61,8 @@ To resolve the issue:
   your **network and firewall settings** allow the Odoo server to open outgoing connections
   towards:
 
-  - Odoo 18.0 and above: `services.odoo.com` on port `443` (or `80`)
-  - Odoo 17.0 and below: `services.openerp.com` on port `443` (or `80`)
+  - Odoo 18.0 and above: `services.odoo.com` on port `80`
+  - Odoo 17.0 and below: `services.openerp.com` on port `80`
 
   These ports must be kept open even after registering a database, as the update notification runs
   once a week.


### PR DESCRIPTION
In Odoo 18 and lower versions, update notifications are sent over HTTP, not HTTPS:

Odoo 18: https://github.com/odoo/odoo/blob/bbcafb7bb15eb324a8ce9bc41e3a6762469134fe/odoo/tools/config.py#L78
Odoo 17: https://github.com/odoo/odoo/blob/a7ccd81fb2a67dfeb544efce2ff1ce892b938954/odoo/tools/config.py#L78
Odoo 16: https://github.com/odoo/odoo/blob/6b5a839428b06e09d90631e9824a9b594ff8f4f5/odoo/tools/config.py#L78

The documentation has listed 443 as the main port since 2019: https://github.com/odoo/documentation/pull/324 , but what it mentions about the most recent version of Odoo using services.odoo.com wasn't true until Odoo 18: https://github.com/odoo/odoo/pull/163202 . That PR kept the HTTP usage and not HTTPS as was originally intended: https://github.com/odoo/odoo/pull/30272 .