### PR TITLE
[IMP] Multi: minor content changes for 19.0

### DIFF
--- a/content/applications/general/users/portal.rst
+++ b/content/applications/general/users/portal.rst
@@ -7,8 +7,8 @@ Portal access
 Portal access is given to users who need the ability to view certain documents or information within
 an Odoo database.
 
-Some common use cases for providing portal access include allowing customers to read/view any or all
-of the following in Odoo:
+Some common use cases for providing portal access include allowing customers to make partial payment
+on an invoice, to add funds to their eWallet, and to read/view any or all of the following in Odoo:
 
 - leads/opportunities
 - quotations/sales orders

--- a/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
@@ -46,9 +46,9 @@ Price` or :guilabel:`Cost` fields.
    :alt: Edit the inventory unit of measure in the "Sales Price" or "Cost" fields.
 
 .. important::
-   The :guilabel:`Sales Price` and :guilabel:`Cost` units of measure cannot be updated
-   independently of each other. When one unit of measure is updated, the other unit of measure
-   automatically updates to use the same unit of measure.
+   The :guilabel:`Sales Price` and :guilabel:`Cost` units of measure cannot be updated independently
+   of each other. When one unit of measure is updated, the other unit of measure automatically
+   updates to use the same unit of measure.
 
 Sales unit of measure (packagings)
 ----------------------------------
@@ -69,7 +69,8 @@ Purchase unit of measure
 
 Units of measure that the product is purchased in are defined in the :guilabel:`Purchase` tab of the
 product. Purchase orders can be created in these units of measure after they are defined in the
-vendor price list.
+vendor price list. Purchase units of measure must be in the same category as the default unit of
+measure.
 
 .. image:: uom/purchase-uom.png
    :alt: Specify a purchase unit of measure in the "Purchase" tab.
@@ -101,8 +102,7 @@ Buy products in the purchase UoM
 When creating a new request for quotation (RFQ) in the *Purchase* app, Odoo pulls the unit that the
 vendor prefers to use, defined in the :guilabel:`Unit` field of the vendor line in the
 :guilabel:`Purchase` tab of the product. The unit the vendor prefers **can** be different from the
-unit your company prefers to use. If needed, manually edit the :guilabel:`Unit` value on
-the |RFQ|.
+unit your company prefers to use. If needed, manually edit the :guilabel:`Unit` value on the |RFQ|.
 
 After the |RFQ| is confirmed into a |PO|, click the :guilabel:`Receipt` smart button at the top of
 the |PO|.
@@ -111,9 +111,9 @@ Odoo automatically converts the purchase unit of measure into the product's sale
 measure, so the :guilabel:`Demand` column of the delivery receipt shows the converted quantity.
 
 .. example::
-   When the product's purchase :guilabel:`Unit` is `m` (meters), and its inventory unit of
-   measure is `yard`, the |PO| shows the quantity in meters, and the receipt (and other
-   internal warehouse documents) shows the quantity in yards.
+   When the product's purchase :guilabel:`Unit` is `m` (meters), and its inventory unit of measure
+   is `yard`, the |PO| shows the quantity in meters, and the receipt (and other internal warehouse
+   documents) shows the quantity in yards.
 
    .. figure:: uom/on-po.png
       :alt: Image of a purchase order that is using the purchase unit of measure.
@@ -163,9 +163,9 @@ measure into the product's inventory unit of measure, so the :guilabel:`Demand` 
 delivery shows the converted quantity.
 
 .. example::
-   When the product's sales :guilabel:`Unit` is `m` (meters), and its inventory unit of
-   measure is `yard`, the |SO| shows the quantity in meters, and the delivery (and other
-   internal warehouse documents) shows the quantity in yards.
+   When the product's sales :guilabel:`Unit` is `m` (meters), and its inventory unit of measure is
+   `yard`, the |SO| shows the quantity in meters, and the delivery (and other internal warehouse
+   documents) shows the quantity in yards.
 
    .. figure:: uom/on-so.png
       :alt: Sales order that is using the sales unit of measure.
@@ -175,8 +175,7 @@ delivery shows the converted quantity.
    .. figure:: uom/on-delivery.png
       :alt: Delivery displaying the inventory unit of measure.
 
-      Upon warehouse delivery, the recorded quantities are in the internal "Unit":
-      `yards`.
+      Upon warehouse delivery, the recorded quantities are in the internal "Unit": `yards`.
 
 Create custom units of measure
 ==============================
@@ -187,8 +186,8 @@ of measure.
 
 To create a new unit, click the :guilabel:`New` button. Specify a unit name. If you want to convert
 between units, specify a quantity and a reference unit of measure to convert between. If applicable,
-enter a :guilabel:`UNSPSC Category`, which is a globally recognized `code managed by
-GS1 <https://www.unspsc.org/>`_, that **must** be purchased in order to use.
+enter a :guilabel:`UNSPSC Category`, which is a globally recognized `code managed by GS1
+<https://www.unspsc.org/>`_, that **must** be purchased in order to use.
 
 .. example::
    You will be purchasing fabric in terms of yards or meters. Specify that one yard is equal to

