### PR TITLE
[I18N] Update translations NL administration

### DIFF
--- a/locale/nl/LC_MESSAGES/administration.po
+++ b/locale/nl/LC_MESSAGES/administration.po
@@ -961,7 +961,7 @@ msgstr ":ref:`odoo_online/duplicate`"
 
 #: ../../content/administration/odoo_online.rst:32
 msgid ":ref:`odoo_online/rename`"
-msgstr ":ref:`odoo_online/hernoemen`"
+msgstr ":ref:`odoo_online/rename`"
 
 #: ../../content/administration/odoo_online.rst:33
 msgid ":ref:`odoo_online/download`"
@@ -969,7 +969,7 @@ msgstr ":ref:`odoo_online/download`"
 
 #: ../../content/administration/odoo_online.rst:34
 msgid ":ref:`odoo_online/domains`"
-msgstr ":ref:`odoo_online/domeinen`"
+msgstr ":ref:`odoo_online/domains`"
 
 #: ../../content/administration/odoo_online.rst:35
 msgid ":ref:`odoo_online/tags`"
@@ -1047,7 +1047,7 @@ msgstr "Naam wijzigen"
 
 #: ../../content/administration/odoo_online.rst:71
 msgid "Rename the database and its URL."
-msgstr "Hernoem de database en deJeRL ervan."
+msgstr "Hernoem de database en de URL ervan."
 
 #: ../../content/administration/odoo_online.rst:76
 msgid "Download"
@@ -1163,7 +1163,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_online.rst:139
 msgid "Invite / remove users"
-msgstr "Gebruikers jeitnodigen/verwijderen"
+msgstr "Gebruikers uitnodigen/verwijderen"
 
 #: ../../content/administration/odoo_online.rst:141
 msgid ""
@@ -1176,7 +1176,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_online.rst-1
 msgid "Inviting a user on a database"
-msgstr "Een gebruiker jeitnodigen voor een database"
+msgstr "Een gebruiker uitnodigen voor een database"
 
 #: ../../content/administration/odoo_online.rst:147
 msgid "To remove users, select them and click :guilabel:`Remove`."
@@ -1372,7 +1372,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_sh/advanced/containers.rst:129
 msgid "Run an Odoo server"
-msgstr "Voer een Odoo-server jeit"
+msgstr "Voer een Odoo-server uit"
 
 #: ../../content/administration/odoo_sh/advanced/containers.rst:131
 msgid ""
@@ -1398,7 +1398,7 @@ msgstr "een module bijwerken,"
 
 #: ../../content/administration/odoo_sh/advanced/containers.rst:158
 msgid "run the tests for a module,"
-msgstr "voer de tests jeit voor een module,"
+msgstr "voer de tests uit voor een module,"
 
 #: ../../content/administration/odoo_sh/advanced/containers.rst:164
 msgid "In the above commands, the argument:"
@@ -1535,7 +1535,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_sh/advanced/containers.rst:226
 msgid "Save the file and then run the Odoo Shell:"
-msgstr "Sla het bestand op en voer vervolgens de Odoo Shell jeit:"
+msgstr "Sla het bestand op en voer vervolgens de Odoo Shell uit:"
 
 #: ../../content/administration/odoo_sh/advanced/containers.rst:232
 msgid ""
@@ -2059,7 +2059,7 @@ msgstr "Betalingsproviders en verzendproviders in testmodus zetten."
 
 #: ../../content/administration/odoo_sh/getting_started/branches.rst:76
 msgid "Disabling IAP services"
-msgstr "IAP-services jeitschakelen"
+msgstr "IAP-services uitschakelen"
 
 #: ../../content/administration/odoo_sh/getting_started/branches.rst:78
 msgid ""
@@ -3137,7 +3137,7 @@ msgstr "Legt al jouw huidige wijzigingen vast."
 
 #: ../../content/administration/odoo_sh/getting_started/branches.rst:552
 msgid "Delete a branch from your repository."
-msgstr "Verwijder een vertakking jeit jouw repository."
+msgstr "Verwijder een vertakking uit jouw repository."
 
 #: ../../content/administration/odoo_sh/getting_started/branches.rst:558
 msgid "Deletes the branch in your remote repository."
@@ -3738,7 +3738,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_sh/getting_started/create.rst:167
 msgid "Check your outgoing email servers"
