### PR TITLE
[IMP] accounting/l10n_cl: Warning for automation disabling

### DIFF
--- a/content/applications/finance/fiscal_localizations/chile.rst
+++ b/content/applications/finance/fiscal_localizations/chile.rst
@@ -212,6 +212,11 @@ Certificates` section. Then, click :guilabel:`New` to configure the certificate:
    :alt: Digital certificate configuration.
    :align: center
 
+.. warning::
+   If the :guilabel:`Certificate Owner` field is set to a specific user, and there are no
+   certificates shared with users, then the automatic sending of electronic documents and receipt
+   acknowledgments is **disabled**.
+
 Multicurrency
 =============
 


### PR DESCRIPTION
The warning advises users that if they assign a certificate owner, automatic sending of electronic documents and reception acknowledgements will be disabled.

The reason if that these actions are done by the OdooBot user through Scheduled Actions. If there is an assigned Certificate Owner, the OdooBot is not able to use the certificate to sign the electronic documents.