### PR TITLE
[FIX] Incorrect example in Webhook doc

### DIFF
--- a/content/applications/studio/automated_actions/webhooks.rst
+++ b/content/applications/studio/automated_actions/webhooks.rst
@@ -177,8 +177,8 @@ that, click the :guilabel:`Body` tab and select the :guilabel:`raw` option. Set 
 .. code-block:: json
 
    {
-       "model": "sale.order",
-       "id": "SALES ORDER NUMBER"
+       "_model": "sale.order",
+       "_id": "SALES ORDER NUMBER"
    }
 
 From here, choose a sales order to test the webhook on. If it is not possible to test in a live


### PR DESCRIPTION
Updates documentation to clearly distinguish between user-testing errors and errors stemming from the Odoo documentation itself. Lack of clarity, particularly with complex topics like Odoo ORM and Webhooks, can discourage users and erode credibility when the perceived error is not their fault.