### PR TITLE
[IMP] contributing: documentation macOS make install

### DIFF
--- a/content/contributing/documentation.rst
+++ b/content/contributing/documentation.rst
@@ -132,11 +132,15 @@ to make changes from the GitHub interface.
 
    .. tabs::
 
-      .. group-tab:: Linux and macOS
+      .. group-tab:: Linux
 
          .. code-block:: console
 
             $ sudo apt install make -y
+
+      .. group-tab:: macOS
+
+         Follow the `guide to install Make on macOS <https://formulae.brew.sh/formula/make>`_
 
       .. group-tab:: Windows
 


### PR DESCRIPTION
Task: [#4593945](https://www.odoo.com/odoo/project.task/4593945)

This PR adds macOS specific instructions to the contributing documentation for installing Make.

The package manager `APT` is not primarily used on macOS, rather [Homebrew](https://brew.sh/) is often used.