### PR TITLE
[IMP] iot: add LED status information

### DIFF
--- a/content/applications/general/iot/connect.rst
+++ b/content/applications/general/iot/connect.rst
@@ -79,6 +79,9 @@ Connection using a connection token
 #. In the :guilabel:`Odoo database connected` section, click :guilabel:`Configure`.
 #. Paste the token into the :guilabel:`Server Token` field and click :guilabel:`Connect`.
 
+.. note::
+   Once the IoT box is connected to a database, its green LED remains constantly lit.
+
 .. _iot/connect/IoT-form:
 
 IoT system form

--- a/content/applications/general/iot/iot_box.rst
+++ b/content/applications/general/iot/iot_box.rst
@@ -89,3 +89,17 @@ The IoT box's IP address can be retrieved by:
 
 Once the IoT box is :doc:`connected to the Odoo database <connect>`, its homepage can be accessed
 from Odoo by opening the IoT app and clicking the URL displayed on the IoT box's card.
+
+.. _iot/iot-box/led-status:
+
+LED status
+==========
+
+The IoT box features two LEDs, located to the right of the SD card slot, which show its status and
+help with troubleshooting when no display is connected. The LEDs can be interpreted as follows:
+
+- **Red LED lit**: The IoT box has no Internet connection. Ensure the Ethernet cable is properly
+  connected or :ref:`connect the IoT box via Wi-Fi <iot/iot_box/network-wifi>`.
+- **Green LED flashing**: The IoT box is awaiting :doc:`connection to a database <connect>`.
+- **Green LED constantly lit**: The IoT box is connected to a database; no further action is
+  required.


### PR DESCRIPTION
New functionality has been added to the IoT box
that allows it to communicate its status via the
onboard LEDs. This commit adds a short section
detailing the different states and the
recommended action the user should take.

task-4603206