### PR TITLE
[IMP] account_reports: Unambiguous cross_report aggregations

### DIFF
--- a/content/applications/finance/accounting/reporting/customize.rst
+++ b/content/applications/finance/accounting/reporting/customize.rst
@@ -173,7 +173,8 @@ expression's **label** (ex. **code.label**).
 `CUR` is the currency code in capital letters, and `amount` is the amount of the bound expressed in
 that currency.
 
-You can also use the `cross_report` subformula to match an expression found in another report.
+`cross_report(xml_id | report_id)`
+   Used to match an expression from another report targeted by the xml_id or the report ID itself.
 
 'Prefix of Account Codes' engine
 --------------------------------


### PR DESCRIPTION
Before this commit, when using cross_report subformula it would search for a report that has an line with this code. We had to ensure there was no duplicate codes and so it was difficult to maintain.

Now, when we use a cross_report subformula, we need to explicitly target the report from where the code is from.

task-4457667