### PR TITLE
[IMP] fiscal_localizations/denmark: add DBA registration info

### DIFF
--- a/content/applications/finance/fiscal_localizations/denmark.rst
+++ b/content/applications/finance/fiscal_localizations/denmark.rst
@@ -10,6 +10,12 @@ specifically regarding the storage and integrity of financial transactions and r
 Odoo recognizes the importance of adhering to Danish regulations and has implemented robust
 measures to ensure clients' data is secure and compliant.
 
+.. important::
+   Odoo’s registration as a digital bookkeeping system has been confirmed by the Danish Business
+   Authority under registration numbers `fob585505` and `fob441967`. Customers must meet certain
+   conditions to benefit from it, as outlined below.
+
+
 Key requirements of the Danish Bookkeeping Act
 ----------------------------------------------
 
@@ -19,7 +25,7 @@ The Danish Bookkeeping Act (DBA) outlines the `requirements for digital bookkepi
 - **Retain transactional data and receipts:** Store all recorded transactions and receipts
   covered by § 3 for a minimum of five years from the end of the financial year to which they pertain.
 
-- **Ensure data integrity:** Prevent the company from changing, backdating, or deleting recorded transactions.
+- **Ensure data integrity:** Prevent the customer from changing, backdating, or deleting recorded transactions.
 
 - **Maintain data accessibility:** Store all recorded transactions in a structured and machine-readable format
   for the required five-year period, regardless of customer relationship status, bankruptcy, or dissolution.
@@ -27,11 +33,31 @@ The Danish Bookkeeping Act (DBA) outlines the `requirements for digital bookkepi
 - **Provide decryption capabilities:** Ensure that encrypted bookkeeping data and receipts can be decrypted
   into a structured and readable format.
 
-Odoo compliance measures
-------------------------
+Odoo Compliance
+---------------
 
-For companies using Odoo on Odoo Cloud hosting specifically, these requirements are met
-through the following features and processes:
+Odoo's registration as digital standard bookkeeping systems with the Danish Business Authority
+confirms that Odoo meets the applicable criteria for digital bookkeeping systems in Denmark,
+in accordance with the requirements of the :abbr:`DBA (Danish Bookkeeping Act)`.
+
+However, to benefit from all the required guarantees for digital bookkeeping systems in Denmark,
+customers must meet a few conditions.
+
+Conditions for full DBA compliance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The customer uses Odoo Accounting on the Odoo SaaS platform (Odoo Online);
+- The customer has an active Odoo subscription (e.g., Standard or Custom Plan), or their database is
+  managed by an officially registered `Odoo Accounting Firm <https://www.odoo.com/accounting-firms>`_;
+- The customer refrains from customizations or actions intended to undermine the system’s immutability,
+  traceability, or security controls.
+
+.. note::
+  Customers using Odoo products outside these conditions are responsible for ensuring their own
+  compliance with the DBA.
+
+When the above conditions are met, the requirements of the DBA are fulfilled through features and
+processes described in the following sections.
 
 Immutable transaction records
 -----------------------------
@@ -58,9 +84,9 @@ Continuous data availability
 Automated data export and secure storage
 ----------------------------------------
 
-- Odoo Accounting implements no automatic deletion or archival of recorded transactions, so if a company has
+- Odoo Accounting implements no automatic deletion or archival of recorded transactions, so if a customer has
   been recording transactions for six years, the six years of history are preserved in the Odoo Accounting database.
-- As described in the `Odoo SLA <https://www.odoo.com/cloud-sla>`_ and
+- As described in the `Odoo Cloud Hosting SLA <https://www.odoo.com/cloud-sla>`_ and
   `Odoo Privacy Policy <https://www.odoo.com/privacy>`_, the Odoo Cloud relies on immutable daily snapshot
   backups, which cannot be individually altered or deleted, even at the customer's request, ensuring their integrity.
 - All documents and receipts stored in a database backup are available as a standard ZIP archive accompanying
@@ -73,12 +99,10 @@ Data lifecycle management
 
 - Odoo database backups are available in standard SQL dump formats at all times and include all recorded
   transactions.
-- The default Odoo Cloud SLA guarantees three months of backup history to all active customers. As a special guarantee for
-  Danish companies subject to the :abbr:`DBA (Danish Bookkeeping Act)` and who opt for an Odoo Cloud solution, the backup retention gets increased
-  to six years as soon as they decide to terminate their Odoo Cloud subscription, in order to comply with the
-  requirements of Annex 1, 4 of Executive Order 97.
-- Companies who are using Odoo products outside of the Odoo Cloud are responsible for implementing their
-  own compliance with the :abbr:`DBA (Danish Bookkeeping Act)`.
+- The `Odoo Cloud Hosting SLA <https://www.odoo.com/cloud-sla>`_ guarantees three months of backup history to all
+  active customers. As a special guarantee for Danish customers subject to the DBA and meeting the conditions
+  highlighted above the last Odoo Cloud backup retention gets increased to six years as soon as they decide to
+  terminate their Odoo Cloud subscription, in order to comply with the requirements of Annex 1, 4 of Executive Order 97.
 
 Decryption
 ----------


### PR DESCRIPTION
Odoo is officially registered with the DBA as of May 22, 2025.

This commit adds the relevant information to inform customers of the conditions for compliance.

> According to Section 4(2) of the Executive Order on Notification and
> Registration, the provider of a registered digital standard
> bookkeeping system must clearly refer to the registration number in
> the marketing of the system and when entering into agreements for
> the use of the system. The term "clearly" refers to a reference that
> businesses are expected to immediately notice without having to read
> through a lengthy text. It is up to the provider to assess whether
> this is the case in practice, as the Danish Business Authority
> cannot approve specific wording proposals.
> This obligation applies to marketing and the conclusion of customer
> agreements that take place after receipt of the registration
> certificate, with allowance for necessary implementation time.

Update related to task-4604193