### PR TITLE
[FIX] payment_providers: reword and add missing Nuvei methods

### DIFF
--- a/content/applications/finance/payment_providers/nuvei.rst
+++ b/content/applications/finance/payment_providers/nuvei.rst
@@ -50,21 +50,21 @@ Configuration on Odoo
 Payment methods
 ===============
 
-Most Nuvei payment methods are **region specific**. The supported payment methods for each country
-are listed below:
+Most Nuvei payment methods are **region specific**. The supported payment methods and brands for
+each country are listed below:
 
 +---------------------------------+----------------------------------+
 | **Argentina**                   | **Ecuador**                      |
 |                                 |                                  |
 | - Boleto                        | - Card (AMEX, Mastercard, Visa)  |
-| - Card (AMEX, Mastercard, Visa) | - Banco Guayaquil                |
-|                                 | - Banco Pichincha                |
+| - Card (AMEX, Mastercard, Visa) | - AstroPay TEF (Banco Guayaquil, |
+|                                 |   Banco Pichincha, Facilito)     |
 +---------------------------------+----------------------------------+
 | **Brazil**                      | **Mexico**                       |
 |                                 |                                  |
 | - Boleto                        | - Card (AMEX, Mastercard, Visa)  |
 | - Card (AMEX, Mastercard, Visa) | - SPEI                           |
-| - Pix                           |                                  |
+| - Pix                           | - Oxxo Pay                       |
 +---------------------------------+----------------------------------+
 | **Canada**                      | **Peru**                         |
 |                                 |                                  |
@@ -78,9 +78,9 @@ are listed below:
 +---------------------------------+----------------------------------+
 | **Colombia**                    | **Uruguay**                      |
 |                                 |                                  |
-| - Card (AMEX, Mastercard, Visa) | - Abitab                         |
-| - PSE                           | - Card (AMEX, Mastercard, Visa)  |
-|                                 | - RedPagos                       |
+| - Card (AMEX, Mastercard, Visa) | - Card (AMEX, Mastercard, Visa)  |
+| - PSE                           | - Local Payments (Abitab,        |
+|                                 |   RedPagos)                      |
 +---------------------------------+----------------------------------+
 
 .. seealso::


### PR DESCRIPTION
The Oxxo Pay payment method was accidentally left out of the documentation on merge. This PR properly adds it under Mexico.

In addition, feedback-wise it's hard to find the payment methods that are hidden under others like AstroPay TEF (Banco Guayaquil, Banco Pichincha) and Local Payments (Abitab, RedPagos) since it doesn't directly appear in the list of payment methods. This change makes it apparent what you need to enable to be able to use these methods.