### PR TITLE
[ADD] accounting/l10n_co: Add doc on automatic currency Colombia

### DIFF
--- a/content/applications/finance/fiscal_localizations/colombia.rst
+++ b/content/applications/finance/fiscal_localizations/colombia.rst
@@ -289,6 +289,18 @@ is based on the PUC (Plan Unico de Cuentas).
 
 .. _localization/colombia/workflows:
 
+Multicurrency
+-------------
+The official exchange rate is provided by the `Banco de la República
+<https://suameca.banrep.gov.co/estadisticas-economicas/>`_.
+
+Go to :menuselection:`Accounting --> Configuration --> Settings --> Currencies: Automatic Currency
+Rates` to set an **Interval** for the exchange rate or select a different **service**.
+
+.. image::colombia/l10n-co-currency-rates.png
+   :align: center
+   :alt: Configuration for automatic currency rate for Colombia
+
 Main workflows
 ==============
 


### PR DESCRIPTION
Add documentation on the automatic currency rate for CO which is an integration with the "Banco de la Republica" service.

Drive with photos: https://drive.google.com/drive/folders/1jdPv6PNF_ekTuNxqw9GXoIJgII9HN-Eh?usp=sharing