### PR TITLE
[IMP] developer: review calendar date_stop/date_delay definitions

### DIFF
--- a/content/developer/reference/user_interface/view_architectures.rst
+++ b/content/developer/reference/user_interface/view_architectures.rst
@@ -3222,15 +3222,7 @@ Their root element is ``<calendar>``. Available attributes on the root node are:
 
    :requirement: Optional
    :type: str
-
-.. attribute:: date_delay
-   :noindex:
-
-   Alternative to ``date_stop``. Provides the duration of the event instead of
-   its end date (unit: hour).
-
-   :requirement: Optional
-   :type: str
+   :default: ``date_start``
 
 .. attribute:: scales
    :noindex:


### PR DESCRIPTION
The `date_delay` option was removed in [1] but the documentation still mentioned it. Also reviewed the default value of `date_stop`.

[1]: https://github.com/odoo/odoo/commit/40c75d3635b4d0de8fca631e4aebd26a466a8709

Related to task-5350495