### PR TITLE
[IMP] Sales: Default pricelist clarification

### DIFF
--- a/content/applications/sales/sales/products_prices/prices/pricing.rst
+++ b/content/applications/sales/sales/products_prices/prices/pricing.rst
@@ -34,7 +34,10 @@ modified at any time.
 
 .. important::
    If there is no specific pricelist configured on a sales quotation, the :guilabel:`Default`
-   pricelist is applied.
+   pricelist is applied. The :guilabel:`Default` pricelist is the first pricelist found in
+   :menuselection:`Sales app --> Products --> Pricelists` without an assigned :guilabel:`Country
+   Group`. Odoo will read the :guilabel:`Pricelist Name` column from top to bottom to determine the
+   :guilabel:`Default` pricelist.
 
 .. note::
    The :guilabel:`Selectable` column is only applicable to Odoo **eCommerce**. This option allows


### PR DESCRIPTION
Hi, Felicia! This PR adds a few sentences to the Sales app's Pricelists page that clarify what the Default pricelist actually is. It uses language from the eCommerce app's Prices page, tweaked slightly to fit better into Sales. This PR resolves the [Update Sales Pricelist Documentation](https://www.odoo.com/odoo/action-4043/5074432) task.

This 18.0 PR can be FWP up to master.