### PR TITLE
Duplicate description in Server Framework 101 Chapter 6

### DIFF
--- a/content/developer/tutorials/server_framework_101/06_basicviews.rst
+++ b/content/developer/tutorials/server_framework_101/06_basicviews.rst
@@ -31,7 +31,7 @@ List
       :align: center
       :alt: List view
 
-List views, also called list views, display records in a tabular form.
+List views display records in a tabular form.
 
 Their root element is ``<list>``. The most basic version of this view simply
 lists all the fields to display in the table (where each field is a column):


### PR DESCRIPTION
"List views, also called list views, display records in a tabular form."

I think this was mistake made when renaming "tree views" to "list views" from 17.0 to 18.0