### PR TITLE
Update 02_build_a_dashboard.rst

### DIFF
--- a/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
+++ b/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
@@ -205,10 +205,11 @@ A basic request could look like this:
 
 .. code-block:: js
 
+   import { rpc } from "@web/core/network/rpc";
+
    setup() {
-         this.rpc = useService("rpc");
          onWillStart(async () => {
-            const result = await this.rpc("/my/controller", {a: 1, b: 2});
+            const result = await rpc("/my/controller", {a: 1, b: 2});
             // ...
          });
    }


### PR DESCRIPTION
fix rpc service use from useService to import

In Odoo 18 the rpc service was moved to core/network.