### PR TITLE
[FIX] coding_guidelines: Change camelcase for Pascal case

### DIFF
--- a/content/contributing/development/coding_guidelines.rst
+++ b/content/contributing/development/coding_guidelines.rst
@@ -828,7 +828,7 @@ Symbols and Conventions
     - When defining *report* model (SQL views e.i.) : use
       ``<related_base_model>.report.<action>``, based on the Transient convention.
 
-- Odoo Python Class : use camelcase (Object-oriented style).
+- Odoo Python Class : use Pascal case (Object-oriented style).
 
 
 .. code-block:: python
@@ -837,7 +837,7 @@ Symbols and Conventions
         ...
 
 - Variable name :
-    - use camelcase for model variable
+    - use Pascal case for model variable
     - use underscore lowercase notation for common variable.
     - suffix your variable name with *_id* or *_ids* if it contains a record id or list of id. Don't use ``partner_id`` to contain a record of res.partner
 
@@ -966,7 +966,7 @@ Javascript coding guidelines
 - ``use strict;`` is recommended for all javascript files
 - Use a linter (jshint, ...)
 - Never add minified Javascript Libraries
-- Use camelcase for class declaration
+- Use Pascal case for class declaration
 
 More precise JS guidelines are detailed in the `github wiki  <https://github.com/odoo/odoo/wiki/Javascript-coding-guidelines>`_.
 You may also have a look at existing API in Javascript by looking Javascript


### PR DESCRIPTION
The coding guidelines establish that we have to write class declaration for both Python and JavaScript in camel case but it's actually in Pascal case. It also establishing that model variable (ex: `Partner = self.env['res.partner]'`) has to be in camel case but it's actually following the Pascal case.

Pascal case has to start all variables with a capital letter where camel case is starting with a lower case letter.

Source: https://builtin.com/articles/pascal-case-vs-camel-case

no task id