### PR TITLE
[IMP] whatsapp: clarify "to" field for test message recipients, remove future tense

### DIFF
--- a/content/applications/general/email_communication/mailjet_api.rst
+++ b/content/applications/general/email_communication/mailjet_api.rst
@@ -94,11 +94,10 @@ Conformance)` settings on the domain of the sender.
    - `Mailjet's DMARC documentation
      <https://documentation.mailjet.com/hc/en-us/articles/20531905163419-Understanding-DMARC>`_
 
-.. important::
-   If the database is not using a custom domain, then in order to verify the sender's address, a
-   temporary alias (of the three email addresses mentioned above) should be set up in Odoo CRM to
-   create a lead. Then, the database is able to receive the verification email and verify the
-   accounts.
+.. warning::
+   It is recommended to set up a custom domain. Due to increased security on provider side, emails
+   sent with an outgoing mail server other than the Odoo's provided one using subdomain
+   (dbname.odoo.com) will fail due to DMARC policy, and/or be marked as spam.
 
 .. _maintain/mailjet-api/add-domain:
 

--- a/content/applications/productivity/whatsapp.rst
+++ b/content/applications/productivity/whatsapp.rst
@@ -4,163 +4,159 @@ WhatsApp
 
 **WhatsApp** is an instant messaging and voice-over-IP app that allows users to send messages, make
 calls, and share content. Businesses can use `WhatsApp Business
-<https://developers.facebook.com/products/whatsapp/>`_ to communicate with their customers by text,
-send documents and provide support.
+<https://developers.facebook.com/products/whatsapp/>`__ to communicate with their customers by text,
+send documents, and provide support. This documentation covers the integration of a WhatsApp
+Business Account (WABA) with Odoo.
 
 .. warning::
-   WhatsApp is an Odoo Enterprise-only application that does not work in Odoo Community edition. To
-   sign up for Odoo Enterprise edition, click here: `Odoo Free Trial <https://www.odoo.com/trial>`_.
+   **WhatsApp** is an Odoo Enterprise-only application that does not work in Odoo Community edition.
+   To use the Odoo **WhatsApp** app, sign up for `Odoo Enterprise edition
+   <https://www.odoo.com/trial>`_.
 
 .. seealso::
-   For more information on migrating from Odoo Community version to Odoo Enterprise version see this
-   documentation: :doc:`/administration/on_premise/community_to_enterprise`.
+   :doc:`/administration/on_premise/community_to_enterprise`
 
-With the **Odoo WhatsApp** app, a company can connect a WhatsApp Business Account (WABA) to an Odoo
-database, which allows for the following:
+Connecting a WhatsApp Business Account (WABA) to an Odoo database enables the following in Odoo's
+**WhatsApp** app:
 
-- Receive and reply to WhatsApp messages directly from an Odoo database
-- Create new templates with dynamic placeholders/variables
-- Send pre-approved templates that use dynamic variables, such as:
+- Send and receive WhatsApp messages directly from an Odoo database.
+- Create and send pre-approved templates with dynamic placeholders/variables, such as:
 
-  - Quotations from the Sales app
-  - Receipts and invoices from the Point of Sale app
-  - Tickets from the Events app
+  - Quotations from the **Sales** app.
+  - Receipts and invoices from the **Point of Sale** app.
+  - Tickets from the **Events** app.
 
 .. seealso::
    - `Meta Business: create message templates for the WhatsApp Business account
-     <https://www.facebook.com/business/help/2055875911147364>`_.
+     <https://www.facebook.com/business/help/2055875911147364>`__
    - `Meta Business: connect a phone number to the WhatsApp Business account
-     <https://www.facebook.com/business/help/456220311516626>`_.
+     <https://www.facebook.com/business/help/456220311516626>`__
    - `Meta Business: change the WhatsApp Business display name
-     <https://www.facebook.com/business/help/378834799515077>`_.
+     <https://www.facebook.com/business/help/378834799515077>`__
 
-WhatsApp is a messaging service operated by Meta, which is the parent company of Facebook. WhatsApp
-is commonly used as a communication tool in many countries and by many businesses. This
-documentation will cover the integration of a WhatsApp Business Account with Odoo. The company's
-Meta account is configured in Odoo via an :abbr:`API (Application Programming Interface)`
-connection.
+The WhatsApp integration supports two flows: company-initiated and customer-initiated. A company can
+start a discussion by sending a template to one or more customers. If the customer answers within 15
+days, a **Discuss** chat window pops up to begin the conversation.
 
-The WhatsApp connector supports two flows: company initiated, and customer initiated. A company can
-initiate a discussion by sending a template to one or more people. Once the template is sent, the
-recipient can answer in order to trigger a discussion between the sender and the receiver (a
-*Discuss* chat window will pop up if the customer answers within 15 days).
-
-If the discussion is initiated by the client (e.g. by sending to the company's public WhatsApp
-number), then Odoo will open a group chat with all operators responsible for this WhatsApp channel.
+If a customer initiates by sending a message to the company's public WhatsApp number, Odoo opens a
+group chat with all operators responsible for the WhatsApp channel.
 
 .. tip::
-   It is recommended to set up multiple WhatsApp accounts for different departments. For example,
-   the help desk team and sales teams can chat on different channels.
+   Consider setting up separate WhatsApp accounts for each department, to better manage
+   communications.
 
-WhatsApp configuration in a Meta
-================================
+.. seealso::
+   `Magic Sheet - WhatsApp configuration [PDF]
+   <https://drive.google.com/drive/folders/1hHEYq6jxmqKGFOeM3UQ7vOfiF7KuGX5W>`_
 
-A WhatsApp integration with Odoo uses a standard :abbr:`API (Application Programming Interface)`
-connection, and is configured on Meta in the following steps:
+WhatsApp configuration in Meta
+==============================
 
-#. Create a Meta business account
-#. Create a Meta developer account
-#. Setup an *app* and WhatsApp *product* on Meta's developer console
+WhatsApp is operated by Meta, the parent company of Facebook. Odoo's WhatsApp integration uses a
+standard :abbr:`API (Application Programming Interface)` connection configured in Meta:
+
+#. Create a Meta business account.
+#. Create a Meta developer account.
+#. Set up an *app* and WhatsApp *product* in Meta's developer console.
 #. Test the API connection.
 
-Once connected, messages are then sent and received through Odoo's *Discuss* application using the
-WhatsApp :abbr:`API (Application Programming Interface)`.
+Once the WhatsApp :abbr:`API (Application Programming Interface)` is connected, Odoo users can send
+and receive messages through Odoo's **Discuss** application.
 
-Meta business account setup
----------------------------
+Create a Meta business account
+------------------------------
 
-To create a Business account with Meta (owner of Facebook) navigate to: `Facebook Business Manager
-<https://business.facebook.com/overview>`_. Begin by clicking :guilabel:`Create account` and then
-enter the business name, the administrator's name, and a work email address. Then click
-:guilabel:`Next`, and a pop-up window will appear prompting to confirm the email address. After
-confirming, click :guilabel:`Done` to close the window.
+.. important::
+   In order to create a Meta business account, the user must have a personal Facebook account that
+   has existed for a minimum of one hour prior to setting up the Facebook Business account. Trying
+   to create the business account prior to this time results in an error.
+
+To create a business account with Meta, navigate to `Meta Business Suite
+<https://business.facebook.com/overview>`__. Click :guilabel:`Create account` and then enter the
+business name, the administrator's name, and a work email address. Click :guilabel:`Next`, and
+confirm the email address in the pop-up window that appears. After confirming, click
+:guilabel:`Done` to close the window.
 
 Next, follow the instructions in the email sent by Facebook to confirm the creation of the business
 account and to complete the setup process.
 
 .. seealso::
    `Set up a Meta business account
-   <https://www.facebook.com/business/help/1710077379203657?id=180505742745347>`_.
+   <https://www.facebook.com/business/help/1710077379203657?id=180505742745347>`__
 
 .. important::
