### PR TITLE
[FIX] Payroll: Missing attachment info

### DIFF
--- a/content/applications/hr/payroll/salary_attachments.rst
+++ b/content/applications/hr/payroll/salary_attachments.rst
@@ -92,7 +92,7 @@ blank :guilabel:`Salary Attachment` form loads. Enter the following information 
 - :guilabel:`Payslip Amount`: Enter the amount taken out of each paycheck in this field.
 - :guilabel:`Total Amount`: Enter the total amount to be paid for the salary attachment. Note that
   this field **only** appears if the :guilabel:`No End Date` option is **not** ticked.
-- :guilabel:`Negative Amount`: Tick this checkbox if the salary attachment
+- :guilabel:`Negative Amount`: Tick this checkbox if the salary attachment is a negative value.
 - :guilabel:`Occurrences`: This field is **not** editable, and only appears once both the
   :guilabel:`Payslip Amount` and :guilabel:`Total Amount` fields are populated. The number indicates
   the amount of payslips needed to complete the salary attachment.


### PR DESCRIPTION
MUBA discovered missing info in the salary attachment doc. Adding the info for the bullet point:

- :guilabel:`Negative Amount`: Tick this checkbox if the salary attachment is a negative value.

This sentence was incomplete/cut off in the original doc.

[Task card](https://www.odoo.com/odoo/project/3835/tasks/5344269) for this PR. This is ONLY for version 18 - there is a 19 update already in Github, being reviewed.