### PR TITLE
Update testing.rst

### DIFF
--- a/content/developer/reference/backend/testing.rst
+++ b/content/developer/reference/backend/testing.rst
@@ -759,7 +759,7 @@ You can then update :file:`__manifest__.py` to add :file:`your_tour.js` in the a
         'data/your_tour.xml',
      ],
      'assets': {
-         'web.assets_backend': [
+         'web.assets_frontend': [
              'your_module/static/src/js/tours/your_tour.js',
          ],
      },


### PR DESCRIPTION
The current instructions generate errors when attempting to load the tour.

`module_loader.js:165 The following modules are needed by other modules but have not been defined, they may not be present in the correct asset bundle:  (3) ['web_tour.tour', 'web.core', 'web.utils']`

Replacing by `web.assets_frontend` fixes the issue.