### PR TITLE
[IMP] developer/javascript_reference: hide_trailing_zeros statinfo option

### DIFF
--- a/content/developer/reference/frontend/javascript_reference.rst
+++ b/content/developer/reference/frontend/javascript_reference.rst
@@ -1036,6 +1036,13 @@ Stat Info (`statinfo`)
                 />
             </button>
 
+    - `hide_trailing_zeros`: hide zeros to the right of the last non-zero digit,
+      e.g. `1.20` becomes `1.2` (`false` by default).
+
+        .. code-block:: xml
+
+            <field name="int_value" widget="statinfo" options="{'hide_trailing_zeros': true}" />
+
 Percent Pie (`percentpie`)
     This widget is meant to represent statistical information in a `stat button`.
     This is similar to a statinfo widget, but the information is represented in


### PR DESCRIPTION
This commit adds the documentation for new option
`hide_trailing_zeros` supported in statinfo widget.

Community PR: https://github.com/odoo/odoo/pull/235931

task-5238438