### PR TITLE
[IMP] inventory: add fedex broken api warning

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration/fedex.rst
+++ b/content/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration/fedex.rst
@@ -7,6 +7,14 @@ delivery rates <../setup_configuration>`, and :doc:`generate delivery labels <la
 This is accomplished by enabling the FedEx *shipping connector*, then configuring at least one
 *shipping method*.
 
+.. warning::
+   As of October 21, 2025, the FedEx integration using the latest API is temporarily unavailable
+   while FedEx reviews Odoo's certification as a solution provider. Any *existing* integrations
+   using the *FedEx Legacy* provider currently work, but *new* setups are currently **blocked**.
+
+   While this issue is being resolved, `submit a support ticket <https://www.odoo.com/help>`_ for
+   available workarounds.
+
 .. note::
    This documentation contains configuration details specific to FedEx integration. See the
    documentation on :doc:`third-party shippers <third_party_shipper>` for general shipper

--- a/content/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration/sendcloud_shipping.rst
+++ b/content/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration/sendcloud_shipping.rst
@@ -6,10 +6,6 @@ Sendcloud is a shipping service aggregator that facilitates the integration of E
 carriers with Odoo. Once integrated, users can select shipping carriers on inventory operations in
 their Odoo database.
 
-.. seealso::
-   `Sendcloud integration documentation <https://support.sendcloud.com/hc/en-us/articles
-   /360059470491-Odoo-integration>`_
-
 Setup in Sendcloud
 ==================
 


### PR DESCRIPTION
Add warning as per Damien's request that the FedEx API is currently unavailable, and suggest customers to continue using FedEx legacy. Will remove this warning block promptly after the issue is fixed.

As per Monika's request, we're removing the Sendcloud article link because the instructions capture a setup workflow using OdooShop, a third party app, and is not reflective of how to set up Sendcloud through Odoo Inc. Our team has contacted Sendcloud's support team about this issue and have not received a response, so we'll remove the Sendcloud reference article for now.  
