### PR TITLE
[FIX] administration: Ubuntu 18.04 and Debian 10 no longer supported

### DIFF
--- a/content/administration/on_premise/packages.rst
+++ b/content/administration/on_premise/packages.rst
@@ -100,9 +100,9 @@ be downloaded from the `Odoo download page <https://www.odoo.com/page/download>`
    .. group-tab:: Debian/Ubuntu
 
       .. note::
-         Odoo {CURRENT_MAJOR_VERSION} 'deb' package currently supports `Debian Buster
-         <https://www.debian.org/releases/buster/>`_ and `Ubuntu 18.04
-         <https://releases.ubuntu.com/18.04>`_ or above.
+         Odoo {CURRENT_MAJOR_VERSION} 'deb' package currently supports `Debian Bookworm (12)
+         <https://www.debian.org/releases/bookworm/>`_ and `Ubuntu Jammy (22.04LTS)
+         <https://releases.ubuntu.com/jammy>`_ or above.
 
       Once downloaded, execute the following commands **as root** to install Odoo as a service,
       create the necessary PostgreSQL user, and automatically start the server:


### PR DESCRIPTION
odoo/odoo#136904

~~DRAFT: the section for fedora must be updated too, but I'm not a fedora user so I don't know~~ the fedora version is correct