### PR TITLE
[REF] on_premise: Install missing libcairo for reportlab 4.0+

### DIFF
--- a/content/administration/on_premise/source.rst
+++ b/content/administration/on_premise/source.rst
@@ -300,7 +300,7 @@ Dependencies
 
             .. code-block:: console
 
-               $ sudo apt install python3-pip libldap2-dev libpq-dev libsasl2-dev
+               $ sudo apt install python3-pip libcairo2-dev libldap2-dev libpq-dev libsasl2-dev
 
             Odoo dependencies are listed in the :file:`requirements.txt` file located at the root of
             the Odoo Community directory.


### PR DESCRIPTION
Reportlab 4.0+ documentation installation says:
    - `If generating bitmaps make sure to add the PyCairo extension`
    - https://docs.reportlab.com/install/ReportLab_Plus_version_installation/

If your PDF report is using QR barcode (bitmaps) it will not be displayed if `pycairo` is not installed

After install this package the QR barcode is displayed correctly

This problem is not reproduced from docker odoo oficial image because it is already installed
    - docker run -it --rm odoo:18.0 pip freeze |grep -i pycairo

The output is:
    - pycairo==1.25.1
    - rlPyCairo==0.3.0

It is because the package `python3-renderpm`:
- apt-get install -y --no-install-recommends python3-renderpm
    - https://github.com/odoo/docker/blob/061cbb890fb7750146483717c32d9f533856468e/18.0/Dockerfile#L33

is installing the pycairo dependency.

However, if you are using requirements.txt directly it is not auto-installed

In fact, if you try to install using:
    - pip install pycairo

You will get the following error:
    - `../cairo/meson.build:31:12: ERROR: Dependency "cairo" not found, tried pkgconfig``

It requires to have installed `libcairo2-dev` apk package:
    - `apt install -y libcairo2-dev`