### PR TITLE
[IMP] inventory: multiple qty def fix

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/warehouses_storage/replenishment/reordering_rules.rst
+++ b/content/applications/inventory_and_mrp/inventory/warehouses_storage/replenishment/reordering_rules.rst
@@ -112,9 +112,13 @@ rule line item:
   triggered. When forecasted stock falls below this number, a replenishment order for the product is
   created.
 - :guilabel:`Max`: The maximum quantity at which the stock is replenished.
-- :guilabel:`Multiple Quantity`: If the product should be ordered in specific quantities, enter the
-  number that should be ordered. For example, if the :guilabel:`Multiple Quantity` is set to `5`,
-  and only 3 are needed, 5 products are replenished.
+- :guilabel:`Multiple Quantity`: Ensures products are replenished in fixed multiples, rounding the
+  ordered quantity up to the nearest multiple that remains below or equal to the :guilabel:`Max`
+  quantity.
+
+  For example, if :guilabel:`Multiple Quantity` is set to `3`, Odoo orders in multiples of three (3,
+  6, 9, ...). If the :guilabel:`Max` is `20` and the forecasted quantity is `7`, the required
+  quantity is `13`. Because `13` is not a multiple of three, Odoo rounds down and orders `12`.
 
 .. figure:: reordering_rules/reordering-rule-form.png
    :alt: The form for creating a new reordering rule.


### PR DESCRIPTION
18.0: Adjust logic of *Multiple* field in reordering rules to prevent overstocking by ensuring replenishment quantities never exceed the defined maximum

## Changelog
- Odoo now selects the largest multiple that **does not exceed the Max** quantity.
  - Previously in [v17](#14849), Odoo selected the multiple that **exceeded** the maximum.
- The Multiple field remains a numeric value, representing a fixed quantity multiple.
- In the v19, the system will **go back to** selecting the multiple that **exceeds** the max.

### Example
If the Multiple = 3 and Max = 20, Odoo orders 18 units — the highest multiple of three that stays below or equal to the maximum.