### PR TITLE
[FIX] ecommerce: require module install for email queue optimization

### DIFF
--- a/content/applications/websites/ecommerce/ecommerce_management/performance.rst
+++ b/content/applications/websites/ecommerce/ecommerce_management/performance.rst
@@ -49,10 +49,12 @@ which sends queued emails as soon as possible.
 To enable asynchronous email sending:
 
 #. Enable the :doc:`developer mode </applications/general/developer_mode>`.
+#. Go to :menuselection:`Apps`, remove the :guilabel:`Apps` filter, and install the :guilabel:`Sales
+   - Async Emails` module.
 #. Go to :menuselection:`Settings --> Technical --> System Parameters` and set the
    :guilabel:`sale.async_emails` system parameter to `True`.
-#. Go to :menuselection:`Settings --> Technical --> Scheduled Actions` and enable the
-   :guilabel:`Sales: Send pending emails` scheduled action.
+#. Go to :menuselection:`Settings --> Technical --> Scheduled Actions` and ensure that the
+   :guilabel:`Sales: Send pending emails` scheduled action is enabled.
 
 .. caution::
    Enabling this feature may delay order confirmation and invoice emails by a few minutes. It is


### PR DESCRIPTION
In version 17.0 to 18.2, it is required to install the `sale_async_emails` module to enable the email queue optimization.

This commit also rephrases slightly the step to enable the cron because it should already be enabled, unless the user disabled it manually. Indeed, the cron is created enabled in versions 17.0 to 18.2, while it is created disabled but automatically enabled when toggling the `sale.async_emails` system parameter in master.

task-3872792