### PR TITLE
[FIX] Recruitment: Applicant analysis typo

### DIFF
--- a/content/applications/hr/recruitment/applicant_analysis.rst
+++ b/content/applications/hr/recruitment/applicant_analysis.rst
@@ -38,7 +38,8 @@ recruitment process. The displayed information can be modified, if desired.
 
 In this example, there are 18 total applicants. Out of that, six have been hired, two have been
 refused, and ten are still in the recruitment pipeline. The :guilabel:`Experienced Developer`
-position has six total applicants, three of which were hired, one refused, and to still in progress.
+position has six total applicants, three of which were hired, one refused, and two still in
+progress.
 
 .. image:: applicant_analysis/pivot-view.png
    :alt: The detailed pivot table view.


### PR DESCRIPTION
The following sentence in the 'Pivot Table' section needs to be edited: " The Experienced Developer position has six applicants, three of whom were hired, one refused, and one is still in progress." 

This should say "two still in progress" at the end of the sentence.

[Task card](https://www.odoo.com/odoo/project/3835/tasks/4967320) for this PR.

MFAR found this typo and posted it in the Odoo Discord:
<img width="1013" height="388" alt="image" src="https://github.com/user-attachments/assets/917cac06-e57d-472c-8870-5dbf24012c60" />
