### PR TITLE
[IMP] admin: missing header with X-Accel-Redirect

### DIFF
--- a/content/administration/on_premise/deploy.rst
+++ b/content/administration/on_premise/deploy.rst
@@ -533,6 +533,8 @@ X-Sendfile and X-Accel).
          location /web/filestore {
              internal;
              alias /path/to/odoo/data-dir/filestore;
+             add_header Content-Security-Policy $upstream_http_content_security_policy;
+             add_header X-Content-Type-Options nosniff;
          }
 
      In case you don't know what is the path to your filestore, start Odoo with the


### PR DESCRIPTION
Nginx doesn't set the Content-Security-Policy and X-Content-Type-Options headers on the response it sends to the browser even though they were present on the response from the Odoo server.