### PR TITLE
use `<chatter>` instead of `<div class="oe_chatter">`

### DIFF
--- a/content/developer/reference/backend/mixins.rst
+++ b/content/developer/reference/backend/mixins.rst
@@ -766,11 +766,11 @@ widgets, respectively).
             <field name="arch" type="xml">
                 <form string="Business Trip">
                     <!-- Your usual form view goes here -->
-                    <div class="oe_chatter">
+                    <chatter>
                         <field name="message_follower_ids" widget="mail_followers"/>
                         <field name="activity_ids" widget="mail_activity"/>
                         <field name="message_ids" widget="mail_thread"/>
-                    </div>
+                    </chatter>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
This pull request includes a change to the `content/developer/reference/backend/mixins.rst` file to update the syntax for the chatter widget in the form view.

Changes in form view syntax:

* [`content/developer/reference/backend/mixins.rst`](diffhunk://#diff-18a56ebc4174cde2ad700e414ebe257a7ac46b80b25739abecab087f942b41faL769-R773): Replaced the `<div class="oe_chatter">` element with the `<chatter>` element to reflect the updated syntax for the chatter widget.