### PR TITLE
Office 365 Outlook version on Windows

### DIFF
--- a/content/applications/general/integrations/mail_plugins/outlook.rst
+++ b/content/applications/general/integrations/mail_plugins/outlook.rst
@@ -54,6 +54,8 @@ then on :guilabel:`Add from file...`
    :align: center
    :alt: Custom add-ins in Outlook
 
+Note: in some cases, the Get Add-ins button may be unavailable. If you see this issue, navigate to aka.ms/olksideload
+
 For the next step, attach the `manifest.xml` file downloaded above, and press :guilabel:`OK`. Next,
 read the warning and click on :guilabel:`Install`.
 


### PR DESCRIPTION
For Office 365 Outlook version on Windows, the "get add-ins" is not showing all the time.