### PR TITLE
[IMP] core: make author field mandatory in manifests

### DIFF
--- a/content/developer/howtos/accounting_localization.rst
+++ b/content/developer/howtos/accounting_localization.rst
@@ -277,6 +277,7 @@ Basic :file:`__manifest__.py` file for such a module looks as following:
         "name": "COUNTRY - Accounting Reports",
         "category": "Accounting/Localizations/Reporting",
         "version": "1.0.0",
+        "author": "Odoo S.A.",
         "license": "OEEL-1",
         "depends": [
             "l10n_XX", "account_reports"

--- a/content/developer/tutorials/server_framework_101/02_newapp.rst
+++ b/content/developer/tutorials/server_framework_101/02_newapp.rst
@@ -63,7 +63,7 @@ On the other hand, the ``__manifest__.py`` file must describe our module and can
 Its only required field is the ``name``, but it usually contains much more information.
 
 Take a look at the
-`CRM file <https://github.com/odoo/odoo/blob/fc92728fb2aa306bf0e01a7f9ae1cfa3c1df0e10/addons/crm/__manifest__.py#L1-L67>`__
+`CRM file <https://github.com/odoo/odoo/blob/67a952f30731fc00941587ae165b7a885da0e77e/addons/crm/__manifest__.py>`__
 as an example. In addition to providing the description of the module (``name``, ``category``,
 ``summary``, ``website``...), it lists its dependencies (``depends``). A dependency means that the
 Odoo framework will ensure that these modules are installed before our module is installed. Moreover, if


### PR DESCRIPTION
External contributors (and namely Odoo PS) forget to set the author field in their manifest file. The result is that the module is wrongly registered with `'author': 'Odoo S.A.'`.

This work makes the field mandatory, with a warning when not set. It also offers an upgrade-code script to mass-rewrite all the manifests in order to set the author.

task-4485983