### PR TITLE
Remove the missing video link line

### DIFF
--- a/content/developer/tutorials/server_framework_101/02_newapp.rst
+++ b/content/developer/tutorials/server_framework_101/02_newapp.rst
@@ -35,10 +35,6 @@ offers above or below the expected selling price. It is up to the seller to acce
    :align: center
    :alt: Form view 02
 
-Here is a quick video showing the workflow of the module.
-
-Hopefully, this video will be recorded soon :-)
-
 Prepare the addon directory
 ===========================
 


### PR DESCRIPTION
This video has not been recorded for over a year now. No point in showing this line in the official documentation. It can be updated when the video is actually recorded.