### PR TITLE
[FIX] rst_guidelines: typo in `ref` example

### DIFF
--- a/content/contributing/documentation/rst_guidelines.rst
+++ b/content/contributing/documentation/rst_guidelines.rst
@@ -610,7 +610,7 @@ markup:
          Use relative links for internal URLs
          ------------------------------------
 
-         Please refer to the :ref:`<contributing/rst/hyperlinks-guidelines>` section to learn more
+         Please refer to the :ref:`contributing/rst/hyperlinks-guidelines` section to learn more
          about :ref:`relative links <contributing/rst/relative-links>`.
 
 .. _contributing/rst/doc-hyperlinks:


### PR DESCRIPTION
This commit fixes a typo into the `code-block`example (syntax of an anchor link). 