### PR TITLE
[ADD] Fiscal Localizations / Croatia

### DIFF
--- a/content/applications/finance/accounting/customer_invoices/electronic_invoicing/croatia.rst
+++ b/content/applications/finance/accounting/customer_invoices/electronic_invoicing/croatia.rst
@@ -18,8 +18,8 @@ e-invoicing in public procurement. Under these regulations, all businesses invol
 (business-to-government)` transactions are required to use electronic invoicing via the :abbr:`CIS
 (Central Invoice System)`, Croatia’s official platform for public sector e-invoicing. Croatia is
 also part of the Peppol network, facilitating standardized cross-border e-invoicing within the
-European Union. Furthermore, e-invoicing is increasingly encouraged for B2B transactions, promoting
-greater transparency and tax compliance.
+European Union. Furthermore, e-invoicing through the e-Račun platform is mandatory for B2B
+transactions starting from 1 January 2026.
 
 Compliance with Croatian e-invoicing regulations
 ================================================
@@ -27,9 +27,12 @@ Compliance with Croatian e-invoicing regulations
 Odoo Invoicing makes it easy for businesses to send, store, and ensure the integrity of their
 invoices. Here is how Odoo ensures compliance:
 
+- **Integrations**: Odoo can send invoices and report payments to the e-Račun platform via an
+  integration with third-party provider `mojeRačun <https://moj-eracun.hr>`_.
 - **Supported formats**: Odoo supports standard e-invoice formats, such as PDF with digital
   signatures and XML in :abbr:`UBL (Universal Business Language)` format, which are fully compatible
-  with Croatia's :abbr:`CIS (Central Invoice System)` for public procurement transactions.
+  with Croatia's :abbr:`CIS (Central Invoice System)` for public procurement transactions and
+  e-Račun platform for B2B transactions.
   Additionally, Odoo enables transmission of e-invoices through any platform connected to the Peppol
   network, as the *Servis eRačun za državu* reached via Peppol, ensuring compliance with both
   Croatian and EU standards.

--- a/content/applications/finance/fiscal_localizations.rst
+++ b/content/applications/finance/fiscal_localizations.rst
@@ -160,6 +160,7 @@ Fiscal localization modules are available for the countries listed below.
    fiscal_localizations/canada
    fiscal_localizations/chile
    fiscal_localizations/colombia
+   fiscal_localizations/croatia
    fiscal_localizations/denmark
    fiscal_localizations/ecuador
    fiscal_localizations/egypt

--- a/content/applications/finance/fiscal_localizations/croatia.rst
+++ b/content/applications/finance/fiscal_localizations/croatia.rst
@@ -1,0 +1,117 @@
+=======
+Croatia
+=======
+
+E-invoicing via mojeRačun
+=========================
+
+Odoo can connect to the national eRačun platform via third-party provider `mojeRačun
+<https://moj-eracun.hr>`_ to send and receive e-invoices.
+
+To make use of this integration, an account and `invoice package
+<https://portal.moj-eracun.hr/podrska/cjenik/>`_ from mojeRačun are needed. The rest of this
+documentation assumes that one has already been obtained.
+
+.. _croatia/configuration:
+
+Configuration
+-------------
+
+Follow these steps to set up e-invoicing via mojeRačun in Odoo.
+
+.. _croatia/configuration/company:
+
+Company configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+Go to :menuselection:`Accounting --> Configuration --> Settings` and scroll down to
+:guilabel:`MojEracun E-invoicing`. Fill the :guilabel:`Username` and :guilabel:`Password` fields
+with the credentials provided by mojeRačun.
+
+Ensure that the :guilabel:`Company ID (OIB or GIN)` and :guilabel:`Company Business Unit (PJ)`
+fields are correctly filled in.
+
+Optionally, specify the :guilabel:`Incoming E-Invoices Journal` where invoices received via MER
+should be created. If left unset, the default purchase journal will be used.
+
+Set the :guilabel:`MojEracun Operating Mode` to :guilabel:`Production` to send and receive invoices
+on the production network.
+
+Then click :guilabel:`Activate` to activate the connection with mojeRačun.
+
+.. _croatia/configuration/journal:
+
+Journal configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+Go to :menuselection:`Accounting --> Configuration --> Journal` and click the :guilabel:`Customer
+Invoices` journal to open its configuration.
+
+In the :guilabel:`Fiscalization (HR)` section, fill the :guilabel:`Business premises label`,
+:guilabel:`Issuing device label`, :guilabel:`Business premises label (refund approval)`, and
+:guilabel:`Issuing device label (refund approval)` fields.
+
+These fields are used along with the journal's :guilabel:`Short Code` to generate the invoice name
+in accordance with :ref:`Croatian standards <croatia/sending/invoice-name>`. The :guilabel:`Business
+premises label` and :guilabel:`Issuing device label` fields are for invoices; the
+:guilabel:`Business premises label (refund approval)` and :guilabel:`Issuing device label (refund
+approval)` fields are for credit notes.
+
+.. _croatia/sending:
+
+Sending an e-invoice
+--------------------
+
+When creating an invoice, the following configuration is needed before sending the invoice via
+mojeRačun.
+
+.. _croatia/sending/invoice-name:
+
+Invoice name
+~~~~~~~~~~~~
+
+The invoice name must be in the form `{Journal code}-{Year}-{Sequence}/{Business premises label}/
+{Issuing device label}`. To have this format suggested to you automatically when creating your first
+invoice, perform the :ref:`journal configuration <croatia/configuration/journal>` as explained
+above.
+
+Product configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+The :guilabel:`KPD category` must be set on the product.
+
+.. seealso::
+   :ref:`accounting/e-invoicing/generation`
+
+Fetching status updates
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Once an invoice has been sent, Odoo will periodically check for any updates to the invoice's status
+(e.g. rejection by MER, the eRačun system, or by the recipient). To manually check for updates,
+click the :guilabel:`MER: Fetch status` button.
+
+Reporting a payment
+~~~~~~~~~~~~~~~~~~~
+
+The Croatian government expects to be notified once payment has been received for an invoice. To
+send this notification, click the :guilabel:`MER: Report payments` button on the invoice view.
+
+.. _croatia/receiving:
+
+Receiving e-invoices
+--------------------
+
+Odoo periodically checks for new invoices received via mojeRačun. New invoices received via
+mojeRačun appear in the :guilabel:`Incoming E-Invoices Journal` specified in the :ref:`settings
+<croatia/configuration/company>`.
+
+Rejecting an invoice
+~~~~~~~~~~~~~~~~~~~~
+
+To reject an incoming invoice, click the :guilabel:`MER: Reject eRacun` button on the invoice view.
+This notifies the eRačun system and the sender that the invoice is rejected.
+
+.. seealso::
+   :doc:`Odoo electronic invoicing in Croatia
+   <../accounting/customer_invoices/electronic_invoicing/croatia>`
+


### PR DESCRIPTION
task-4925745

Starting from 1 January 2026, companies in Croatia must send all invoices as e-invoices via the national platform eRačun. In the related PR, we wrote an integration with third party provider mojeRačun that allows us to be compliant.

There is quite a bit of configuration needed for users to correctly set this up, so to explain this, we create a new a page for Croatia in the Fiscal Localizations section.

Community PR: https://github.com/odoo/odoo/pull/230757