### PR TITLE
[FIX] howto/website_themes: Building blocks typo

### DIFF
--- a/content/developer/howtos/website_themes/building_blocks.rst
+++ b/content/developer/howtos/website_themes/building_blocks.rst
@@ -476,7 +476,7 @@ page, directly from the edit panel.
 2. Group creation
 ~~~~~~~~~~~~~~~~~
 
-Add a group at the top of the list (feel free to the put it where needed in this list).
+Add a group at the top of the list (feel free to put it where needed in this list).
 
 .. code-block:: xml
    :caption: ``/website_airproof/views/snippets/options.xml``


### PR DESCRIPTION
This PR fixes a typo located into the "Custom snippets - Group creation".

Task-4708496