### PR TITLE
📝 Use Bytes unit instead of Octets (GB instead of Go)

### DIFF
--- a/content/administration/on_premise/deploy.rst
+++ b/content/administration/on_premise/deploy.rst
@@ -240,7 +240,7 @@ Configuration sample
 * 60 users / 6 = 10 <- theoretical number of worker needed
 * (4 * 2) + 1 = 9 <- theoretical maximal number of worker
 * We'll use 8 workers + 1 for cron. We'll also use a monitoring system to measure cpu load, and check if it's between 7 and 7.5 .
-* RAM = 9 * ((0.8*150) + (0.2*1024)) ~= 3Go RAM for Odoo
+* RAM = 9 * ((0.8*150) + (0.2*1024)) ~= 3GB RAM for Odoo
 
 in :ref:`the configuration file <reference/cmdline/config_file>`:
 


### PR DESCRIPTION
Fixed a small typo.