### PR TITLE
Update packages.rst command change for dnf addrepo

### DIFF
--- a/content/administration/on_premise/packages.rst
+++ b/content/administration/on_premise/packages.rst
@@ -81,7 +81,7 @@ the following commands:
 
       .. code-block:: console
 
-         $ sudo dnf config-manager --add-repo=https://nightly.odoo.com/{CURRENT_MAJOR_BRANCH}/nightly/rpm/odoo.repo
+         $ sudo dnf config-manager addrepo --from-repofile=https://nightly.odoo.com/master/nightly/rpm/odoo.repo
          $ sudo dnf install -y odoo
          $ sudo systemctl enable odoo
          $ sudo systemctl start odoo


### PR DESCRIPTION
It could help, I have noticed this command change.

For info, a trace of the command:
phe@fedora:~/Gits/odoo-tutorials (18.0)$ sudo dnf5 config-manager addrepo --from-repofile=https://nightly.odoo.com/master/nightly/rpm/odoo.repo 
 https://nightly.odoo.com/master/nightly/rpm/odoo.repo    100% | 728.0   B/s | 158.0   B |  00m00s
phe@fedora:~/Gits/odoo-tutorials (18.0)$ 