### PR TITLE
[IMP] conf: strip `odoo.upgrade.testing`

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -383,11 +383,13 @@ def source_read_replace(app, docname, source):
 def upgrade_util_signature_rewrite(app, domain, objtype, contentnode):
     # Same as add_module_names=False but **only** for odoo.upgrade.util functions or classes
     signature = contentnode.parent[0]
-    if objtype == 'function' and signature.astext().startswith('odoo.upgrade.util.'):
+    if objtype == 'function' and signature.astext().startswith(('odoo.upgrade.util.', 'odoo.upgrade.testing.')):
         # <odoo.upgrade.util.modules>, <modules_installed>, <(cr, *modules)>
+        # <odoo.upgrade.testing>, <change_version>, <(version_str)>
         signature.pop(0)
-    if objtype == 'class' and signature.astext().startswith('class odoo.upgrade.util.'):
+    if objtype == 'class' and signature.astext().startswith(('class odoo.upgrade.util.', 'class odoo.upgrade.testing.')):
         # <class >, <odoo.upgrade.util.pg.>, <PGRegexp>
+        # <class >, <odoo.upgrade.testing.>, <UpgradeCase>
         signature.pop(1)
 
 def setup(app):

--- a/content/developer/reference/upgrades/upgrade_utils.rst
+++ b/content/developer/reference/upgrades/upgrade_utils.rst
@@ -111,3 +111,10 @@ Misc
 
 .. automodule:: odoo.upgrade.util.misc
    :members:
+
+
+Testing upgrade scripts
+=======================
+
+.. automodule:: odoo.upgrade.testing
+   :members:


### PR DESCRIPTION
The prefix that includes the full module path is just noise. This patch follows the same strategy used to remove `odoo.upgrade.util` prefix.

To be merged after: odoo/upgrade-util#324