--- a/content/applications/sales/sales.rst
+++ b/content/applications/sales/sales.rst
@@ -7,11 +7,12 @@
 Sales
 =====
 
-**Odoo Sales** is the application to run your sales process (from quotation to sales order) and
-deliver and invoice what has been sold.
+The **Sales** application is used to run the sales process (from quotation to sales order) and
+deliver and invoice what has been sold. Any product with the *Sales* checkbox ticked on its product
+form can be sold with the **Sales** app.
 
 .. seealso::
-   - `Odoo Tutorials: Sales Tutorials <https://www.odoo.com/slides/sales-17>`_
+   - `Odoo Tutorials: Sales <https://www.odoo.com/slides/sales-17>`_
 
 .. toctree::
    :titlesonly:

--- a/content/applications/sales/sales/commissions.rst
+++ b/content/applications/sales/sales/commissions.rst
@@ -97,9 +97,9 @@ Achievement-based commission plans
 ----------------------------------
 
 In a *Achievement* based commission plan, salespeople earn a percentage of their invoice value as
-commission. Target based plans are ideal for rewarding sales activity consistently, regardless of
-specific goals. For example, offering a `5%` commission on all invoiced amounts, regardless of how
-much is sold.
+commission. Achievement-based plans are ideal for rewarding sales activity consistently, regardless
+of specific goals. For example, offering a `5%` commission on all invoiced amounts, regardless of
+how much is sold.
 
 .. tip::
    Achievement based plans differ from *Target* based plans because they are calculated based on
@@ -126,7 +126,8 @@ Achievements
 ------------
 
 Performance can be measured in several ways in performance plans. These are configured in the
-:guilabel:`Achievements` tab of each plan.
+:guilabel:`Achievements` tab of each plan. It is possible to track achievements by all products
+sold, by specific products sold, by all products sold in a specific category, and more.
 
 - :guilabel:`Amount Sold`: the total value of sales orders (SOs).
 - :guilabel:`Amount Invoiced`: the total value of confirmed invoices.

--- a/content/applications/sales/sales/invoicing/invoicing_policy.rst
+++ b/content/applications/sales/sales/invoicing/invoicing_policy.rst
@@ -4,12 +4,13 @@ Invoice based on delivered or ordered quantities
 
 Different business policies might require different options for invoicing:
 
-- The *Invoice what is ordered* rule is used as the default mode in Odoo *Sales*, which means
+- The *Invoice what is ordered* rule is used as the default mode in Odoo **Sales**, which means
   customers are invoiced once the sales order is confirmed.
 - The *Invoice what is delivered* rule invoices customers once the delivery is done. This rule is
   often used for businesses that sell materials, liquids, or food in large quantities. In these
   cases, the ordered quantity may differ slightly from the delivered quantity, making it preferable
-  to invoice the quantity actually delivered.
+  to invoice the quantity actually delivered. When the delivery order is validated, Odoo will
+  automatically decrease the on-hand quantity in the inventory.
 
 Being able to have different invoicing options provides more flexibility.
 
@@ -66,7 +67,6 @@ The following is a breakdown of how invoicing policy rules impact the aforementi
       :align: center
       :alt: If Delivered Quantities invoicing policy is chosen, ensure a quantity has been
             delivered.
-
 .. note::
    Once a quotation is confirmed, and the status changes from :guilabel:`Quotation sent` to
    :guilabel:`Sales order`, the delivered and invoiced quantities are available to view, directly

--- a/content/applications/sales/sales/invoicing/milestone.rst
+++ b/content/applications/sales/sales/invoicing/milestone.rst
@@ -2,9 +2,9 @@
 Invoice project milestones
 ==========================
 
