### PR TITLE
[ADD] inventory: add expiration notifications

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/product_management/product_tracking/expiration_dates.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/product_tracking/expiration_dates.rst
@@ -269,3 +269,17 @@ Then, click :guilabel:`Filters`, and choose :guilabel:`Expiration Alerts`.
 .. image:: expiration_dates/expiration-dates-expiration-alert.png
    :align: center
    :alt: Expiration alert for product past the expiration date.
+
+Expiration notifications
+------------------------
+
+Users can be notified when the expiration date for a product has passed. This can help keep specific
+employees up to date on the status of items under their purview.
+
+To configure a notification, navigate to :menuselection:`Inventory app --> Products --> Products`.
+Select a product configured with lot/serial numbers and expiration date tracking. Navigate to the
+:guilabel:`Inventory` tab. Under the :guilabel:`Logistics` section, select a user in the
+:guilabel:`Responsible` field.
+
+When the expiation date passes for a lot/serial number for this product, a notification is sent to
+the user in this field.


### PR DESCRIPTION
- Add Expiration Notification section to the inventory documentation.

This is a manual backport of the content (01cf1d3) that is currently on 18.0. At the moment, there is zero documentation for 17.0 users who are curious about setting up expiration notifications.