### PR TITLE
Update 02_build_a_dashboard.rst

### DIFF
--- a/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
+++ b/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
@@ -199,21 +199,23 @@ Let's improve the dashboard by adding a few dashboard items to display *real* bu
 The `awesome_dashboard` addon provides a `/awesome_dashboard/statistics` route that is meant
 to return some interesting information.
 
-To call a specific controller, we need to use the :ref:`rpc service <frontend/services/rpc>`.
-It only exports a single function that perform the request: :code:`rpc(route, params, settings)`.
+To call a specific controller, we need to use the *rpc* function from `@web/core/network/rpc`.
+The `rpc` function takes a route as an argument and performs the request: :code:`rpc(route, params, settings)`.
+You can also pass `params` and `settings` as *optional* arguments.
 A basic request could look like this:
 
 .. code-block:: js
 
+   import { rpc } from "@web/core/network/rpc";
+   ...
    setup() {
-         this.rpc = useService("rpc");
          onWillStart(async () => {
-            const result = await this.rpc("/my/controller", {a: 1, b: 2});
+            const result = await rpc("/my/controller", {a: 1, b: 2});
             // ...
          });
    }
 
-#. Update `Dashboard` so that it uses the `rpc` service.
+#. Update `Dashboard` so that it uses the `rpc` function.
 #. Call the statistics route `/awesome_dashboard/statistics` in the `onWillStart` hook.
 #. Display a few cards in the dashboard containing:
 
@@ -227,7 +229,7 @@ A basic request could look like this:
    :align: center
 
 .. seealso::
-   `Code: rpc service <{GITHUB_PATH}/addons/web/static/src/core/network/rpc_service.js>`_
+   `Code: rpc function <{GITHUB_PATH}/addons/web/static/src/core/network/rpc.js>`_
 
 5. Cache network calls, create a service
 ========================================


### PR DESCRIPTION
The useService("rpc") function is deprecated in odoo 18.

Now, the default way to call a controller which is not associated with a model is using the rpc function located in the web/static/src/core/network/rpc.js.

Therefore updated the "4. Call the server, add some statistics"  section to reflect the correct references in the odoo 18 tutorials/discover_js_framework docs.