### PR TITLE
[FIX] spain: remove reference to deleted module

### DIFF
--- a/content/applications/finance/fiscal_localizations/spain.rst
+++ b/content/applications/finance/fiscal_localizations/spain.rst
@@ -284,10 +284,6 @@ Administrative centers
 In order for **FACe** to work with **administrative centers**, the invoice *must* include specific
 data about the centers.
 
-.. note::
-   Make sure to have the :guilabel:`Spain - Facturae EDI - Administrative Centers Patch
-   (l10n_es_edi_facturae_adm_centers)` module :ref:`installed <general/install>`.
-
 To add **administrative centers**, create a new **contact** to add to the **partner** company.
 Select :guilabel:`FACe Center` as the **type**, assign one or more **role(s)** to that contact, and
 :guilabel:`Save`. The **three** roles usually required are:


### PR DESCRIPTION
In Odoo saas-17.1 the module `l10n_es_edi_facturae_adm_centers` was merged into the module `l10n_es_edi_facturae`[^1] and doesn't need to be installed separately anymore.

We remove the reference to this module and step in the documentation.

[^1]: https://github.com/odoo/odoo/commit/0f5c89b40da923e35e27648b0a09601950fe2c30