-msgstr "Controleer jouw jeitgaande e-mailservers"
+msgstr "Controleer jouw uitgaande e-mailservers"
 
 #: ../../content/administration/odoo_sh/getting_started/create.rst:169
 msgid ""
@@ -3776,7 +3776,7 @@ msgstr "Controleer jouw geplande acties"
 
 #: ../../content/administration/odoo_sh/getting_started/create.rst:184
 msgid "All scheduled actions are disabled after the import."
-msgstr "Alle geplande acties worden na het importeren jeitgeschakeld."
+msgstr "Alle geplande acties worden na het importeren uitgeschakeld."
 
 #: ../../content/administration/odoo_sh/getting_started/create.rst:186
 msgid ""
@@ -3859,7 +3859,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_sh/getting_started/first_module.rst:13
 msgid "Basic use of Git and Github is explained."
-msgstr "Het basisgebruik van Git en Github wordt jeitgelegd."
+msgstr "Het basisgebruik van Git en Github wordt uitgelegd."
 
 #: ../../content/administration/odoo_sh/getting_started/first_module.rst:15
 msgid "The below assumptions are made:"
@@ -4583,7 +4583,7 @@ msgstr "Bewerk het modulemanifest *__manifest__.py*"
 
 #: ../../content/administration/odoo_sh/getting_started/first_module.rst:510
 msgid "Stage and commit your changes:"
-msgstr "Voer jouw wijzigingen jeit en voer deze door:"
+msgstr "Voer jouw wijzigingen uit en voer deze door:"
 
 #: ../../content/administration/odoo_sh/getting_started/first_module.rst:518
 msgid "Then, push your changes:"
@@ -4634,7 +4634,7 @@ msgstr "Bewerk de broncode"
 
 #: ../../content/administration/odoo_sh/getting_started/online-editor.rst:27
 msgid "The working directory is composed of the following folders:"
-msgstr "De werkmap bestaat jeit de volgende mappen:"
+msgstr "De werkmap bestaat uit de volgende mappen:"
 
 #: ../../content/administration/odoo_sh/getting_started/online-editor.rst:49
 msgid ""
@@ -4737,7 +4737,7 @@ msgstr ""
 
 #: ../../content/administration/odoo_sh/getting_started/online-editor.rst:93
 msgid "You can also open a terminal and execute the command:"
-msgstr "Je kunt ook een terminal openen en de opdracht jeitvoeren:"
+msgstr "Je kunt ook een terminal openen en de opdracht uitvoeren:"
 
 #: ../../content/administration/odoo_sh/getting_started/online-editor.rst:102
 msgid "Commit & Push your changes"
@@ -5797,7 +5797,7 @@ msgid ""
 "identification. You can then link your database with your Odoo Enterprise "
 "Subscription by entering the code you received by e-mail in the form input"
 msgstr ""
-"Jehoeft de server niet handmatig te starten, de service is actief. Jij zou "
+"Je hoeft de server niet handmatig te starten, de service is actief. Jij zou "
 "verbinding moeten kunnen maken met jouw Odoo Enterprise-instantie met behulp"
 " van jouw gebruikelijke identificatiemiddel. Vervolgens kunt je jouw "
 "database koppelen aan jouw Odoo Enterprise-abonnement door de code die je "
@@ -7679,7 +7679,7 @@ msgstr ""
 
 #: ../../content/administration/on_premise/packages.rst:13
 msgid "Nightly packages may be difficult to keep up to date."
-msgstr "Nachtelijke pakketten kunnen moeilijk jep-to-date te houden zijn."
+msgstr "Nachtelijke pakketten kunnen moeilijk up-to-date te houden zijn."
 
 #: ../../content/administration/on_premise/packages.rst:15
 msgid ""
@@ -7874,7 +7874,7 @@ msgstr ""
 
 #: ../../content/administration/on_premise/packages.rst:158
 msgid "Execute the downloaded file."
-msgstr "Voer het gedownloade bestand jeit."
+msgstr "Voer het gedownloade bestand uit."
 
 #: ../../content/administration/on_premise/packages.rst:161
 msgid ""
@@ -8414,7 +8414,7 @@ msgstr ""
 
 #: ../../content/administration/on_premise/source.rst:428
 msgid "Running Odoo"
-msgstr "Odoo jeitvoeren"
+msgstr "Odoo uitvoeren"
 
 #: ../../content/administration/on_premise/source.rst:430
 msgid ""
