### PR TITLE
[FIX] web:  documentation for render invisible menus and actions

### DIFF
--- a/content/developer/reference/backend/actions.rst
+++ b/content/developer/reference/backend/actions.rst
@@ -55,6 +55,9 @@ attributes used to present an action in an arbitrary model's contextual menu:
     a comma-separated list of view types for which the action appears in the
     contextual menu, mostly "list" and / or "form". Defaults to ``list,form``
     (both list and form )
+``binding_invisible``
+    Python expression, when evaluated as true, the action isn't shown in the
+    action menu.
 
 .. _reference/actions/window:
 

--- a/content/developer/reference/backend/data.rst
+++ b/content/developer/reference/backend/data.rst
@@ -230,6 +230,10 @@ Defines an ``ir.ui.menu`` record with a number of defaults and fallbacks:
     of an action to execute when the menu is open
 ``id``
     the menu item's :term:`external id`
+``web_icon``
+    the web icon file.
+``web_invisible``
+    Python expression, when evaluated as true, the menu isn't shown.
 
 .. _reference/data/template:
 

--- a/content/developer/reference/user_interface/view_architectures.rst
+++ b/content/developer/reference/user_interface/view_architectures.rst
@@ -37,6 +37,26 @@ expression** that will be executed in an environment that has access to the foll
 - `uid (int)`: the id of the current user;
 - `today (str)`: the current local date in the `YYYY-MM-DD` format;
 - `now (str)`: the current local datetime in the `YYYY-MM-DD hh:mm:ss` format.
+- `companies (dict)`: the information of the companies. The dict contains:
+  - `multi_company (bool)`: A boolean indicating whether the user has access to multiple companies.
+  - `allowed_ids`: The list of company IDs the user is allowed to connect to.
+  - `active_ids`: The list of company IDs the user is connected to (selected in the company
+    switcher dropdown).
+  - `active_id`: The ID of the main company selected (the one highlighted in the company switcher
+    dropdown and displayed in the navbar of the webclient).
+  - `has(id|ids, 'property', value)`: returns a boolean indicating whether there's a company with id
+    in ids for which field matches the given value. Note that the properties of the companies are
+    those sent by the server in the session info. If a new property is needed, the company function
+    _get_session_info can be overridden. For example, the following code will add the
+    company_code property:
+    .. code-block:: python
+
+        def _get_session_info(self, allowed_company_ids):
+          res = super()._get_session_info(allowed_company_ids)
+          res.update({
+            'country_code': self.country_id.code
+          })
+          return res
 
 .. example::
    .. code-block:: xml
@@ -54,6 +74,16 @@ expression** that will be executed in an environment that has access to the foll
               <field name="field_b" invisible="parent.field_a"/>
           </form>
       </field>
+
+.. example::
+   .. code-block:: xml
+
+      <field name="foo" invisible="not companies.multi_company"/>
+
+.. example::
+   .. code-block:: xml
+
+      <field name="foo" invisible="not companies.has(companies.active_ids, 'country_code', 'PE')"/>
 
 .. _reference/view_architectures/form:
 


### PR DESCRIPTION
This commit adds the documentation about the new action (`binding_invisible`)[1] and on menu (`web_invisible`)[2] fields.

This commit also adds the documentation about the new python expression variable `companies` [3].

[1] https://github.com/odoo/odoo/commit/8abd21a739be9b19bc0fb9db95035c7fc2cf1e2a
[2] https://github.com/odoo/odoo/commit/1177ab3a89412d7e03fee3c7966f0c326d648aa5
[3] https://github.com/odoo/odoo/commit/22e9d822e8cab08114c006eb8c4054c4de0c40f2