-Invoicing based on project milestones can be used for expensive or large-scale projects. The series
-of milestones in a project represent a clear sequence of work that will inevitably result in the
-completion of a project and/or contract.
+Invoicing based on project milestones can be used for expensive or large-scale projects with
+discrete, measurable deliverables. The series of milestones in a project represent a clear sequence
+of work that will inevitably result in the completion of a project and/or contract.
 
 This method of invoicing ensures the company gets a consistent flow of money throughout the lifetime
 of the project. Customers can closely monitor every phase of the project's development as it

--- a/content/applications/sales/sales/products_prices/prices/pricing.rst
+++ b/content/applications/sales/sales/products_prices/prices/pricing.rst
@@ -2,9 +2,10 @@
 Pricelists
 ==========
 
-A *pricelist* is a method of dynamic pricing that applies a list of prices (or price rules) to
-adjust sales prices. This adjustment can apply to specific customers, customer groups, sales orders,
-time periods, etc., and is useful for creating pricing strategies and optimizing sales margins.
+A *pricelist* is a method of dynamic pricing that applies a list of prices (or price rules) that
+overrides the sales price on a product's product form. This adjustment can set to apply to all
+products sold or tailored to only apply to specific customers, customer groups, sales orders, time
+periods, etc., and is useful for creating pricing strategies and optimizing sales margins.
 
 Odoo **Sales** has a useful pricelist feature that can be tailored to fit any unique pricing
 strategy. Pricelists suggest certain prices, but they can always be overridden on the sales order.
@@ -73,9 +74,11 @@ Price Rules tab
 ---------------
 
 In the :guilabel:`Price Rules` tab, each line creates a new record that will implement customized
-pricing to the sales order where the pricelist is applied. To create a new price rule, click on
-:guilabel:`Add a line`, which opens a new pricelist rules form.
+pricing to the sales order where the pricelist is applied. This can be used to create complex
+pricing structures, such as progressive discounts when greater quantities of a product are
+purchased.
 
+To create a new price rule, click on :guilabel:`Add a line`, which opens a new pricelist rules form.
 Then, select whether to apply this set of rules to a :guilabel:`Product` or :guilabel:`Category`.
 
 From here, there are several configuration options:

--- a/content/applications/sales/sales/products_prices/products/variants.rst
+++ b/content/applications/sales/sales/products_prices/products/variants.rst
@@ -78,7 +78,8 @@ The :guilabel:`Display Type` options are:
 - :guilabel:`Select`: options appear in a drop-down menu on the product page of the online store.
   set, on the product page of the online store.
 - :guilabel:`Multi-checkbox (option)`: options appear as selectable checkboxes on the product page
-  of the online store.
+  of the online store. This allows customers to choose options for themselves and is good choice for
+  highly customizable products.
 
 .. image:: variants/display-types.png
    :align: center
@@ -92,8 +93,8 @@ once an attribute is added to a product.
    order for the :guilabel:`Multi-checkbox (option)` to work properly as the :guilabel:`Display
    Type`.
 
-- :guilabel:`Instantly`: creates all possible variants as soon as attributes and values are added
-  to a product template.
+- :guilabel:`Instantly`: creates all possible variants as soon as attributes and values are added to
+  a product template.
 - :guilabel:`Dynamically`: creates variants **only** when corresponding attributes and values are
   added to a sales order.
 - :guilabel:`Never (option)`: never automatically creates variants.
@@ -162,23 +163,23 @@ color selector pop-up window.
 .. image:: variants/picking-a-color.png
    :alt: Selecting a color from the HTML color pop-up window that appears on attribute form.
 
-In this pop-up window, select a specific color by dragging the color slider to a particular hue,
-and clicking on the color portion directly on the color gradient window.
+In this pop-up window, select a specific color by dragging the color slider to a particular hue, and
+clicking on the color portion directly on the color gradient window.
 
 Or, choose a specific color by clicking the *dropper* icon, and selecting a desired color that's
 currently clickable on the screen.
 
