### PR TITLE
[IMP] tutorials/server_framework_101: add warning about access rights

### DIFF
--- a/content/developer/tutorials/server_framework_101/06_basicviews.rst
+++ b/content/developer/tutorials/server_framework_101/06_basicviews.rst
@@ -66,6 +66,12 @@ to see the result.
     You will probably use some copy-paste in this chapter, therefore always make sure that the ``id``
     remains unique for each view!
 
+
+.. warning::
+   Remember to set the correct access rights to the user as explained in the :doc:`security intro <04_securityintro>`!
+
+   The :guilabel:`Create` button is not shown if the user has only read permission.
+
 Form
 ====
 


### PR DESCRIPTION
When readers follow the server framework 101 tutorial, it's common for them to set the model access rights the same as in the tutorial's example at chapter 4. Following this example they will have read only permissions and by chapter 6 they will not be able to create/update or delete objects in order to follow with the tutorial (example [stackoverflow question](https://stackoverflow.com/questions/71614240/create-button-is-not-showing-up-after-following-the-odoo-tutorial-when-creating)).

This commit adds a warning for readers to remind them of the relation between the access rights set previously and what they can see and do using the UI.