-   If the business account is linked to a personal Facebook account then the administrator must
-   toggle between the personal account to the business account for the remainder of the
-   configuration.
+   If the business account is linked to a personal Facebook account, the administrator must switch
+   between their personal account and the business account for the remainder of the configuration.
 
-   To toggle to the business account navigate to the `Facebook Developer Console
-   <https://developers.facebook.com>`_ and click on the *account name* in the upper right corner.
-   Under the :guilabel:`Business Accounts` heading, click on the desired business that the WhatsApp
-   configuration should take place in. This will be the account for which Odoo will send and receive
-   WhatsApp messages.
+   To switch to the business account, navigate to the `Meta Developer Dashboard
+   <https://developers.facebook.com>`__ and click the *account name* in the top-right corner. Under
+   :guilabel:`Business Accounts`, select the business to be configured.
 
-   .. image:: whatsapp/toggle.png
-      :align: center
-      :alt: Toggle between Meta personal and business accounts.
+Create a Meta developer app for Odoo
+------------------------------------
 
-.. important::
-   In order to create a Meta business account, the user must already have a personal Facebook
-   account that has existed for a minimum of one hour prior to setting up the Facebook Business
-   account. Trying to create the business account prior to this time will result in an error.
-
-App creation
-------------
-
-On the `Meta for Developers <https://developers.facebook.com>`_ dashboard, sign in with the Meta
-developer account. If no account is configured yet, link a Facebook account to create a Meta
+On the `Meta Developer Dashboard <https://developers.facebook.com>`__ dashboard, sign in with the
+Meta developer account. If no account is configured yet, link a Facebook account to create a Meta
 developer account.
 
 .. note::
    A Facebook *developer* account is different than a Facebook *business* account. While developer
-   accounts are made up of personal Facebook accounts, business accounts are **not** as they
-   represent a business and manage all of the business's assets in Meta, such as apps.
+   accounts are tied to personal Facebook accounts, business accounts are **not** as they represent
+   a business and manage all of the business's assets in Meta, such as apps.
 
 .. seealso::
    `Set up the WhatsApp Business Platform
-   <https://www.facebookblueprint.com/student/collection/409587/path/360218>`_.
+   <https://www.facebookblueprint.com/student/collection/409587/path/360218>`__
 
-Click on :guilabel:`My Apps` in the top right corner after successfully signing in to the Meta
-developer account. This will redirect the administrator to all the apps the developer has configured
-in this specific developer account. Click on :guilabel:`Create App` to begin the process of
-configuring a new Meta application.
+After signing in to the Meta developer account, click :guilabel:`My Apps` in the top-right corner.
+This redirects the administrator to all the apps the developer has configured in the specific
+developer account. Click :guilabel:`Create App` to configure a new Meta application.
 
-App type
---------
+.. _whatsapp/app-details:
 
-On the :menuselection:`Create an app` page, select :guilabel:`Other` under the section labeled,
-:guilabel:`Looking for something else?`, and then click :guilabel:`Next` to be directed to another
-page in order to select the app type. Then, click on the first option listed under the
-:guilabel:`Select an app type` label, titled :guilabel:`Business`. This selection allows for the
-creation and management of the WhatsApp :abbr:`API (Application Programming Interface)`.
+Add app details
+---------------
 
-Now, click :guilabel:`Next` to configure the app, as desired. When the app *type* has been
-configured, the administrator will move onto the app *details* section.
-
-App details
------------
-
-On the :guilabel:`Details` section of the :guilabel:`Create an app` process, enter `Odoo` in the
-field under the :guilabel:`Add an app name` label.
+The first step of the :guilabel:`Create an app` process is to fill out the :guilabel:`App details`
+section. Enter `Odoo` in the :guilabel:`App name` field.
 
 .. note::
-   The app name can be changed at a later time in the settings, if necessary.
+   The app name can be changed in the settings afterward.
 
 .. warning::
-   Trademarks and branded elements may not be used in this text section. These include the Meta
-   group of companies. Do not include the word: `WhatsApp` or the system will flag this in error.
+   Trademarks and branded elements may **not** be used in this text section. This includes the Meta
+   group of companies. Do **not** include the word `WhatsApp` or the system flags this as an error.
 
-Next, enter the developer email address in the field under the :guilabel:`App contact email` label.
+Next, enter the developer email address in the :guilabel:`App contact email` field, then click
+:guilabel:`Next`.
 
-Lastly, set the :guilabel:`Business Account - Optional` field to the Meta business account profile,
-using the drop-down menu. To finish, click :guilabel:`Create app`. This action will create the app
-and prompts the *Meta Platform Terms* and *Developer Policies* agreements.
+Select the app type
+-------------------
 
-To accept the agreements, enter the Facebook password for security purposes, and click
-:guilabel:`Submit` to finalize the app creation. The browser will then direct to the :guilabel:`Meta
-for Developers` dashboard.
+The next step in app creation is the ::guilabel:`Use cases` section. Under :menuselection:`Filter
+by`, select :guilabel:`Others`, select :guilabel:`Others`, then click :guilabel:`Next`. The page
+redirects to :guilabel:`Select an app type`.
 
-.. note::
-   If the Meta business account is prohibited from advertising, claiming an app won't be allowed. To
-   resolve this issue navigate to `<https://business.facebook.com/business>`_ for assistance.
+Select :guilabel:`Business`. This selection allows for the creation and management of the WhatsApp
+:abbr:`API (Application Programming Interface)`. Click :guilabel:`Next` to configure the app as
+desired.
+
+Select the business portfolio
+-----------------------------
+
+The last step of the app creation process is to connect a business portfolio.
+
+Under :guilabel:`Business portfolio - Optional`, click the drop-down menu and select the Meta
+business account profile. Review the *Meta Platform Terms* and *Developer Policies* agreements, then
+click :guilabel:`Create app` to accept and create the app.
+
+To accept the agreements and create the app, enter the Facebook account password and click
+:guilabel:`Submit`. The browser then redirects to the :guilabel:`Meta for Developers` dashboard.
+
+.. warning::
+   If the Meta business account is prohibited from advertising, the app can't be claimed. To resolve
+   this issue, navigate to `Meta Business Suite <https://business.facebook.com/business>`__ for
+   assistance.
 
    For more information, see `Meta's documentation on advertising restrictions
    <https://www.facebook.com/business/help/975570072950669>`_.
@@ -168,48 +164,49 @@ for Developers` dashboard.
 Add a WhatsApp product to the app
 ---------------------------------
 
-Now that the basic structure of the app has been created, a product will need to be added to the
-app. Begin by accessing the Meta app dashboard by navigating to
-`<https://developers.facebook.com/apps>`_, and clicking on the app that is being configured.
+Now that the basic structure of the app has been created, a product needs to be added to the app.
+Navigate to the `Meta Developer Dashboard <https://developers.facebook.com/apps>`__, and click on
+the app that is being configured. The page redirects to the app's dashboard.
 
-On the next page: since WhatsApp will be used, click :guilabel:`Set up` next to the box containing
-WhatsApp, located towards the bottom of the page.
+Under :guilabel:`Add products to your app`, go to WhatsApp near the bottom of the page and click
+:guilabel:`Set up`.
 
 .. seealso::
-   `Meta's WhatsApp developer documentation <https://developers.facebook.com/docs/whatsapp/>`_.
+   `Meta's WhatsApp developer documentation <https://developers.facebook.com/docs/whatsapp/>`__
 
