### PR TITLE
Update external_api.rst

### DIFF
--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -952,7 +952,7 @@ a record).
 
       .. code-tab:: python
 
-         models.execute_kw(db, uid, password, 'res.partner', 'write', [[id], {'name': "Newer partner"}])
+         models.execute_kw(db, uid, password, 'res.partner', 'write', [id, {'name': "Newer partner"}])
          # get record name after having changed it
          models.execute_kw(db, uid, password, 'res.partner', 'read', [[id], ['display_name']])
 


### PR DESCRIPTION
Corrected the 'write' method arguments by removing the extra list nesting around the record ID. The correct format is [id, {fields}], not [[id], {fields}].