### PR TITLE
The actual minimal python that runs Odoo 19 is 3.10.12

### DIFF
--- a/content/administration/on_premise/source.rst
+++ b/content/administration/on_premise/source.rst
@@ -1,4 +1,4 @@
-==============
+.==============
 Source install
 ==============
 
@@ -118,7 +118,7 @@ Prepare
 Python
 ~~~~~~
 
-Odoo requires **Python 3.10** or later to run.
+Odoo requires **Python 3.10.12** or later to run.
 
 .. versionchanged:: 17
     Minimum requirement updated from Python 3.7 to Python 3.10.


### PR DESCRIPTION


Odoo 19 requires minimal of python 3.10.12 because it uses a variable named _WHATWG_C0_CONTROL_OR_SPACE that was introduced in version 3.10.12. Please check [release notes](https://docs.python.org/release/3.10.12/whatsnew/changelog.html), more specifically [Pull request gh-102153](https://github.com/python/cpython/pull/102508). Running Odoo 19 on python 3.10.4 which is the base not updated version of python on Ubuntu 22.04 gives the following error: 

from urllib.parse import *WHATWG*C0_CONTROL_OR_SPACE ImportError: cannot import name '_WHATWG_C0_CONTROL_OR_SPACE' from 'urllib.parse' (/usr/lib/python3.10/urllib/parse.py) 