### PR TITLE
[IMP] Attendances: Updating Main Details Section

### DIFF
--- a/content/applications/hr/attendances.rst
+++ b/content/applications/hr/attendances.rst
@@ -242,9 +242,10 @@ Main details
   employee has checked out.
 - :guilabel:`Worked Time`: the total amount of time the employee logged for the day, across multiple
   check-ins and outs. In an hour and minute format (HH:MM).
-- :guilabel:`Worked Extra Hours`: approved overtime (shows **only** when present for the employee).
-- :guilabel:`Extra Hours`: unpaid overtime hours worked beyond the expected working schedule (the
-  :guilabel:`Worked Time` minus the approved :guilabel:`Worked Extra Hours`.
+- :guilabel:`Worked Extra Hours`: unpaid overtime hours worked beyond the expected working schedule
+  (shows **only** when present for the employee).
+- :guilabel:`Extra Hours`: approved overtime (the :guilabel:`Worked Time` minus the approved
+  :guilabel:`Worked Extra Hours`.
 
 Check in/check out details
 --------------------------


### PR DESCRIPTION
Error found by  CSAM - this was from a Discord chat:

"Hi, mistake in the documentation I believe: https://www.odoo.com/documentation/18.0/applications/hr/attendances.html#main-details
It should be the other way around. "Worked Extra hours" is what is registered as just extra worked. "Extra Hours" is what is approved as paid overtime."

Original [task card](https://www.odoo.com/odoo/project/3835/tasks/5009867) for this PR.