@@ -8670,7 +8670,7 @@ msgid ""
 msgstr ""
 "De centrale downloadpagina is https://www.odoo.com/page/download. Als je een"
 " link \"Kopen\" ziet voor de Odoo Enterprise-download, zorg er dan voor dat "
-"ujeingelogd bent op Odoo.com met dezelfde login als die gekoppeld is aan je "
+"je ingelogd bent op Odoo.com met dezelfde login als die gekoppeld is aan je "
 "Odoo Enterprise-abonnement."
 
 #: ../../content/administration/on_premise/update.rst:70
@@ -8911,7 +8911,7 @@ msgstr "Deze matrix toont de ondersteuningsstatus van elke versie."
 
 #: ../../content/administration/supported_versions.rst:22
 msgid "**Major releases are in bold type.**"
-msgstr "**Grote jeitvoeringen zijn vetgedrukt.**"
+msgstr "**Grote uitvoeringen zijn vetgedrukt.**"
 
 #: ../../content/administration/supported_versions.rst:31
 msgid "On-Premise"
@@ -9040,7 +9040,7 @@ msgstr "|red| Einde van de ondersteuning"
 
 #: ../../content/administration/supported_versions.rst:89
 msgid "N/A Never released for this platform"
-msgstr "N.v.t. Nooit jeitgebracht voor dit platform"
+msgstr "N.v.t. Nooit uitgebracht voor dit platform"
 
 #: ../../content/administration/supported_versions.rst:92
 msgid ""
@@ -9104,7 +9104,7 @@ msgstr ""
 
 #: ../../content/administration/upgrade.rst:0
 msgid "The upgrade message prompt on the top right of the database"
-msgstr "De jepgradeberichtprompt rechtsboven in de database"
+msgstr "De upgradeberichtprompt rechtsboven in de database"
 
 #: ../../content/administration/upgrade.rst:44
 msgid ""
@@ -9130,7 +9130,7 @@ msgstr ""
 
 #: ../../content/administration/upgrade.rst:55
 msgid "An upgrade does not cover:"
-msgstr "Een jepgrade dekt niet:"
+msgstr "Een upgrade dekt niet:"
 
 #: ../../content/administration/upgrade.rst:57
 msgid "Downgrading to a previous version of Odoo"
@@ -9270,7 +9270,7 @@ msgstr ""
 msgid ""
 "The database manager with an upgrade button next to the name of a database."
 msgstr ""
-"De databasemanager met een jepgradeknop naast de naam van een database."
+"De databasemanager met een upgradeknop naast de naam van een database."
 
 #: ../../content/administration/upgrade.rst:121
 msgid ""
@@ -9539,7 +9539,7 @@ msgstr ""
 
 #: ../../content/administration/upgrade.rst:239
 msgid "Scheduled actions are disabled."
-msgstr "Geplande acties zijn jeitgeschakeld."
+msgstr "Geplande acties zijn uitgeschakeld."
 
 #: ../../content/administration/upgrade.rst:240
 msgid ""
@@ -9867,7 +9867,7 @@ msgstr ""
 
 #: ../../content/administration/upgrade.rst:0
 msgid "View from the upgrade tab"
-msgstr "Bekijk vanaf het tabbladJepgrade"
+msgstr "Bekijk vanaf het tabblad upgrade"
 
 #: ../../content/administration/upgrade.rst:356
 msgid ""
@@ -9991,7 +9991,7 @@ msgstr ""
 
 #: ../../content/administration/upgrade.rst:416
 msgid "the upgrade of all **standard applications**;"
-msgstr "de jepgrade van alle **standaardapplicaties**;"
+msgstr "de upgrade van alle **standaardapplicaties**;"
 
 #: ../../content/administration/upgrade.rst:417
 msgid ""
@@ -10026,7 +10026,7 @@ msgstr "Upgradeservices die niet onder de SLA vallen"
 
 #: ../../content/administration/upgrade.rst:430
 msgid "The following upgrade-related services are **not** included:"
-msgstr "De volgende jepgradegerelateerde services zijn **niet** inbegrepen:"
+msgstr "De volgende upgradegerelateerde services zijn **niet** inbegrepen:"
 
 #: ../../content/administration/upgrade.rst:432
 msgid ""


### PR DESCRIPTION
Translation errors have been removed. The "u" letter has been replaced by "je" at different locations. Secondly the Reference to "rename" and "domains" where translated, what should not have been translated