### PR TITLE
[IMP] reference/cli: db-filter for Web UI

### DIFF
--- a/content/developer/reference/cli.rst
+++ b/content/developer/reference/cli.rst
@@ -220,7 +220,7 @@ Database
 
 .. option:: --db-filter <filter>
 
-    hides databases that do not match ``<filter>``. The filter is a
+    hides databases that do not match ``<filter>`` for the Web UI. The filter is a
     `regular expression`_, with the additions that:
 
     - ``%h`` is replaced by the whole hostname the request is made on.
@@ -269,6 +269,8 @@ Database
     and update base module on one database: 11firstdatabase.
     If database 11seconddatabase doesn't exist, the database is created and base modules
     is installed
+
+    .. warning:: This option does not affect cron workers, if no --database is given, cron workers will run on every available database
 
 .. option:: --db-template <template>
 


### PR DESCRIPTION
The odoo-bin help for the db-filter says:
`Regular expressions for filtering available databases for Web UI.`

However, the current documentation does not mention that the filters
only affect the Web UI, and not the cron workers.