-The page then directs to the configuration page for the :guilabel:`WhatsApp Business Platform API`.
-Use the drop-down menu to select the Meta business to be configured for the :guilabel:`Select a Meta
-Business Account` option, and then click :guilabel:`Continue` to confirm the selection.
+The browser then redirects to the configuration page for the :guilabel:`WhatsApp Business Platform
+API`.
+
+Under :guilabel:`Select a Meta Business Account` option, select the Meta business to be configured,
+then click :guilabel:`Continue` to confirm the selection and agree to Meta's terms and conditions as
+linked on the :guilabel:`Meta App Dashboard`.
+
+Once the WhatsApp product is added to the app, Meta provides a WhatsApp test phone number. This test
+phone number can send unlimited messages to a maximum of five recipients.
+
+Under :guilabel:`Send and receive messages`, select the :guilabel:`To` field and choose
+:guilabel:`Manage phone number list`. Add up to five valid WhatsApp number as recipients, then enter
+the confirmation codes sent to those phone numbers in WhatsApp to verify.
+
+.. seealso::
+   `WhatsApp Cloud API guide
+   <https://developers.facebook.com/docs/whatsapp/cloud-api/get-started#add-recipient-number>`__
+
+WhatsApp API quickstart
+-----------------------
+
+Once the Meta accounts and app have been configured, click :guilabel:`Continue` to proceed to the
+WhatsApp :guilabel:`Quickstart` page. This page provides a starting point for configuring the
+WhatsApp API by adding a phone number and sending an initial test message.
 
 .. note::
-   When :guilabel:`Continue` is clicked, the administrator agrees to Meta's terms and conditions as
-   linked on the :guilabel:`Meta App Dashboard`.
+   If the browser doesn't automatically redirect to the WhatsApp :guilabel:`Quickstart` page,
+   navigate to the `Meta Developer Dashboard <https://developers.facebook.com/apps>`__ and select
+   the `Odoo` app.
 
-.. note::
-   Once the WhatsApp product is added to the app, Meta will provide a WhatsApp test phone number
-   with 5 test messages.
-
-Start using the WhatsApp API
-----------------------------
-
-After finishing the previous WhatsApp product wizard, and clicking :guilabel:`Continue`, the browser
-should have directed to the WhatsApp :guilabel:`Quickstart` page; this :guilabel:`Quickstart` page
-is where to begin configuring the WhatsApp API by adding a phone number and then sending an initial
-test message.
-
-.. image:: whatsapp/quickstart.png
-   :align: center
-   :alt: Navigating to the WhatsApp quickstart wizard in Meta for Developer dashboard.
-
-.. note::
-   If the browser isn't on the :guilabel:`Quickstart` page for WhatsApp, navigate to
-   `<https://developers.facebook.com/apps>`_ and click on the app that is being configured, (the
-   app name is `Odoo` if the instructions above were followed).
-
-   Then, in the menu on the left-hand side of the page, click the :guilabel:`v (menu toggle)` icon
-   next to the :guilabel:`WhatsApp` section heading. A small menu will open, containing the
-   following options:
+   In the menu on the left-hand side of the page, click the :icon:`fa-chevron-down` :guilabel:`(down
+   chevron)` icon next to the :guilabel:`WhatsApp` section heading. A small menu opens, containing
+   the following options:
 
    - :guilabel:`Quickstart`
    - :guilabel:`API Setup`
@@ -222,49 +219,47 @@ API Setup
 
 After clicking on :guilabel:`Start using the API`, the page navigates to the :guilabel:`API Setup`.
 Now that the test number has been created, a test message can be sent to confirm that WhatsApp is
-working properly. To begin, navigate to the section on the page labeled :guilabel:`Send and receive
-messages` and click the drop-down menu next to :guilabel:`To`, under :guilabel:`Step 1 Select phone
-numbers`.
+working properly. Navigate to the :guilabel:`Send and receive messages` section. Under
+:guilabel:`Step 1 Select phone numbers`, click the drop-down menu next to :guilabel:`To`.
 
-Now, select the only option available: :guilabel:`Manage phone number list`. Follow the steps and
-add up to five numbers to send the free test messages to. After entering the appropriate country
-code and phone number, click on :guilabel:`Next`.
+Next, select the only option available: :guilabel:`Manage phone number list`. Follow the steps and
+add up to five phone numbers to send the free test messages to. Enter the appropriate country code
+and phone number, then click :guilabel:`Next`.
 
 .. important::
-   Adding a phone number to send to in this step will allow for a successful test to be sent by the
+   Adding a phone number to send to in this step allows for a successful test to be sent by the
    terminal. This is critical to ensure the WhatsApp :abbr:`API (Application Programming Interface)`
    is working.
 
-A verification code from WhatsApp Business is then sent to the phone number, which needs to be input
-on the next screen to verify ownership of the number. Enter the verification code and click
-:guilabel:`Next` to verify the number.
+On the next page, enter the verification code sent to the phone numbers, and click :guilabel:`Next`
+to verify the numbers.
 
 Send a test message via terminal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Next, send a test message via the terminal. Under the section labeled :guilabel:`Step 2 Send
-messages with the API`, click :guilabel:`Send Message`. A test message will then be sent to the
-phone number that was set in the previous section.
+Once the phone number has been verified, send a test message via the terminal. Under :guilabel:`Step
+2 Send messages with the API`, click :guilabel:`Send Message`. This should send a test message to
+the phone numbers that were added.
 
-Upon successfully receiving the message to the number, move onto the next section to produce and
-configure webhooks.
+Upon successfully receiving the message to the numbers, move onto the next section to :ref:`produce
+and configure webhooks <productivity/whatsapp/webhooks>`.
 
 .. _productivity/whatsapp/webhooks:
 
 WhatsApp configuration in Odoo
 ==============================
 
-The next steps configured in this section are all within the Odoo database. A few different values
-for a token, phone number, and account IDs all need to be configured in Odoo; these values are
-necessary in order to create a :guilabel:`Callback URL` and :guilabel:`Webhook Verify Token`, which
-are then used to configure the webhooks (in order to receive messages back into the database).
+To create a :guilabel:`Callback URL` and :guilabel:`Webhook Verify Token`, the phone number, token,
+app ID, and account ID need to be configured in Odoo; these values are used to set up webhooks,
+which make it possible to receive messages in the database. The configuration steps in this section
+are all performed in the Odoo database.
 
-In Odoo, navigate to :menuselection:`WhatsApp app --> Configuration --> WhatsApp Business Accounts`.
-Then click :guilabel:`New` to configure the WhatsApp business account in Odoo.
+In Odoo, navigate to :menuselection:`WhatsApp app --> Configuration --> WhatsApp Business Accounts`,
+then click :guilabel:`New` to configure the WhatsApp business account in Odoo.
 
-In another browser tab, navigate to :menuselection:`https://developers.facebook.com --> My Apps -->
-WhatsApp --> API Configuration`, and then copy the following values from the Meta developer console
-into the corresponding fields in Odoo:
+In another browser tab, navigate to `Meta Developer Dashboard <https://developers.facebook.com>`__.
+Select :menuselection:`My Apps --> WhatsApp --> API Configuration`, and then copy the following
+values from the Meta developer console into the corresponding fields in Odoo:
 
 .. list-table::
    :header-rows: 1
@@ -286,60 +281,56 @@ into the corresponding fields in Odoo:
      - :guilabel:`WhatsApp Business Account ID`
      - :guilabel:`Account ID`
 
-To retrieve the :guilabel:`App Secret`, navigate to the Meta developer console,
-`<https://developers.facebook.com/apps>`_ and select the app that Odoo is being configured in. Then
-in the left-side menu, under :guilabel:`App settings`, select :guilabel:`Basic`.
+To retrieve the :guilabel:`App Secret`, navigate to the `Meta Developer Dashboard
+<https://developers.facebook.com/apps>`__, and select the `Odoo` app. In the left-hand side menu,
+under :guilabel:`App settings`, select :guilabel:`Basic`.
 
