### PR TITLE
[FIX] coding_guidelines: fix the alphabetic orders for the import

### DIFF
--- a/content/contributing/development/coding_guidelines.rst
+++ b/content/contributing/development/coding_guidelines.rst
@@ -425,7 +425,7 @@ Inside these 3 groups, the imported lines are alphabetically sorted.
     from datetime import datetime
     # 2 : imports of odoo
     import odoo
-    from odoo import api, fields, models, _ # alphabetically ordered
+    from odoo import Command, _, api, fields, models # alphabetically ordered
     from odoo.tools.safe_eval import safe_eval as eval
     # 3 : imports from odoo addons
     from odoo.addons.web.controllers.main import login_redirect


### PR DESCRIPTION
In odoo, as we suggest everyone to follow an alphebetic order.

The translator(`_`), ASCII is 95 and `a` ASCII value is 97 which '_' < 'a', the translator should be defined first in the import before the `api` not at the end of the import

This commits adds an example to import static class `Command` with a Capital alphabet with a ASCII value of `C` as 67 which will be before than the `_`
'C' < '_' < 'a'

This order of import should be followed while the import