### PR TITLE
[IMP] mail: from filter ICP missing part

### DIFF
--- a/content/applications/general/email_communication/email_servers_outbound.rst
+++ b/content/applications/general/email_communication/email_servers_outbound.rst
@@ -17,6 +17,16 @@ emails. The deliverability is optimized for this subdomain as it uses Odoo’s D
    If the database subdomain is `company-name.odoo.com` and all mailing configurations are the
    default ones, all emails will be sent from `notifications@company-name.odoo.com`.
 
+.. _email-outbound-default-from-filtering:
+
+This configuration is handled by the system parameter `mail.default.from_filter`.
+In case where the sender's domain do not match the value of this parameter, the notification address
+is used instead. Multiple values can be defined in this system parameter: comma-separated, domains
+or full email addresses are all allowed. Once an :ref:`outgoing mail server is configured
+<email-outbound-different-servers-personalized>`, the system parameter is no longer considered
+and the value used is the :ref:`FROM filtering
+<email-outbound-different-servers-personalized-from-filtering>` of the mail server.
+
 .. image:: email_servers_outbound/diagram-inbound-mailing-method.png
    :alt: Odoo’s default outbound messages configuration.
 
@@ -205,6 +215,9 @@ When an email is sent from Odoo, the following sequence is used to choose the ou
    higher the priority is). Failing to do so, the first server is determined by the servers' names,
    using alphabetical order.
 
+- If there is no mail server, Odoo relies on the :ref:`system parameter
+  <email-outbound-default-from-filtering>` value.
+
 It is also possible to use Odoo's mail server for transactional emails in addition to mass mailings.
 
 .. _email-outbound-different-servers-external-odoo:
@@ -325,7 +338,7 @@ Using a unique email address for all outgoing emails
 
 To force the email address from which emails are sent, activate the :ref:`developer-mode`, and go to
 :menuselection:`Settings --> Technical --> Email: Alias Domains`. On the :guilabel:`Default From
-Alias`, use the the local-part or a complete email address as the value.
+Alias`, use the local-part or a complete email address as the value.
 
 .. warning::
    If a **complete address** is used as the :guilabel:`Default From Alias` value, **all** outgoing


### PR DESCRIPTION
Functionals support noted that the from filter part without mail server was missing.
But was present on ancient documentation:
https://www.odoo.com/documentation/16.0/applications/general/email_communication/email_servers.html#use-a-default-from-email-address

Let's re-add it to clarify. And adding the anchoring

opw-4568395