-If you sell products with specific patterns, you can also add an image to display the
-pattern of the product. To do so, click the :icon:`fa-camera` :guilabel:`(camera)` icon,
-then click the :icon:`fa-pencil` :guilabel:`(pencil)` icon and select an image from your local
-drive. This pattern will appear as a color option on the ecommerce product page.
+Businesses can attach images to product variant attribute values for customers to view on an
+eCommerce webite. To do so, click the :icon:`fa-camera` :guilabel:`(camera)` icon, then click the
+:icon:`fa-pencil` :guilabel:`(pencil)` icon and select an image from your local drive. This image
+will appear as a color option on the ecommerce product page.
 
 .. image:: variants/ecommerce-pattern-option.png
    :alt: Pattern as color option on the ecommerce page.
 
 .. tip::
-   Attributes can also be created directly from the product template by adding a new line and
-   typing the name into the :guilabel:`Variants` tab.
+   Attributes can also be created directly from the product template by adding a new line and typing
+   the name into the :guilabel:`Variants` tab.
 
 Once an attribute is added to a product, that product is listed and accessible, via the attribute's
 :guilabel:`Related Products` smart button. That button lists every product in the database currently
@@ -283,8 +284,8 @@ impacts that can be taken advantage of throughout the Odoo database.
 
 - :guilabel:`Barcode`: barcodes are associated with each variant, instead of the product template.
   Each individual variant can have its own unique barcode/SKU.
-- :guilabel:`Price`: every product variant has its own public price, which is the sum of the
-  product template price *and* any extra charges for particular attributes.
+- :guilabel:`Price`: every product variant has its own public price, which is the sum of the product
+  template price *and* any extra charges for particular attributes.
 
   .. example::
    A red shirt's sales price is $23 -- because the shirt's template price is $20, plus an additional

--- a/content/applications/sales/sales/sales_quotations/create_quotations.rst
+++ b/content/applications/sales/sales/sales_quotations/create_quotations.rst
@@ -148,7 +148,8 @@ newly-selected catalog items can be found in the :guilabel:`Order Lines` tab.
 
 If multiple items should be presented in a more organized way on the quotation, click :guilabel:`Add
 a section`, enter a name for the section, and drag-and-drop that section heading in the desired
-location amongst the items in the :guilabel:`Order Lines` tab. The section heading appears in bold.
+location amongst the items in the :guilabel:`Order Lines` tab. The section heading appears in bold
+and a sub-total for all products in a section is displayed.
 
 If needed, click :guilabel:`Add a note` beneath a certain product line to add a custom note about
 that specific product. The note appears in italics. Then, if needed, proceed to drag-and-drop the

--- a/content/applications/sales/sales/sales_quotations/margin.rst
+++ b/content/applications/sales/sales/sales_quotations/margin.rst
@@ -79,8 +79,7 @@ product. Follow these steps:
 
 #. Go to :menuselection:`Sales app --> Products --> Pricelists` and click the :guilabel:`New`
    button.
-#. Enter the name of the pricelist and click :guilabel:`Add a line` to create a new pricelist
-   rule.
+#. Enter the name of the pricelist and click :guilabel:`Add a line` to create a new pricelist rule.
 #. Configure the pricelist and click :guilabel:`Save & Close` button.
 #. Go to :menuselection:`Sales app --> Orders --> Quotations` and create a quotation.
 #. In the :guilabel:`Pricelist` field, select the newly made pricelist.
@@ -110,6 +109,6 @@ product. Follow these steps:
 .. tip::
    Another way to visualize the impact of margins on sales orders is to go to :menuselection:`Sales
    app --> Orders --> Quotations`, select the :icon:`fa-area-chart` :guilabel:`(area chart)` icon or
-   :icon:`oi-view-pivot` :guilabel:`(pivot)` icon, click :guilabel:`Measures` button and change it
-   to :guilabel:`Margin` to see margin contributions across the customer base.
+   :icon:`oi-view-pivot` :guilabel:`(pivot)` icon, click :guilabel:`Measures` drop-down button and
+   change it to :guilabel:`Margin` to see margin contributions across the customer base.
 

--- a/content/applications/websites/ecommerce/checkout.rst
+++ b/content/applications/websites/ecommerce/checkout.rst
@@ -29,11 +29,11 @@ Default add to cart behavior
 
 When clicking the :guilabel:`Add to cart` button, different actions can be triggered. To configure
 them, go to :menuselection:`Website --> Configuration --> Settings`, scroll down to the
-:guilabel:`eCommerce` section, and select one of the following options for the
-:guilabel:`Add to cart` feature:
+:guilabel:`eCommerce` section, and select one of the following options for the :guilabel:`Add to
+cart` feature:
 
