### PR TITLE
[FIX] l10n_my: MyInvois credential update for preproduction

### DIFF
--- a/content/applications/finance/fiscal_localizations/malaysia.rst
+++ b/content/applications/finance/fiscal_localizations/malaysia.rst
@@ -104,7 +104,10 @@ portal to grant Odoo the **right to invoice** as an intermediary for your compan
 
    - :guilabel:`TIN`: `C57800417080`
    - :guilabel:`BRN`: `BE0477472701`
-   - :guilabel:`Name`: `ODOO S.A.`
+   - :guilabel:`Name`:
+
+     - :guilabel:`Production`: `ODOO S.A.`
+     - :guilabel:`Pre-production`: `OXXX_XXXXO S.A.`
 
 #. Grant the following permissions by clicking the :icon:`fa-toggle-on` :guilabel:`(toggle-on)`
    icon:


### PR DESCRIPTION
Despite registering ODOO S.A. as the name for both production and preproduction environment, MyInvois force changed pre-production to OXXX_XXXXO S.A. requiring an update on the credential for usage.