-Next, click :guilabel:`Show` next to the field :guilabel:`App secret`, and enter the account
-password to verify ownership. Copy the :guilabel:`App secret` and then paste that copied value into
-the :guilabel:`App Secret` field on the Odoo :guilabel:`WhatsApp Business Account` configuration
-dashboard.
+Next, click :guilabel:`Show` next to :guilabel:`App secret`, and enter the account password. Copy
+the :guilabel:`App secret` and then paste it into the :guilabel:`App Secret` field on the Odoo
+:guilabel:`WhatsApp Business Account` configuration dashboard.
 
-To complete the setup of the WhatsApp business account in Odoo, click :guilabel:`Test Connection`. A
-successful message in green will populate in the upper-right corner of the dashboard if the
-configuration is set correctly.
+To complete the setup of the WhatsApp business account in Odoo, click :guilabel:`Test Connection`.
+If the configuration is set correctly, a successful message in green populates the upper-right
+corner of the dashboard.
 
-Configuring webhooks
---------------------
+Configure webhooks
+------------------
 
-To configure the webhooks for WhatsApp in Odoo, navigate to
-`<https://developers.facebook.com/apps>`_ and select the app that Odoo is being configured in. Next
-under the :guilabel:`WhatsApp` menu heading on the left side of the screen, click on the
-:guilabel:`API Setup` menu item. Finally go to the section marked :guilabel:`Step 3: Configure
-webhooks to receive messages` and click on :guilabel:`Configure webhooks`.
+To configure the webhooks for the Odoo **WhatsApp** app, navigate to the `Meta Developer Dashboard
+<https://developers.facebook.com/apps>`__, and select the `Odoo` app. In the left-hand side menu,
+click :menuselection:`WhatsApp --> API Setup`. Go to :guilabel:`Step 3: Configure webhooks to
+receive messages` and click :guilabel:`Configure webhooks`.
 
 .. tip::
-   Another way to configure *Webhooks* is to navigate to `<https://developers.facebook.com/apps>`_
-   and select the app that Odoo is being configured in. Then select :guilabel:`Webhooks` in the left
-   hand menu.
+   Webhook configuration settings can also be accessed by navigating to the `Meta Developer
+   Dashboard <https://developers.facebook.com/apps>`__, selecting the `Odoo` app, and then selecting
+   :guilabel:`Webhooks` in the left hand menu.
 
    .. image:: whatsapp/webhooks.png
-      :align: center
       :alt: Manually navigating to the Whatsapp webhooks configuration.
 
-On the :menuselection:`Webhook configuration` page, click on :guilabel:`Edit`, where both the
-:guilabel:`Callback URL` and :guilabel:`Webhook Verify Token` values from the Odoo will be added.
+On the :menuselection:`Webhook configuration` page, click :guilabel:`Edit`. This is where the
+:guilabel:`Callback URL` and :guilabel:`Webhook Verify Token` values from Odoo are added.
 
 ..  note::
-    Both the :guilabel:`Callback URL` and :guilabel:`Webhook Verify Token` values were automatically
+    The :guilabel:`Callback URL` and :guilabel:`Webhook Verify Token` values are both automatically
     populated after clicking on :guilabel:`Test Connection` in the previous step.
 
 In a separate browser window, retrieve the necessary values in Odoo by navigating to
-:menuselection:`WhatsApp app --> Configuration --> WhatsApp Business Accounts` and select the
-account that is being configured. Locate the values under the section labeled :guilabel:`Receiving
-Messages`.
+:menuselection:`WhatsApp app --> Configuration --> WhatsApp Business Accounts` and then selecting
+the account that is being configured. The values are located under :guilabel:`Receiving Messages`.
 
 Copy and paste the :guilabel:`Callback URL` from Odoo into the :guilabel:`Callback URL` field in
-Meta. Similarly, copy and paste the :guilabel:`Webhook Verify Token` into the :guilabel:`Verify
-Token` field on the Meta developer console, as well.
+Meta, then copy and paste the :guilabel:`Webhook Verify Token` into the :guilabel:`Verify Token`
+field on the Meta developer console. Click :guilabel:`Verify and save`.
 
-Finally, click :guilabel:`Verify and save` to record the values in the Meta developer console.
+Add webhook fields
+~~~~~~~~~~~~~~~~~~
 
-Webhook fields
-~~~~~~~~~~~~~~
-
-Now input individual webhook fields into Meta's developer console, under the :guilabel:`Webhook
-fields` section. Click :guilabel:`Manage` and when the pop-up window appears, check the boxes in the
+Now that the Odoo database and WhatsApp have been configured to communicate with each other, the
+next step is to add webhook fields to specify the information that should be sent between the two.
+To add individual webhook fields in Meta's developer console, go to the :guilabel:`Webhook fields`
+section and click :guilabel:`Manage`. In the pop-up window that loads, check the boxes in the
 :guilabel:`Subscribe` column for the following *field names*:
 
 - account_update
@@ -350,43 +341,37 @@ fields` section. Click :guilabel:`Manage` and when the pop-up window appears, ch
 
 After making the selections, click :guilabel:`Done`.
 
-The finished :guilabel:`Webhooks` configuration will appear like this in the Meta developer console:
+If the :guilabel:`Webhooks` configuration is successful, the buttons in the :guilabel:`Subscribe`
+column should change from :guilabel:`Subscribe` to :guilabel:`Unsubscribe`:
 
 .. image:: whatsapp/webhooks-done.png
-   :align: center
    :alt: WhatsApp webhooks set in the Meta developer console.
 
 .. important::
-   The :guilabel:`Webhook fields` will only appear once the subscription is confirmed using the
+   :guilabel:`Webhook fields` only appear once the subscription is confirmed using the
    :guilabel:`Callback URL` and :guilabel:`Webhook Verify Token`.
 
 .. seealso::
    `Meta's WhatsApp documentation on setting webhooks
-   <https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks>`_.
+   <https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks>`__
 
-Add phone number
-~~~~~~~~~~~~~~~~
+Add a phone number
+~~~~~~~~~~~~~~~~~~
 
-To configure the phone number to use for WhatsApp in Odoo, navigate back to the Meta developer
-console (`<https://developers.facebook.com/apps>`_) and again select the app that Odoo is being
-configured in. Under the :guilabel:`WhatsApp` menu heading on the left side of the screen, click on
-the :guilabel:`API Setup` menu item. From there, go to the section marked: :guilabel:`Step 5: Add a
-phone number`, and click on :guilabel:`Add phone number`.
+To configure the business phone number to use for **WhatsApp** in Odoo, navigate back to the `Meta
+Developer Dashboard <https://developers.facebook.com/apps>`__ and select the `Odoo` app. Under
+:guilabel:`WhatsApp` in the left-hand side menu, click :guilabel:`API Setup`. Go to :guilabel:`Step
+5: Add a phone number`, and click :guilabel:`Add phone number`.
 
-In the fields, enter a :guilabel:`Business name` as well as a :guilabel:`Business website or profile
-page`.
+Enter a :guilabel:`Business name` and :guilabel:`Business website or profile page`.
 
 .. tip::
