### PR TITLE
[FIX] coding_guidelines: Add comment to indicate ASCII-based ordering

### DIFF
--- a/content/contributing/development/coding_guidelines.rst
+++ b/content/contributing/development/coding_guidelines.rst
@@ -425,7 +425,7 @@ Inside these 3 groups, the imported lines are alphabetically sorted.
     from datetime import datetime
     # 2 : imports of odoo
     import odoo
-    from odoo import Command, _, api, fields, models # alphabetically ordered
+    from odoo import Command, _, api, fields, models # ASCIIbetically ordered
     from odoo.tools.safe_eval import safe_eval as eval
     # 3 : imports from odoo addons
     from odoo.addons.web.controllers.main import login_redirect


### PR DESCRIPTION
Following the fix - https://github.com/odoo/documentation/pull/11983/commits/92c7099a0ee88b548f04ecd36e46663c2e88dc70 Adding a comment to explicitly indicate that the import is ordered alphabetically based on ASCII values.