-- :guilabel:`Stay on Product Page`: The customer can choose if they want to :guilabel:`Add
-  to cart` and continue shopping or :guilabel:`Go to the Checkout`.
+- :guilabel:`Stay on Product Page`: The customer can choose if they want to :guilabel:`Add to cart`
+  and continue shopping or :guilabel:`Go to the Checkout`.
 - :guilabel:`Go to cart`: The customer is immediately redirected to the cart.
 
 .. _ecommerce/checkout/prevent-sale:
@@ -66,8 +66,8 @@ You can add additional :guilabel:`Add to Cart` buttons and link them to specific
 website page.
 
 To add them, open the website editor and place the :guilabel:`Add to Cart Button` inner content
-building block. Once placed, click the button, scroll to the :guilabel:`Add to Cart Button`
-section, and configure the following:
+building block. Once placed, click the button, scroll to the :guilabel:`Add to Cart Button` section,
+and configure the following:
 
 - :guilabel:`Product`: Select the product to link the button with.
 - :guilabel:`Action`: Choose if it should be an :guilabel:`Add to Cart` or :ref:`Buy Now
@@ -154,9 +154,9 @@ Order summary
 
 The :guilabel:`Order summary` step allows customers to see the items they added to their cart,
 adjust quantities, :guilabel:`Remove` products, and :ref:`reorder products from a previous order
-<ecommerce/checkout/reorder>`. Information related to the product prices and
-taxes applied are also displayed. Customers can then click the :guilabel:`Checkout` button to
-continue to the :ref:`Address and delivery <ecommerce/checkout/delivery>` step.
+<ecommerce/checkout/reorder>`. Information related to the product prices and taxes applied are also
+displayed. Customers can then click the :guilabel:`Checkout` button to continue to the :ref:`Address
+and delivery <ecommerce/checkout/delivery>` step.
 
 Open the website editor to :ref:`enable <ecommerce/checkout/customize_steps>` checkout options such
 as:
@@ -225,15 +225,14 @@ Configuration --> Payment Providers`, :guilabel:`Activate` the relevant payment 
 :ref:`configure <payment_providers/add_new>` it.
 
 .. tip::
-   The options displayed at checkout depend on the active payment providers, the
-   enabled :ref:`payment methods <payment_providers/payment_methods>`, the :ref:`customer’s country
-   and currency <payment_providers/currencies_countries>`, and, optionally, the :ref:`maximum
-   amount <payment_providers/maximum_amount>` set for the provider.
+   The options displayed at checkout depend on the active payment providers, the enabled
+   :ref:`payment methods <payment_providers/payment_methods>`, the :ref:`customer’s country and
+   currency <payment_providers/currencies_countries>`, and, optionally, the :ref:`maximum amount
+   <payment_providers/maximum_amount>` set for the provider.
 
-   To display an :ref:`availability <payment_providers/availability>` report for payment
-   providers and payment methods and help diagnose potential availability issues on the payment
-   form, enable the :ref:`developer mode <developer-mode>` and click the :icon:`fa-bug`
-   (:guilabel:`bug`) icon.
+   To display an :ref:`availability <payment_providers/availability>` report for payment providers
+   and payment methods and help diagnose potential availability issues on the payment form, enable
+   the :ref:`developer mode <developer-mode>` and click the :icon:`fa-bug` (:guilabel:`bug)` icon.
 
 Terms and conditions
 ~~~~~~~~~~~~~~~~~~~~
@@ -260,7 +259,9 @@ Order confirmation
 ------------------
 
 The final step of the checkout process is the :guilabel:`Order confirmation`, which provides a
-summary of the customer's purchase details.
+summary of the customer's purchase details. If the :guilabel:`Automatic Invoice` setting has been
+activated in the **Sales** app's configuration settings, a sales order and invoice will
+automatically be created by Odoo.
 
 .. seealso::
    :doc:`Order handling documentation <order_handling>`


### PR DESCRIPTION
Hiya, Felicia! Here's a slew of minor content changes to align our documentation with the 19.0 release. This PR has 14 minor changes across 11 pages. Beyond this, I think there will be three more PRs addressing features that aren't adequately documented, and possibly two whole new pages around setting warnings on products and eventually how the heck the customer portal works.

This version also implement feedback from auva from a now-closed branch.

This 19.0 PR can be FWP up to master.