### PR TITLE
[FIX] howto/website_themes: Setup/Media - Custom header/footer templates typo

### DIFF
--- a/content/developer/howtos/website_themes/media.rst
+++ b/content/developer/howtos/website_themes/media.rst
@@ -137,8 +137,8 @@ Add videos as content.
 .. code-block:: xml
 
    <div class="media_iframe_video" data-oe-expression="...">
-       <div class="css_editable_mode_display">&nbsp;</div>
-       <div class="media_iframe_video_size" contenteditable="false">&nbsp;</div>
+       <div class="css_editable_mode_display" />
+       <div class="media_iframe_video_size" contenteditable="false" />
        <iframe src="..."
            frameborder="0"
            contenteditable="false"

--- a/content/developer/howtos/website_themes/setup.rst
+++ b/content/developer/howtos/website_themes/setup.rst
@@ -212,7 +212,7 @@ If necessary, disable the two-factor authentication enforcing policy option.
 .. code-block:: bash
 
     psql <database-name>
-    update res_users set top_secret='' where id=2;
+    update res_users set totp_secret='' where id=2;
 
 .. _website_themes/setup/getting_started :
 


### PR DESCRIPTION
This PR fixes 2 typos: 
- In the command line that remove the two factors authentication: `top` => `totp`;
- In the example of an embed video: `&nbsp;` replaced by an auto-closed tag.

Task-4879383