### PR TITLE
[FIX] administration: correct Fedora version

### DIFF
--- a/content/administration/on_premise/packages.rst
+++ b/content/administration/on_premise/packages.rst
@@ -132,7 +132,7 @@ be downloaded from the `Odoo download page <https://www.odoo.com/page/download>`
    .. group-tab:: Fedora
 
       .. note::
-         Odoo {CURRENT_MAJOR_VERSION} 'rpm' package supports Fedora 36.
+         Odoo {CURRENT_MAJOR_VERSION} 'rpm' package supports Fedora 38.
 
       Once downloaded, the package can be installed using the 'dnf' package manager:
 


### PR DESCRIPTION
The Odoo 17 and 18 RPM builds target Fedora 38 instead of 36:

16: https://github.com/odoo/odoo/blob/16.0/setup/package.dffedora#L3
17: https://github.com/odoo/odoo/blob/17.0/setup/package.dffedora#L3
18: https://github.com/odoo/odoo/blob/18.0/setup/package.dffedora#L3

Note that both Fedora 36 and 38 are EOL:
https://docs.fedoraproject.org/en-US/releases/eol/