### PR TITLE
[FIX] payment_providers/xendit: remove step to enable optional 3ds

### DIFF
--- a/content/applications/finance/payment_providers/xendit.rst
+++ b/content/applications/finance/payment_providers/xendit.rst
@@ -33,8 +33,6 @@ Configuration on the Xendit Dashboard
 #. In the :guilabel:`Webhook URL` section, enter your Odoo database's URL, followed by
    `/payment/xendit/webhook` (e.g., `https://example.odoo.com/payment/xendit/webhook`) in the field
    :guilabel:`Invoices paid` and click the :guilabel:`Test and save` button next to it.
-#. Navigate to the `Card Settings page <https://dashboard.xendit.co/settings/payment-methods/cards-configuration>`_
-   and ensure that :guilabel:`Optional 3DS` is enabled while :guilabel:`Dynamic 3DS` is disabled.
 
 Configuration on Odoo
 =====================


### PR DESCRIPTION
Enabling optional 3DS should not part of the official step. This configuration
is specific to cards payment, by default should perform 3DS, and only eligible
merchant able to perform cards payment with optional 3DS enabled.