### PR TITLE
[IMP] iot: remove adam scales

### DIFF
--- a/content/applications/general/iot/devices/scale.rst
+++ b/content/applications/general/iot/devices/scale.rst
@@ -74,5 +74,4 @@ Guide for Ariva S series scales <https://www.mt.com/dam/RET_DOCS/Ariv.pdf>`_ and
 #. Press **>0<**.
 #. Press **>0<** again to :guilabel:`SAVE`; the scale restarts.
 #. Reboot the IoT box or :ref:`restart the Windows virtual IoT service <iot/windows_iot/restart>`.
-   The scale should then appear as `Toledo 8217`, as opposed to the previous display, where it
-   appeared as `Adam Equipment Serial`.
+   The scale should then appear as `Toledo 8217`.


### PR DESCRIPTION
We have deprecated Adam scales support in saas-18.3 and this PR aims to delete associated text from the documentation

Associated PRs:
1) odoo: https://github.com/odoo/odoo/pull/206832
2) enterprise: https://github.com/odoo/enterprise/pull/83793
3) upgrade: https://github.com/odoo/upgrade/pull/7589