### PR TITLE
[IMP] l10n_gt: Add Infile registration form link to documentation

### DIFF
--- a/content/applications/finance/fiscal_localizations/guatemala.rst
+++ b/content/applications/finance/fiscal_localizations/guatemala.rst
@@ -27,7 +27,8 @@ The supported documents are:
 - :guilabel:`FACT-Factura with Export Complement`.
 
 The localization requires an `Infile <https://infile.com.gt/>`_ account, which enables users to
-generate electronic documents within Odoo.
+generate electronic documents within Odoo. To request an Infile account, fill out the `Infile
+Registration Form <https://share.hsforms.com/1HksZ6i1VRRWHRhXPvYZORQrwu2r>`_.
 
 .. seealso::
    :doc:`Documentation on e-invoicing's legality and compliance in Guatemala
@@ -131,6 +132,11 @@ Infile
 
 Sign a service agreement directly with `Infile <https://infile.com.gt/>`_. Infile will then provide
 the necessary credentials to input in Odoo.
+
+.. note::
+   To create an Infile account and benefit from the **8% discount** available for Odoo customers,
+   fill out the: `Infile Registration Form <https://share.hsforms.com/1HksZ6i1VRRWHRhXPvYZORQrwu2r>`_.
+   An Infile agent will contact you to help you complete the onboarding process and sign the service agreement.
 
 Odoo
 ~~~~


### PR DESCRIPTION
This PR updates the Guatemala EDI documentation to include a direct link to the official Infile registration form used by Odoo customers to request their account.

**Changes included**

- Added a new note under the Infile subsection with the registration form link and a short explanation of how Infile will contact the user to complete the onboarding.
- Added a reference to the same form in the Introduction section to give users an additional entry point when starting the setup.

**Purpose**

This update helps new customers begin their Infile onboarding process more easily by providing the correct registration channel directly in the documentation. It ensures that users know where to submit their information before configuring credentials in Odoo.

No functional changes

Documentation-only update.