### PR TITLE
[IMP] hosting: change ticket submission links from help to help-form

### DIFF
--- a/content/administration/hosting.rst
+++ b/content/administration/hosting.rst
@@ -23,7 +23,7 @@ To Odoo Online
 #. Create a :ref:`duplicate of the database <on-premise/duplicate>`.
 #. In this duplicate, uninstall all **non-standard apps**.
 #. Use the database manager to grab a *dump with filestore*.
-#. `Submit a support ticket <https://www.odoo.com/help>`_ including the following:
+#. `Create a support ticket <https://www.odoo.com/help-form>`_ including the following:
 
    - your **subscription number**,
    - the **URL** you want to use for the database (e.g., `company.odoo.com`), and
@@ -33,8 +33,8 @@ To Odoo Online
    issues during the process, Odoo might contact you.
 
 .. note::
-   If you have time constraints, `submit a support ticket <https://www.odoo.com/help>`_ as soon as
-   possible to schedule the transfer.
+   If you have time constraints, `create a support ticket <https://www.odoo.com/help-form>`_ as soon
+   as possible to schedule the transfer.
 
 To Odoo.sh
 ----------
@@ -56,19 +56,20 @@ Transferring an Odoo Online database
       17.0.
 
    .. tip::
-      Click the gear icon (:guilabel:`⚙`) next to the database name on the `Odoo Online database
-      manager <https://www.odoo.com/my/databases/>`_ to display its version number.
+      Click the :icon:`fa-gear` (:guilabel:`gear`) button next to the database name on the `Odoo
+      Online database manager <https://www.odoo.com/my/databases/>`_ to display its version number.
 
    .. warning::
       If there is an active Odoo subscription linked to the database being migrated, reach out to
-      the Customer Service Manager or `submit a support ticket <https://www.odoo.com/help>`_  to
+      the Customer Service Manager or `contact Odoo support <https://www.odoo.com/help>`_ to
       complete the subscription transfer.
 
 To on-premise
 -------------
 
-#. Sign in to `the Odoo Online database manager <https://www.odoo.com/my/databases/>`_ and click the
-   gear icon (:guilabel:`⚙`) next to the database name to :guilabel:`Download` a backup. If the
+#. Download a database backup by signing in to `the Odoo Online database manager
+   <https://www.odoo.com/my/databases/>`_, clicking the :icon:`fa-gear` (:guilabel:`gear`) button
+   next to the database name, then selecting :icon:`fa-cloud-download` :guilabel:`Download`. If the
    download fails due to the file being too large, `contact Odoo support
    <https://www.odoo.com/help>`_.
 #. Restore the database from the database manager on your local server using the backup.
@@ -76,8 +77,9 @@ To on-premise
 To Odoo.sh
 ----------
 
-#. Sign in to `the Odoo Online database manager <https://www.odoo.com/my/databases/>`_ and click the
-   gear icon (:guilabel:`⚙`) next to the database name to :guilabel:`Download` a backup. If the
+#. Download a database backup by signing in to `the Odoo Online database manager
+   <https://www.odoo.com/my/databases/>`_, clicking the :icon:`fa-gear` (:guilabel:`gear`) button
+   next to the database name, then selecting :icon:`fa-cloud-download` :guilabel:`Download`. If the
    download fails due to the file being too large, `contact Odoo support
    <https://www.odoo.com/help>`_.
 #. Follow the instructions found in :ref:`the Import your database section
@@ -93,7 +95,7 @@ To Odoo Online
    Odoo Online is *not* compatible with **non-standard apps**.
 
 #. Uninstall all **non-standard apps** in a staging build before doing it in the production build.
-#. `Create a support ticket <https://www.odoo.com/help>`_ including the following:
+#. `Create a support ticket <https://www.odoo.com/help-form>`_ including the following:
 
    - your **subscription number**,
    - the **URL** you want to use for the database (e.g., `company.odoo.com`),
@@ -106,8 +108,8 @@ To Odoo Online
    issues during the process, Odoo might contact you.
 
 .. note::
-   - If you have time constraints, `submit a support ticket <https://www.odoo.com/help>`_ as soon as
-     possible to schedule the transfer.
+   - If you have time constraints, `create a support ticket <https://www.odoo.com/help-form>`_ as
+     soon as possible to schedule the transfer.
    - Select the **region** closest to most of your users to reduce latency.
    - Future **administrator(s)** must have an Odoo.com account.
    - The **date and time** you want the database to be up and running are helpful to organize the


### PR DESCRIPTION
The ticket form page was moved to /help-form following the restructuration of the /help page. Directly linking to the ticket form page should make it easier for users.