### PR TITLE
[IMP] Lunch: fix vendors error

### DIFF
--- a/content/applications/hr/lunch/vendors.rst
+++ b/content/applications/hr/lunch/vendors.rst
@@ -154,7 +154,7 @@ or condiments.
       :alt: The first of the extras configured for pizza toppings.
 
    The pizzeria also offers a free beverage with any purchase. To set this up, the :guilabel:`Extra
-   2 Label` is set to `Beverages`, and the :guilabel:`Extra 1 Quantity` is set to :guilabel:`Only
+   2 Label` is set to `Beverages`, and the :guilabel:`Extra 2 Quantity` is set to :guilabel:`Only
    One`. The various beverage choices are added, and the cost for each remains zero.
 
    .. image:: vendors/beverages.png


### PR DESCRIPTION
Fixing an issue found by MFAR: "Hi, just noticed this, it should be Extra 2 quantity instead of Extra 1, as it's talking about the second extra and not the first one again https://www.odoo.com/documentation/18.0/applications/hr/lunch/vendors.html"

Just changing "1" to "2" in the very end of the doc.