### PR TITLE
[FIX] Upgrade: Correct URL and text for post-upgrade issues

### DIFF
--- a/content/administration/upgrade.rst
+++ b/content/administration/upgrade.rst
@@ -390,8 +390,8 @@ few exceptions.
          filestore before deploying the new version.
 
 In case of an issue with your production database, you can request the assistance of Odoo by going
-to the `Support page and selecting "An issue related to my future upgrade (I am testing an upgrade)"
-<https://www.odoo.com/help?stage=migration>`_.
+to the `Support page and selecting "An issue related to my upgrade (production)"
+<https://www.odoo.com/help?stage=post_upgrade>`_.
 
 .. _upgrade-sla:
 


### PR DESCRIPTION
As stated on the sentence above, in case of an issue with the **production** database, we should open a ticket with the label (production) and not testing an upgrade.

This commits adapt the test to match the label currently present on odoo.com/help and the URL to pre-select the correct stage as well