### PR TITLE
[IMP] pos_urban_piper: clarify combo product handling

### DIFF
--- a/content/applications/sales/point_of_sale/online_food_delivery.rst
+++ b/content/applications/sales/point_of_sale/online_food_delivery.rst
@@ -107,6 +107,11 @@ To make multiple products available for food delivery at once,
 .. image:: online_food_delivery/product-list.png
    :alt: Product list
 
+.. note::
+   - Currently, UrbanPiper does not support combo products.
+   - As a workaround, create a product and define combo choices as :doc:`Attributes & Variants
+     <../sales/products_prices/products/variants>`.
+
 Synchronization
 ---------------
 


### PR DESCRIPTION
In this commit:
===
- Added a note explaining that UrbanPiper does not support combo products.
- Users need to create a new product and add combo items as variants to use them with UrbanPiper.

task-4546712