### PR TITLE
[FIX] IAP: fix format type

### DIFF
--- a/content/applications/essentials/in_app_purchase.rst
+++ b/content/applications/essentials/in_app_purchase.rst
@@ -41,7 +41,7 @@ The following |IAP| services are offered by Odoo:
 - :guilabel:`Lead Generation`: generates leads based on a set of criteria, and converts web visitors
   into quality leads and opportunities.
 - :guilabel:`Snailmail`: sends customer invoices and follow-up reports by post, worldwide.
-- :guilabel:`Signer identification with itsme®: Ask document signatories in
+- :guilabel:`Signer identification with itsme®`: Ask document signatories in
   Odoo **Sign** to provide their identity using the *itsme* :icon:`fa-registered` identity platform,
   which is available in Belgium and the Netherlands.
 


### PR DESCRIPTION
This commit fix a typo in the IAP doc page, in the user docs. One line in the IAP services section was bold and there was a :icon: visible. This commit fix this issue.

The formating error was introduced here: 21654b42e8b5593ff0e215dad0c8963f122c0015, where there was a missing "`"

no-task