### PR TITLE
[FIX] developer: wrong import path for Form module in tests

### DIFF
--- a/content/developer/tutorials/unit_tests.rst
+++ b/content/developer/tutorials/unit_tests.rst
@@ -213,7 +213,7 @@ Here are a few things to take into consideration before writing a test
 
 .. note:: Remember that ``onchange`` only applies in the Form views, not by changing the attributes
   in python. This also applies in the tests. If you want to emulate a Form view, you can use
-  ``odoo.tests.common.Form``.
+  ``odoo.tests.Form``.
 
 The tests should be in a ``tests`` folder at the root of your module. Each test file name
 should start with `test_` and be imported in the ``__init__.py`` of the test folder. You shouldn't


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/116779/commits/f5e7c67892cb7f096a08869e085ea1b5c546ed3d, Form is in odoo.tests and not in odoo.tests.common anymore

task-none