### PR TITLE
[IMP] accounting: cheat sheet styles

### DIFF
--- a/static/css/accounting.css
+++ b/static/css/accounting.css
@@ -21,6 +21,7 @@ main.index .toctree-wrapper > .row:first-child > .col-md-3 {
 
 .related {
     background-color: hsl(317deg 16% 90%) !important;
+    border: 1px solid #000000 !important;
     transition: .3s;
 }
 .secondary {
@@ -46,13 +47,13 @@ label:hover,
 .accounts-table dl {
     margin: 0;
     padding: .5rem 0;
+    border: 1px solid transparent;
 }
 
 .accounts-table h4, .accounts-table h5 {
     font-weight: 700;
     text-transform: uppercase;
     padding: .5rem;
-
 }
 
 .accounts-table h4 {
@@ -61,11 +62,13 @@ label:hover,
 /* table root */
 .accounts-table > div {
     display: flex;
+    border: 1px solid transparent;
 }
 /* P&L & Balance Sheet columns */
 .accounts-table > div > div {
     flex: 1;
     padding: .5rem;
+    border: 1px solid transparent;
 }
 
 .accounts-table > div > div:first-child {
@@ -76,6 +79,7 @@ label:hover,
 .accounts-table > div > div div {
     display: flex;
     flex-direction: column;
+    border: 1px solid transparent;
 }
 
 .accounts-table > div > div div > h5 {
@@ -139,16 +143,19 @@ label:hover,
     .chart-of-accounts .highlight-op,
     .valuation-chart .highlight-op {
         background-color: #030035;
+        border-bottom: 1px solid #000000 !important;
     }
 
     .chart-of-accounts .highlight-op,
     .valuation-chart-continental .highlight-op {
         background-color: #030035;
+        border-bottom: 1px solid #000000 !important;
     }
 
     .chart-of-accounts .highlight-op,
     .valuation-chart-anglo-saxon .highlight-op {
         background-color: #030035;
+        border-bottom: 1px solid #000000 !important;
     }
 }
 .entries-listing {
@@ -173,20 +180,24 @@ label:hover,
         padding-top: 5px;
         padding-bottom: 5px;
         background-color: transparent;
+        border-bottom: 1px solid transparent;
     }
     60% {
         background-color: hsl(317deg 16% 90%);
+        border-bottom: 1px solid #000000;
     }
     80% {
         opacity: 1;
         padding-top: 5px;
         padding-bottom: 5px;
+        border-bottom: 1px solid #000000;
     }
     100% {
         opacity: 0;
         padding-top: 0;
         padding-bottom: 0;
         display: none;
+        border-bottom: 1px solid #000000;
     }
 }
 .reconcile1 .invoice1, .reconcile1 .invoice1 td {

--- a/static/js/reconciliation.js
+++ b/static/js/reconciliation.js
@@ -49,7 +49,7 @@
         update_btn();
 
         function update_btn() {
-            var $reconcile = $('<button class="btn btn-success" type="button">')
+            var $reconcile = $('<button class="btn btn-secondary" type="button">')
                 .text("Next Reconcile")
                 .appendTo($buttons.empty())
             switch (state) {


### PR DESCRIPTION
Task: [#4743756](https://www.odoo.com/odoo/project/3835/tasks/4743756)
FWP up to `master`

This PR improves the styles on the [Accounting Cheat Sheet](https://www.odoo.com/documentation/16.0/applications/finance/accounting/get_started/cheat_sheet.html) by adding borders which adds more contrast to the highlights.

- [Current Accounting Cheat Sheet](https://www.odoo.com/documentation/16.0/applications/finance/accounting/get_started/cheat_sheet.html)
- [This PR Accounting Cheat Sheet](https://runbot233.odoo.com/runbot/static/build/79031168-16-0/logs/build/html/applications/finance/accounting/get_started/cheat_sheet.html)

![Screenshot 2025-04-24 at 12 42 23 PM](https://github.com/user-attachments/assets/fc880a9f-b26b-4bf8-96d7-978ba9a0bde8)

As well as corrects the color of the Reconciliation button to use the Odoo primary and secondary colors:

![Screenshot 2025-04-24 at 12 43 37 PM](https://github.com/user-attachments/assets/574002d9-28c9-4f8c-abf2-92500b7121db)