### PR TITLE
[IMP] Sales: clarification around invoicing on delivery

### DIFF
--- a/content/applications/sales/sales/invoicing/invoicing_policy.rst
+++ b/content/applications/sales/sales/invoicing/invoicing_policy.rst
@@ -28,7 +28,8 @@ delivered`.
 .. important::
    If the :guilabel:`Invoice what is delivered` rule is chosen, it is **not** possible to activate
    the :guilabel:`Automatic Invoice` feature, which automatically generates invoices when an online
-   payment is confirmed.
+   payment is confirmed. Regular draft invoices can only be created once the delivery order has been
+   processed and validated.
 
 Invoicing policy on product form
 ================================
@@ -63,7 +64,8 @@ The following is a breakdown of how invoicing policy rules impact the aforementi
 
    .. image:: invoicing_policy/invoicing-policy-error-message.png
       :align: center
-      :alt: If Delivered Quantities invoicing policy is chosen, ensure a quantity has been delivered.
+      :alt: If Delivered Quantities invoicing policy is chosen, ensure a quantity has been
+            delivered.
 
 .. note::
    Once a quotation is confirmed, and the status changes from :guilabel:`Quotation sent` to


### PR DESCRIPTION
Hi, Felicia! This is a clarification that when selling products with the "invoice based on what's delivered" option, it's not possible to generate an invoice at all until the delivery order has been verified. I thought that this clarification would originally require more elaboration, but as I was looking for a suitable document to add it to, I found an existing section that it slots nicely into. I originally anticipated this being a more involved update, but as is, I'd say it's only worth 1 point.

This 19.0 PR can be FWP up to master.