### PR TITLE
[FIX] fiscal_localizations: change iot Mac to identifier

### DIFF
--- a/content/applications/finance/fiscal_localizations/belgium.rst
+++ b/content/applications/finance/fiscal_localizations/belgium.rst
@@ -576,8 +576,8 @@ IoT box, you must contact us through our `support contact form <https://www.odoo
 provide the following information:
 
 - your VAT number;
-- your company's name, address, and legal structure; and
-- the Mac address of your IoT Box.
+- your company's name, address, and legal structure;
+- the identifier of your IoT Box.
 
 Once your IoT box is certified, :doc:`connect <../../general/iot/connect>` it to your database. To
 verify that the IoT Box recognizes the FDM, go to the IoT homepage and scroll down the


### PR DESCRIPTION
The new identifier for IoT Boxes it the serial number (or motherboard uuid, for Virtual IoT Boxes), we then need to update the documentation to lead to IoT Boxes identifier instead of not existing anymore mac address.

Task: 5001274