-   The :guilabel:`Business website or profile page` field can be a social media page's :abbr:`URL
-   (Uniform Resource Locator)`.
+   The :guilabel:`Business website or profile page` field can be a link to a social media page.
 
-Complete filling out the business information by next selecting the country that the company does
-business in from the drop-down menu in the :guilabel:`Country` section. Add an address if desired,
-however, this information is optional. After adding the location, click :guilabel:`Next` to
-continue.
+Select the country that the company does business in from the :guilabel:`Country` drop-down menu; a
+business address is optional. After adding the business location, click :guilabel:`Next`.
 
-The following page contains information for the :guilabel:`WhatsApp Business profile`. Complete the
-following sections, accordingly:
+On the next page, fill out the following :guilabel:`WhatsApp Business profile` details:
 
 - :guilabel:`WhatsApp Business Profile Display Name`
 - :guilabel:`Timezone`
@@ -394,64 +379,59 @@ following sections, accordingly:
 - :guilabel:`Business description` (optional)
 
 Once these sections are complete, click :guilabel:`Next`. The page refreshes and then prompts the
-administrator to :guilabel:`Add a phone number for WhatsApp` in the respective field. Here, enter
-the phone number to configure in WhatsApp.
+administrator to :guilabel:`Add a phone number for WhatsApp` in the respective field. Enter the
+business phone number to be used with WhatsApp.
 
 .. seealso::
    `Migrate an Existing WhatsApp Number to a Business Account
    <https://developers.facebook.com/docs/whatsapp/cloud-api/get-started/migrate-existing-whatsapp-
-   number-to-a-business-account>`_.
+   number-to-a-business-account>`__
 
-Next, choose a verification method for the phone number. Select either :guilabel:`Text message` or
-:guilabel:`Phone call`, and then click :guilabel:`Next` proceed.
+Select :guilabel:`Text message` or :guilabel:`Phone call` for the phone number verification method,
+and then click :guilabel:`Next` to proceed.
 
-The phone number entered will receive either a text or a phone call by WhatsApp with a code,
-depending on the verification method chosen. Enter that verification code into the
-:guilabel:`Verification code` field and click :guilabel:`Next` to finish.
+The business phone number receives a WhatsApp code through the chosen verification method. Enter the
+verification code into the :guilabel:`Verification code` field and click :guilabel:`Next` to verify
+the business phone number.
 
 .. warning::
-   If a payment method hasn't been added this will be necessary to proceed. `Visit Meta's
-   documentation on how to add a payment method in Meta's Business Manager
-   <https://www.facebook.com/business/help/915454841921082?id=180505742745347>`_. This is part of
-   Meta's fraud detection system, in order to ensure that the account/company are real a payment
-   method is required to proceed.
+   A payment method **must** be added to proceed. This is part of Meta's fraud detection system. In
+   order to ensure that the account/company is real, a payment method is required to proceed. See
+   Meta's documentation on `how to add a payment method in Meta Business Suite
+   <https://www.facebook.com/business/help/915454841921082?id=180505742745347>`__.
 
 .. seealso::
    `Meta for Developers: Add a Phone Number
-   <https://developers.facebook.com/docs/whatsapp/cloud-api/get-started/add-a-phone-number>`_.
+   <https://developers.facebook.com/docs/whatsapp/cloud-api/get-started/add-a-phone-number>`__
 
 .. _productivity/whatsapp/token:
 
-Permanent token
-~~~~~~~~~~~~~~~
+Create a permanent token
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-After configuration and testing are complete, a permanent token should be created to replace the
+After configuration and testing are complete, create a permanent token to replace the
 :guilabel:`Temporary token`.
 
 .. seealso::
    `Meta for Developers: System User Access Tokens
    <https://developers.facebook.com/docs/whatsapp/business-management-api/get-started#system-user-
-   access-tokens>`_.
+   access-tokens>`__
 
-Begin by navigating to `<https://business.facebook.com/>`_ and then go to :menuselection:`Business
-settings --> User --> System Users`. Select an existing system user or create a new system user by
-clicking on :guilabel:`Add`.
+Navigate to `Meta Business Suite <https://business.facebook.com/>`__ and then go to
+:menuselection:`Business settings --> User --> System Users`. Select an existing system user or
+create a new system user by clicking :guilabel:`Add`.
 
-Assets now must be added to the system user and then a permanent token can be generated.
+To generate a permanent token, assets must be added to the system user. Click :guilabel:`Add
+assets`, and a pop-up window appears. Select :guilabel:`Apps` under :guilabel:`Select asset type`,
+then select the `Odoo` app and toggle the permissions to :guilabel:`On` under the :guilabel:`Full
+control` option, then click :guilabel:`Save Changes`. Click :guilabel:`Done` in the confirmation
+window that appears.
 
-Click on :guilabel:`Add assets`, and when the pop-up window appears select :guilabel:`Apps` under
-the :guilabel:`Select asset type`. Then, select the Odoo app and toggle the permissions to *On*
-under the :guilabel:`Full control` option. Set this new permission setting by clicking
-:guilabel:`Save Changes`, to which a confirmation window will appear, acknowledging the addition of
-the asset to the system user. Finish by clicking :guilabel:`Done`.
+Click :guilabel:`Generate new token`, and a pop-up window appears asking which app this token should
+be generated for. Select the `Odoo` app, then set the expiration date to either :guilabel:`60 days`
+or :guilabel:`Never`.
 
-Next, the permanent token will be generated. Click on :guilabel:`Generate new token`, and a pop-up
-window will appear asking which app this token should be generated for. Select the :guilabel:`App`
-that this token is for. Then determine the expiration date of either :guilabel:`60 days` or
-:guilabel:`Never`.
-
-Finally, when Meta asks which permissions should the system user allow, add all of the following
-permissions:
+Meta asks which permissions the system user allows.  Add both of the following permissions:
 
 - WhatsApp_business_messaging
 - WhatsApp_business_management
@@ -466,22 +446,20 @@ Accounts`.
 Go live with the Meta app
 =========================
 
-Finally, to launch the app, the Meta app must be set to :guilabel:`Live` in the Meta developer
-console. Navigate to `<https://developers.facebook.com/apps>`_ and click on the app that is being
-configured. In the top menu, toggle the :guilabel:`App Mode` field from :guilabel:`Development` to
-:guilabel:`Live`.
+Finally, to launch the app, the Meta app must be set to :guilabel:`Live` in the `Meta Developer
+Dashboard <https://developers.facebook.com/apps>`__. Click the app that is being configured, then
+toggle the :guilabel:`App Mode` field from :guilabel:`Development` to :guilabel:`Live`.
 
 .. important::
-   If the app status is not set to *live*, then the database will only be able to contact the test
+   If the app status is **not** set to *live*, then the database is only able to contact the test
    numbers specified in the developer console.
 
 .. warning::
-   A privacy policy URL must be set in order for the app to be set to live. Go to the Meta developer
-   console, `<https://developers.facebook.com/apps>`_ and select the app that Odoo is being
-   configured in. Then, using the menu on the left side of the screen, go to :menuselection:`App
-   Settings --> Basic`. Then, enter the privacy policy hyperlink address under the
-   :guilabel:`Privacy Policy URL` field of the form. Click :guilabel:`Save changes` to apply the
-   privacy policy to the app.
+   A privacy policy URL must be set in order for the app to be set to live. Go to the `Meta
+   Developer Dashboard <https://developers.facebook.com/apps>`__ and select the `Odoo` app. Then, in
+   the left-hand side menu, go to :menuselection:`App Settings --> Basic`. Enter the privacy policy
+   hyperlink address under the :guilabel:`Privacy Policy URL` field of the form. Click
+   :guilabel:`Save changes` to apply the privacy policy to the app.
 
 Once the app has gone live in the Meta developer console, a confirmation email is sent to the
 administrator.
@@ -491,86 +469,77 @@ administrator.
 WhatsApp templates
 ==================
 
-WhatsApp templates are saved messages that are used repeatedly to send messages from the database.
-They allow users to send quality communications, without having to compose the same text repeatedly.
+WhatsApp templates allow users to store messages that are frequently sent. By creating templates
+tailored to specific situations, users can easily send pre-approved messages, without having to
+compromise on quality or compose the same text repeatedly. This ensures quick turnaround and
+consistent customer service messaging, and increases the overall engagement rate with the customer.
 
