### PR TITLE
[I18N] fix Korean po file

### DIFF
--- a/locale/ko/LC_MESSAGES/finance.po
+++ b/locale/ko/LC_MESSAGES/finance.po
@@ -11109,8 +11109,8 @@ msgstr ":doc:`알맞게 결제대행업체 설정 <../../payment_providers>` 되
 msgid "By default, \":doc:`Wire Transfer </applications/finance/payment_providers/wire_transfer>`\" is the only payment provider activated, but you still have to fill out the payment details."
 msgstr ""
 "기본값으로 "
-"\":doc:`온라인 이체 </applications/finance/payment_providers/wire_transfer>`\"
-""만 결제대행업체을 사용하도록 설정되어 있으나, 여기에도 결제 세부 정보를 "
+"\":doc:`온라인 이체 </applications/finance/payment_providers/wire_transfer>`"
+"\"만 결제대행업체을 사용하도록 설정되어 있으나, 여기에도 결제 세부 정보를 "
 "입력해야 합니다."
 
 #: ../../content/applications/finance/accounting/payments/online.rst:25


### PR DESCRIPTION
Weblate sometimes incorrectly msgmerges when a line ends with `/""` and wraps one of the `"`'s to the next line causing an invalid po file since the closing `"` is now escaped so the line never correctly ends.

This unfortunately has to be manually fixed directly in the code for now.