### PR TITLE
[IMP] Barcode: Link to other RFID docs in setup

### DIFF
--- a/content/applications/inventory_and_mrp/barcode/setup/rfid.rst
+++ b/content/applications/inventory_and_mrp/barcode/setup/rfid.rst
@@ -84,3 +84,7 @@ Limitations
   a quantity of `1`. It does not count individual products in a receipt.
 - Only ultra-high frequency (UHF) RFID tags are supported.
 - Products need to be GS1-registered because barcodes must be unique.
+
+.. seealso::
+   - :doc:`../operations/scan_rfid`
+   - :doc:`../operations/retrieve_epcs`


### PR DESCRIPTION
Now that the other RFID docs are published, we should link to them from the RFID setup doc. I added a seealso block linking to these two documents.

This 18.0 PR can be FWP up to master.