-Creating different templates that are tailored to specific situations lets users choose the right
-message for the right audience. This increases the quality of the message and the overall
-engagement rate with the customer.
-
-WhatsApp templates can be created on both the Odoo and Meta consoles. The following process will
-overview the process for creating templates in Odoo and then afterward in Meta.
+WhatsApp templates can be created on both the :ref:`Odoo <whatsapp/odoo-templates>` and :ref:`Meta
+<whatsapp/meta-templates>` consoles.
 
 .. important::
-   WhatsApp has an approval process that must be completed before the template can be used.
-   :ref:`productivity/whatsapp/approval`.
+   WhatsApp has an approval process that **must** be completed *before* the template can be used.
+   See :ref:`productivity/whatsapp/approval`.
 
-.. _WhatsApp/templates:
+To access WhatsApp templates, navigate to the :menuselection:`WhatsApp app --> Templates` dashboard.
 
-Creating templates in Odoo
---------------------------
+Each template has three tabs:
 
-To access and create WhatsApp templates, begin by navigating to the :menuselection:`WhatsApp app -->
-Templates` dashboard.
+- :guilabel:`Body`\: stores the message body. The message body may contain placeholders for dynamic
+  content which is populated when the message is sent.
+- :guilabel:`Buttons`\: adds clickable buttons/hyperlinks at the bottom of the WhatsApp template.
+  Currently, there are three button types\: *Quick Reply*, *Visit Website*, and *Call Number*.
+  *Visit Website* supports static, dynamic, and tracked URLs.
+- :guilabel:`Variables`\: lists all of the placeholders in the template, as well as the variables
+  that should be populated. For example, messages can contain placeholders for a recipient's name,
+  purchased products, or sales order number.
 
-At the bottom of an individual template's form, there are three tabs: :guilabel:`Body`,
-:guilabel:`Buttons`, and :guilabel:`Variables`; these three tabs combined create the WhatsApp
-template.
+.. _whatsapp/odoo-templates:
 
-The text is entered into the :guilabel:`Body` tab, and dynamic content that is called out in the
-:guilabel:`Body` tab is specified in the :guilabel:`Variables` tab. Every piece of dynamic content
-(e.g., placeholders) in the message (body) is specifically called out and specified in the
-:guilabel:`Variables` tab.
-
-Templates are prefabricated layouts that allow users to send professional looking messages to
-customers. These templates are capable of containing dynamic data that will populate in the end
-message using variables that are set in the template configuration. For example, messages can
-contain the end user's name, call out specific products, or reference a sales order, to name a few
-convenient and impactful variables.
+Create WhatsApp templates in Odoo
+---------------------------------
 
 To create a WhatsApp template, go to the :menuselection:`WhatsApp app --> Templates` dashboard and
-click :guilabel:`New`. On the form, enter a :guilabel:`Name` for the template, and select a
-:guilabel:`Language`.
+click :guilabel:`New`. Enter a :guilabel:`Name` for the template, and select a :guilabel:`Language`.
 
 .. important::
-   In order to complete this next task, administrator access rights are needed to edit the
-   :guilabel:`Applies to` field. See this :doc:`access rights documentation
-   <../general/users/access_rights>` for more information.
+   In order to complete this next task, :doc:`administrator access rights
+   <../general/users/access_rights>` are needed to edit the :guilabel:`Applies to` field.
 
 In the :guilabel:`Account` drop-down menu, select the *WhatsApp business account* in Odoo that this
-template should link to. Next, under the :guilabel:`Applies to` field select the *model* the server
-action will apply to for this template.
+template should link to. Next, under the :guilabel:`Applies to` field, select the *model* the server
+action should apply to this template.
 
 .. tip::
-   These models can also be accessed in :ref:`developer mode <developer-mode>`. On a contact form
-   (or similar relevant form in Odoo), navigate to the model that will be referenced, and hover over
-   any field name. A box of backend information will reveal itself with the specific Odoo
-   :guilabel:`Model` name in the backend. Search (using the front-end name) for this model in the
-   :guilabel:`Applies to` drop-down menu in the WhatsApp template.
+   These models can also be accessed in :ref:`developer mode <developer-mode>`. In a contact form
+   (or similar relevant form in Odoo), navigate to the model to be referenced, and hover over a
+   field name. This displays backend information, including the specific Odoo :guilabel:`Model` name
+   in the backend. Search for the model's *frontend* name  in the WhatsApp template, under the
+   :guilabel:`Applies to` drop-down menu.
 
 .. warning::
-   Often when changing the model or :guilabel:`Applies to` field, the :guilabel:`Phone Field` may
-   produce an error The :guilabel:`Phone Field` should always be set to the `Phone` or `Mobile`
-   model.
+   The :guilabel:`Phone Field` may produce an error when changing the model or :guilabel:`Applies
+   to` field. The :guilabel:`Phone Field` should always be set to the `Phone` or `Mobile` model.
 
-To search available fields, type in the front-end name in the :guilabel:`Search...` box.  This will
-find a result from all of the available fields for the model (:guilabel:`Applies to`) that the
-template is created for.
+To search available fields, type the frontend name in the :guilabel:`Search...` box.  This displays
+results from all of the available fields for the model (:guilabel:`Applies to`) that the template is
+created for.
 
 .. note::
-   In order to find specific fields, multiple levels may need to be navigated in the search results
-   box. Use the :guilabel:`> (right chevron)` and :guilabel:`⬅️ (left arrow)` icons to navigate
-   between the menu levels.
+   To find specific fields, multiple levels may need to be navigated in the search results box. Use
+   the :icon:`fa-chevron-right` :guilabel:`(right chevron) and :icon:`fa-arrow-left`
+   :guilabel:`(left arrow)` icon icons to navigate between the menu levels.
 
 .. image:: whatsapp/phone-field.png
-   :align: center
    :alt: Searching for the phone field in the search bar.
 
-Change the :guilabel:`Category` to fit either a :guilabel:`Marketing`, :guilabel:`Utility`, or
-:guilabel:`Authentication` category. In most instances the first two options will be used, unless
-the user would like to send a password reset or something security related. Set to
-:guilabel:`Marketing` should there be anything promotional being sent and set to :guilabel:`Utility`
-should there be general transactional messages being sent (i.e., sales order, event ticket, etc).
+Change the :guilabel:`Category` to one of the following:
+
+- :guilabel:`Marketing`: Promotions or information about your business, products or services. Or any
+     message that isn't utility or authentication.
+- :guilabel:`Utility`: Messages about a specific transaction, account, order or customer request.
+- :guilabel:`Authentication`: One-time passwords your customers use to authenticate a transaction or
+     login.
 
 .. important::
    Specifying an incorrect category can cause a flag/rejected status from Meta during the approval
@@ -589,15 +558,15 @@ The available :guilabel:`Header types` are as follows:
 
 Navigate to the :guilabel:`Body` tab to configure the main message of the template.
 
-When all the necessary changes are made to the template, click on the :guilabel:`Submit for
-approval` button in the upper-left corner. This will cause the status of the template to change to
-:guilabel:`Pending`.
+When all the necessary changes are made to the template, click the :guilabel:`Submit for approval`
+button in the upper-left corner, and the status of the template changes to :guilabel:`Pending`.
 
-The status will remain in :guilabel:`Pending` until a decision has been made by Meta, whereby a
-confirmation email will then be sent indicating that the template has been approved (or rejected).
-The templates will then need to be synced from the Odoo database.
+The status remains :guilabel:`Pending` until a decision has been made by Meta, whereby a
+confirmation email is sent indicating that the template has been approved or rejected. Next, sync
+the templates from the Odoo database.
 
-See this section for more information on :ref:`syncing templates <productivity/whatsapp/sync>`.
+.. seealso::
+   :ref:`Syncing templates <productivity/whatsapp/sync>`
 
 .. tip::
    There are pre-configured demo data templates available in Odoo to use or modify. These templates
@@ -605,7 +574,7 @@ See this section for more information on :ref:`syncing templates <productivity/w
 
    To use these templates, navigate to :menuselection:`WhatsApp app --> Templates` and select a
    pre-configured template. Click :guilabel:`Submit for Approval` to start the approval process. An
