### PR TITLE
Update PWA instructions

### DIFF
--- a/content/administration/mobile.rst
+++ b/content/administration/mobile.rst
@@ -25,10 +25,10 @@ instructions to install a PWA depend on the platform and browser used.
 
    .. tab:: Android
 
-      **Chrome**: open Chrome's menu (:guilabel:`⋮`), select :guilabel:`Install app`, and tap
+      **Chrome**: open Chrome's menu (:guilabel:`⋮`), select :guilabel:`Add to home screen`, and tap
       :guilabel:`Install`.
 
-      **Firefox**: open Firefox's menu (:guilabel:`⋮`), select :guilabel:`Install`, and either touch
+      **Firefox**: open Firefox's menu (:guilabel:`⋮`), select :guilabel:`Add to Home screen`, and either touch
       and hold the Odoo icon or tap :guilabel:`Add automatically`.
 
       The PWA can also be installed with **Samsung Internet**, **Edge**, and **Opera**.


### PR DESCRIPTION
- In both Chrome and Firefox, the button to install PWAs has changed from 'Install' to 'Add to home screen' https://support.google.com/chrome/answer/9658361?co=GENIE.Platform%3DAndroid&oco=1