### PR TITLE
[FIX] in_app_purchase: fix outdated doc of low credit notification email

### DIFF
--- a/content/applications/essentials/in_app_purchase.rst
+++ b/content/applications/essentials/in_app_purchase.rst
@@ -176,12 +176,6 @@ Services`.
 The available |IAP| accounts appear in a list view on the :guilabel:`IAP Account` page. From here,
 click on the desired |IAP| account to view that service's :guilabel:`Account Information` page.
 
-On the :guilabel:`Account Information` page, tick the :guilabel:`Warn Me` checkbox. Doing so reveals
-two fields on the form: :guilabel:`Threshold` and :guilabel:`Warning Email`.
-
-In the :guilabel:`Threshold` field, enter an amount of credits Odoo should use as the
-minimum threshold for this service. In the :guilabel:`Warning Email` field, enter the email address
-that receives the notification.
-
-Odoo sends a low-credit alert to the :guilabel:`Warning Email` when the balance of credits falls
-below the amount listed as the :guilabel:`Threshold`.
+Set the :guilabel:`Email Alert Threshold` to the credit amount that should trigger a low-credit
+alert when the balance falls below it. Next, select which user(s) should receive the email
+notification using the :guilabel:`Email Alert Recipients` field.


### PR DESCRIPTION
Since odoo/odoo#175562, the interface to set the low credit notification email has changed slightly.

Before, you had to tick a "Warn Me" box to enable the notifications, and then set a warning threshold and some recipient email.

![image](https://github.com/user-attachments/assets/4e46b41f-e9f5-499e-a610-16d771b321fb)

 Now, the threshold is shown directly and you then need to set a list of users as the recipients of the notification email.

![image](https://github.com/user-attachments/assets/fa586bf9-3b7e-41c4-897f-5857e1ca1585)