### PR TITLE
[FIX] howto/website_themes: Theming/Media - Company logo typo

### DIFF
--- a/content/developer/howtos/website_themes/media.rst
+++ b/content/developer/howtos/website_themes/media.rst
@@ -86,8 +86,8 @@ Background images
 Company logo
 ~~~~~~~~~~~~
 
-For the company logo, the use is a little bit different. First declare it within the `images.xml`
-library and then call it using the right template. For instance, to call inside the header, we will
+For the company logo, the use is a little bit different. First declare it within the `website.xml`
+file and then call it using the right template. For instance, to call inside the header, we will
 use `<t t-call="website.placeholder_header_brand">`.
 
 .. code-block:: xml

--- a/content/developer/howtos/website_themes/theming.rst
+++ b/content/developer/howtos/website_themes/theming.rst
@@ -678,7 +678,7 @@ structure below.
    <odoo noupdate="1">
       <record id="website.default_website" model="website">
          <field name="name">Airproof</field>
-         <field name="logo" type="base64" file="website_airproof/static/src/img/content/logo_pred.png"/>
+         <field name="logo" type="base64" file="website_airproof/static/src/img/content/logo_airproof.png"/>
          <field name="favicon" type="base64" file="website_airproof/static/description/favicon.png" />
          <field name="shop_ppg">18</field>
          <field name="shop_ppr">3</field>


### PR DESCRIPTION
This PR fixes a little typo regarding what's explained into the Theming section about the `website.xml` file. The company logo is not declared as a regular image but as a field value into the website object itself. 

Task-4708496