### PR TITLE
[IMP] inventory: multiple qty def fix

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/warehouses_storage/replenishment/reordering_rules.rst
+++ b/content/applications/inventory_and_mrp/inventory/warehouses_storage/replenishment/reordering_rules.rst
@@ -102,9 +102,14 @@ and fill out the following fields for the new reordering rule line item:
   levels goes below this number, the replenishment is triggered.
 - :guilabel:`Max Quantity`: The amount of product that should be available after replenishing the
   product.
-- :guilabel:`Multiple Quantity`: If the product should be ordered in specific quantities, enter the
-  number that should be ordered. For example, if the :guilabel:`Multiple Quantity` is set to `5`,
-  and only 3 are needed, 5 products are replenished.
+- :guilabel:`Multiple Quantity`: Ensures products are replenished in fixed multiples, rounding the
+  ordered quantity up to the nearest multiple that meets or slightly exceeds the :guilabel:`Max
+  Quantity`.
+
+  For example, if :guilabel:`Multiple Quantity` is `3`, products are ordered in multiples of three
+  (3, 6, 9, ...). If the :guilabel:`Max Quantity` is `20` and the forecasted quantity is `7`, the
+  required quantity is `13`. Because `13` is not a multiple of three, Odoo rounds up and orders
+  `15`.
 
 .. image:: reordering_rules/reordering-rule-form.png
    :align: center


### PR DESCRIPTION
17.0: Clarifies *Multiple* field definition, defining replenishment quantities to be defined in fixed multiples.

## Changelog
- Odoo selects the smallest multiple that exceeds the defined Max quantity
- *Multiple* value is entered on the replenishment report as a defined quantity
- In [v18](#14850), this will change to the biggest multiple that **does not** exceed the Max.
- In [v19](#14853), this will change back to the smallest multiple that exceed the max.

### Example
If the Multiple = 3 and Max = 20, Odoo orders 21 units — the smallest multiple of three that exceeds the maximum.