### PR TITLE
[FIX] Update default request limit from 8196 to 65536

### DIFF
--- a/content/developer/reference/cli.rst
+++ b/content/developer/reference/cli.rst
@@ -596,7 +596,7 @@ Multiprocessing
         Number of requests a worker will process before being recycled and
         restarted.
 
-        Defaults to *8196*.
+        Defaults to *65536*.
 
     .. option:: --limit-memory-soft <limit>
 


### PR DESCRIPTION
Since [this commit](https://github.com/odoo/odoo/commit/aa8de3d4d2609f2bac093bb7b485a9fd8481e18a) the limit was changed