### PR TITLE
Documentation contradiction about putaway rules for untracked products.

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/product_management/configure/type.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/configure/type.rst
@@ -156,7 +156,7 @@ documents.
      - Yes
    * - :ref:`Use putaway rules <inventory/product_management/putaway>`
      - Yes
-     - No
+     - Yes
    * - :ref:`Can be manufactured, subcontracted, or used in another good's BoM
        <inventory/product_management/manufacturing>`
      - Yes


### PR DESCRIPTION
Table incorrectly states untracked products cannot use putaway rules.

Correct Statement

  Both tracked and untracked goods can use putaway rules. Only services are excluded.

  Code Evidence

  | File                                    | Line          | Evidence                                                      |
  |-----------------------------------------|---------------|---------------------------------------------------------------|
  | addons/stock/models/product_strategy.py | 48            | domain="[('type', '!=', 'service')]" - only services excluded |
  | addons/stock/models/stock_location.py   | 294-373       | _get_putaway_strategy() - no is_storable check                |
  | addons/stock/models/stock_move_line.py  | 254-278       | _apply_putaway_strategy() - no tracking check                 |
  | addons/stock/views/product_views.xml    | 247, 371, 498 | invisible="type == 'service'" - button visible for all goods  |