-   email will be sent to the administrator of the Meta account when the template has been approved.
+   email is sent to the administrator of the Meta account when the template has been approved.
 
 Buttons
 ~~~~~~~
@@ -616,12 +585,12 @@ specify the :guilabel:`Button Text`, :guilabel:`Call Number` or :guilabel:`Websi
 :guilabel:`Url Type`), depending on the :guilabel:`Type` of button.
 
 .. note::
-   Buttons can also be added on the Meta business console. See Meta's WhatsApp template dashboard by
-   navigating to `<https://business.facebook.com/wa/manage/home>`_. Then go to
-   :menuselection:`Account tools --> Message templates`.
+   Buttons can also be added on the `Meta Business Suite
+   <https://business.facebook.com/wa/manage/home>`__. To see Meta's WhatsApp template dashboard, go
+   to :menuselection:`Account tools --> Message templates`.
 
-Using placeholders and variables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Placeholders and variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dynamic variables reference certain fields within the Odoo database to produce unique data in the
 WhatsApp message when using a template. Dynamic variables are encoded to display fields from within
@@ -634,7 +603,6 @@ the database, referencing fields from within a model.
    email from the :guilabel:`Customer` field on the :guilabel:`Sales Order` model.
 
 .. image:: whatsapp/message.png
-   :align: center
    :alt: WhatsApp message with dynamic variables highlighted.
 
 Dynamic variables can be added in to the :guilabel:`Body` by adding :guilabel:`placeholders` in the
@@ -652,9 +620,9 @@ placeholder enter `{{2}}` and increase incrementally as more placeholders are ad
    Thank you
 
 .. seealso::
-   :ref:`productivity/whatsapp/templates`.
+   :ref:`productivity/whatsapp/templates`
 
-These placeholders must be configured on the :guilabel:`Variables` tab of the template before
+These placeholders **must** be configured on the :guilabel:`Variables` tab of the template before
 submitting for approval from Meta. To edit the dynamic variables on a template, first change the
 :guilabel:`Type` to :guilabel:`Field of Model`. This allows Odoo to reference a field within a model
 to produce unique data in the message being sent.
@@ -662,8 +630,8 @@ to produce unique data in the message being sent.
 Next, edit the :guilabel:`Field` of the dynamic variables. The :guilabel:`Applies to` field in the
 template should be edited prior to ensure the correct model and field are referenced.
 
-To search the available fields, type in the front-end name of the field in the search box. This will
-find a result from all of the available fields for the model (:guilabel:`Applies to`) that the
+To search the available fields, type in the front-end name of the field in the search box. This
+finds a result from all of the available fields for the model (:guilabel:`Applies to`) that the
 template is created for. There may be multiple levels that need to be configured.
 
 .. example::
@@ -717,17 +685,16 @@ template is created for. There may be multiple levels that need to be configured
 Meta template approval
 ~~~~~~~~~~~~~~~~~~~~~~
 
-After updating the dynamic variables on the template, the template needs to be submitted to Meta for
-approval again. Click :guilabel:`Submit for Approval` to start the approval process. An email will
-be sent to the administrator of the Meta account when the template has been approved.
+After updating the dynamic variables on the template, the template needs to be resubmitted to Meta
+for approval. Click :guilabel:`Submit for Approval` to start the approval process. An email is sent
+to the administrator of the Meta account when the template has been approved.
 
 Following the approval from Meta, sync the templates again in the Odoo database. See this
 documentation: :ref:`productivity/whatsapp/sync`.
 
 .. tip::
-   To see the status to Meta's WhatsApp template dashboard by navigating to
-   `<https://business.facebook.com/wa/manage/home>`_. Then go to :menuselection:`Account tools -->
-   Message templates`.
+   To see the status, go to `Meta Business Suite <https://business.facebook.com/wa/manage/home>`__
+   and select :menuselection:`Account tools --> Message templates`.
 
 .. _productivity/whatsapp/sync:
 
@@ -737,12 +704,11 @@ Syncing templates
 Templates must be synced on the Odoo database once they are approved by the Meta team. To do so,
 begin by navigating to :menuselection:`WhatsApp app --> Configuration --> WhatsApp Business
 Accounts` and select the configuration that should be synced. Under the section marked
-:menuselection:`Sending messages`, towards the bottom, click on :guilabel:`Sync Templates`. Meta
-will update the templates that are approved so that they can be utilized with various apps in the
+:menuselection:`Sending messages`, towards the bottom, click :guilabel:`Sync Templates`. Meta
+updates the templates that are approved so that they can be utilized with various apps in the
 database.
 
 .. image:: whatsapp/sync-template.png
-   :align: center
    :alt: Syncing Meta WhatsApp templates to the Odoo database, with the 'Sync Templates'
          highlighted.
 
@@ -752,58 +718,59 @@ updated.
 .. tip::
    Templates can also be synced individually from the template itself. Navigate to the
    :menuselection:`WhatsApp app --> Templates` dashboard and select the template to sync. Then,
-   click on the :guilabel:`Sync Template` button located in the top menu of the template's form.
+   click the :guilabel:`Sync Template` button located in the top menu of the template's form.
 
-Creating templates in Meta
---------------------------
+.. _whatsapp/meta-templates:
 
-First, navigate to `Meta's WhatsApp template dashboard
-<https://business.facebook.com/wa/manage/home>`_, and then go to :menuselection:`Account tools -->
-Message templates`.
+Create WhatsApp templates in Meta
+---------------------------------
+
+First, navigate to `Meta Business Suite <https://business.facebook.com/wa/manage/home>`__, and then
+go to :menuselection:`Account tools --> Message templates`.
 
 .. image:: whatsapp/account-tools.png
-   :align: center
    :alt: Account tools highlighted in business manager with the manage templates link highlighted.
 
-To create a WhatsApp template, click on the blue :guilabel:`Create template` button, and then select
-the :guilabel:`Category`. The options listed include: :guilabel:`Marketing`, :guilabel:`Utility`,
-and :guilabel:`Authentication`. In most instances the first two options will be used, unless the
-user would like to send a password reset or something security related.
+To create a WhatsApp template, click the blue :guilabel:`Create template` button, and then select
+the :guilabel:`Category` from one of the following:
+
+- :guilabel:`Marketing`: Promotions or information about your business, products or services. Or any
+     message that isn't utility or authentication.
+- :guilabel:`Utility`: Messages about a specific transaction, account, order or customer request.
+- :guilabel:`Authentication`: One-time passwords your customers use to authenticate a transaction or
+     login.
 
 Enter the :guilabel:`Name` of the template and then select the :guilabel:`Language` for the
 template.
 
 .. note::
-   Multiple languages can be selected by typing the language name(s) and selecting the other
+   Multiple languages can be selected by typing the language names, then selecting the other
    languages as needed.
 
 .. image:: whatsapp/template-config.png
-   :align: center
    :alt: Template configuration options listed, with Marketing, Utility, Name and Language
          highlighted.
 
-After making the appropriate selections, click on :guilabel:`Continue` in the upper-right corner.
-The page redirects to the :guilabel:`Edit template` page. Here the :guilabel:`Header`,
-:guilabel:`Body`, :guilabel:`Footer` and :guilabel:`Buttons` are configured. To the right of the
-template is a preview of what the template will look like in production.
+After making the appropriate selections, click :guilabel:`Continue` in the top-right corner. The
+browser redirects to the :guilabel:`Edit template` page where the :guilabel:`Header`,
+:guilabel:`Body`, :guilabel:`Footer`, and :guilabel:`Buttons` are configured. To the right of the
+template is a preview of what the template looks like in production.
 
 .. image:: whatsapp/edit-template.png
