### PR TITLE
[IMP] Subscription: Add Important block regarding On Delivery invoicing

### DIFF
--- a/content/applications/sales/subscriptions.rst
+++ b/content/applications/sales/subscriptions.rst
@@ -182,6 +182,11 @@ subscription product will function correctly:
 - :guilabel:`Sales Price`: enter the recurring cost of the subscription that the customer will pay
   per recurrence period.
 
+.. important::
+   When creating a subscription for a physical good, selecting the wrong :guilabel:`Invoicing
+   Policy` will lead to errors when creating invoices. Physical products must be set to
+   :guilabel:`Ordered quantities`.
+
 Optionally set up information on the :doc:`Attributes & Variants
 <sales/products_prices/products/variants>` tab if the subscription contains multiple choices for
 customers (i.e. food delivery, tailored fashion boxes, etc.).


### PR DESCRIPTION
Quick fix on subscriptions.rst to add an "Important" block highlighting that combining a physical product subscription with an on delivery invoicing policy will throw an error during invoicing. This PR resolves [this task](https://www.odoo.com/odoo/my-tasks/3990242).

This 17.0 PR can be FWP up to master.