-   :align: center
    :alt: Edit the template using a header, body, footer and buttons.
 
-When all the necessary changes are made to the template, click on the :guilabel:`Submit` button in
-the upper-right corner. A confirmation window appears to confirm the language— click
-:guilabel:`Confirm` to approve and then another window appears stating that the template will be
-submitted to Meta for review and approval.
+When all necessary changes are made to the template, click :guilabel:`Submit` button in the
+top-right corner, and a window populates to confirm the language. Click :guilabel:`Confirm` to
+approve and then another window states that the template has been submitted to Meta for review and
+approval.
 
-The :guilabel:`Status` of the template will remain in :guilabel:`In review` until a decision has
-been made by Meta. Once an email confirmation is received approving the template, the templates will
-need to be synced from within the Odoo database.
+The :guilabel:`Status` of the template remains :guilabel:`In review` until a decision is made by
+Meta. Once an email confirmation approving the template is received, the templates need to be synced
+from within the Odoo database.
 
 .. seealso::
-   For more information on configuring templates on the Meta developer console visit `Meta's
-   WhatsApp template documentation
-   <https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/>`_.
+   `Meta's WhatsApp template documentation
+   <https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/>`__
 
 Notifications
 =============
@@ -815,24 +782,23 @@ WhatsApp business account configuration in Odoo.
 Notification settings can be adjusted by navigating to :menuselection:`WhatsApp app -->
 Configuration --> WhatsApp Business Accounts`. From there, select the account and scroll down to the
 :menuselection:`Control` section where notifications are handled. Under the :guilabel:`Notify users`
-heading, type in the field which user(s) should be notified for this particular WhatsApp channel.
+heading, type in the field which users should be notified for this particular WhatsApp channel.
 
 .. note::
    Once a conversation is initiated between a user and a customer, notifications to all the users
    specified in the WhatsApp business account configuration won't occur. Only notifications to the
-   user(s) in the conversation will occur. Should the user not respond within 15 days, the
-   customer's reply after the 15 days will populate once again to all the users specified in the
-   WhatsApp configuration.
+   users in the conversation occur. Should the user not respond within 15 days, the customer's reply
+   after the 15 days populates once again to all the users specified in the WhatsApp configuration.
 
-Adding users to chat
-====================
+Add users to a chat
+===================
 
 Users can be added to a WhatsApp chat by expanding the WhatsApp pop-up window. WhatsApp
-conversations are located in the *Discuss* app. Click on the :guilabel:`👤+ (add user)` icon next to
-it, and a window appears to invite users to the conversation.
+conversations are located in the **Discuss** app. Select a conversation, then click the
+:icon:`fa-user-plus` :guilabel:`(Add User)` icon in the top-right, and a window appears to invite
+users to the conversation.
 
 .. image:: whatsapp/add-users.png
-   :align: center
    :alt: Adding users to a WhatsApp conversation, with the add user icon highlighted.
 
 WhatsApp API FAQ
@@ -844,53 +810,70 @@ Verification
 As of February 1, 2023, if the Meta app requires advanced level access to permissions, a complete
 business verification may need to be completed. This includes submitting office business documents
 to Meta. `See this documentation
-<https://developers.facebook.com/docs/development/release/business-verification>`_.
+<https://developers.facebook.com/docs/development/release/business-verification>`__.
 
 .. seealso::
    `Meta's WhatsApp access verification documentation
-   <https://developers.facebook.com/docs/development/release/access-verification/>`_.
+   <https://developers.facebook.com/docs/development/release/access-verification/>`__
 
 Template errors
 ---------------
 
-Editing templates can cause tracebacks and errors unless the exact process is followed above, here:
-(:ref:`productivity/whatsapp/templates`).
+Editing templates can cause tracebacks and errors unless :ref:`the exact process is followed
+<productivity/whatsapp/templates>`.
 
 Duplicate validation error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When syncing the templates there may be an instance when there are multiple templates with the same
-name on Meta's business manager and in Odoo. This causes a duplicate validation error. To correct
-this issue, rename the duplicate template name on Odoo and sync the templates once again by
-following the steps here: :ref:`productivity/whatsapp/sync`.
+name on Meta's business manager and in Odoo. This causes a duplicate validation error. Odoo displays
+`Validation Error: The operation cannot be completed: Duplicate template is not allowed for one Meta
+account`. To correct this issue, rename the duplicate template name on Odoo and :ref:`sync the
+templates once again <productivity/whatsapp/sync>`.
 
 .. image:: whatsapp/validation-error-2.png
-   :align: center
-   :alt: User error populated in Odoo when a duplicate template exists.
+   :alt: Error message displayed in Odoo when a duplicate template exists.
 
 Token errors
 ------------
 
-User error
-~~~~~~~~~~
+User error 190
+~~~~~~~~~~~~~~
 
-Should the temporary token not be replaced with a permanent token a user error will populate in Odoo
-when testing the connection after sending fails. To correct this issues see
-:ref:`productivity/whatsapp/token`.
+If the temporary token is not replaced with a permanent token, Odoo displays `User Error 190: Error
+validating access token: Session has expired`. To correct this issue, :ref:`add a permanent token
+<productivity/whatsapp/token>`.
 
 .. image:: whatsapp/user-error.png
-   :align: center
-   :alt: User error populated in Odoo when token expires.
+   :alt: Error message displayed in Odoo when the temporary token expires.
 
-System user error 100
-~~~~~~~~~~~~~~~~~~~~~
+User error 100
+~~~~~~~~~~~~~~
 
-Should the system user be an :guilabel:`Employee` when setting up the permanent token, a user error
-100 will populate.
+If an :guilabel:`Employee` attempts to set up the permanent token, Odoo displays `User Error 100:
+Unsupported get request`.
 
-To correct this error, create an :guilabel:`Admin` system user, following the process outlined here:
-:ref:`productivity/whatsapp/token`.
+To correct this error, :ref:`create an Admin system user <productivity/whatsapp/token>`.
 
 .. image:: whatsapp/user-error-2.png
-   :align: center
-   :alt: User error populated in Odoo when an employee token is generated instead of a Admin user.
+   :alt: Error message displayed in Odoo when an employee token is generated instead of an Admin
+    user.
+
+Other
+-----
+
+WhatsApp template can't be sent to multiple contacts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Make sure the *Multi-Template* feature is enabled on the template.
+
+Check why a WhatsApp message failed to send
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable the *Failure Type* and *Failure Reason* columns under :guilabel:`WhatsApp ---> Messages`.
+
+Other error codes
+-----------------
+
+For other errors, see Meta’s Developer Suite for `WhatsApp Error Codes
+<https://developers.facebook.com/documentation/business-messaging/whatsapp/support/error-codes>`__.


### PR DESCRIPTION
documentation task card: https://www.odoo.com/odoo/action-4043/5257364

key changes @ line 181 / 192:
- clarified restrictions on test phone number provided during whatsapp config (max. 5 recipients, unlimited messages)
- added instructions for adding message recipients, link to meta documentation
    - see [section header in 17.0 prod](https://www.odoo.com/documentation/17.0/applications/productivity/whatsapp.html#add-a-whatsapp-product-to-the-app)

other:
- removed callout and appended first sentence to preceding paragraph
- also removed instances of future tense ("will") to match current style; created follow-up task for full article refresh (https://www.odoo.com/odoo/action-4043/5356551)

This 17.0 PR can be FWP up to master. In the event of a merge conflict, tense changes can be left out for future work.