### PR TITLE
[l10n_fr] Translate Activities icons (essentials)

### DIFF
--- a/locale/fr/LC_MESSAGES/essentials.po
+++ b/locale/fr/LC_MESSAGES/essentials.po
@@ -31,48 +31,62 @@ msgstr "Activités"
 
 #: ../../content/applications/essentials/activities.rst:7
 msgid "*Activities* are follow-up tasks tied to a record in an Odoo database."
+<<<<<<< HEAD
 msgstr ""
 "Les *activités* sont des tâches de suivi liées à un enregistrement dans une "
 "base de données Odoo."
+=======
+msgstr "Les *activités* sont des tâches de suivi associées à un enregistrement dans une base de données Odoo."
+>>>>>>> 6f7d11c34 (l10n_fr: add French translations for Activities icons)
 
 #: ../../content/applications/essentials/activities.rst:11
 msgid ""
 "The icon used to display activities varies, depending on the :ref:`activity "
 "type <activities/types>`:"
 msgstr ""
+"L’icône utilisée pour afficher les activités varie en fonction du :ref:`type "
+"d’activité <activities/types>` :"
 
 #: ../../content/applications/essentials/activities.rst:14
 msgid ""
 ":icon:`fa-clock-o` :guilabel:`(clock)` icon: the default activities icon."
 msgstr ""
+":icon:`fa-clock-o` :guilabel:`(clock)` icon : icône par défaut des activités."
 
 #: ../../content/applications/essentials/activities.rst:15
 msgid ":icon:`fa-phone` :guilabel:`(phone)` icon: a phone call is scheduled."
-msgstr ""
+msgstr " :icon:`fa-phone` :guilabel:`(phone)` icon : un appel téléphonique est planifié."
 
 #: ../../content/applications/essentials/activities.rst:16
 msgid ":icon:`fa-envelope` :guilabel:`(envelope)` icon: an email is scheduled."
-msgstr ""
+msgstr " :icon:`fa-envelope` :guilabel:`(envelope)` icon : un e-mail est planifié."
 
 #: ../../content/applications/essentials/activities.rst:17
 msgid ":icon:`fa-check` :guilabel:`(check)` icon: a \"to-do\" is scheduled."
-msgstr ""
+msgstr ":icon:`fa-check` :guilabel:`(check)` icon : une tâche « à faire » est planifiée."
 
 #: ../../content/applications/essentials/activities.rst:18
+<<<<<<< HEAD
 msgid ":icon:`fa-users` :guilabel:`(users)` icon: a meeting is scheduled."
 msgstr ""
+=======
+msgid ":icon:`fa-users` :guilabel:`(people)` icon: a meeting is scheduled."
+msgstr ":icon:`fa-users` :guilabel:`(people)` icon : une réunion est planifiée."
+>>>>>>> 6f7d11c34 (l10n_fr: add French translations for Activities icons)
 
 #: ../../content/applications/essentials/activities.rst:19
 msgid ""
 ":icon:`fa-upload` :guilabel:`(upload)` icon: a document is scheduled to be "
 "uploaded."
 msgstr ""
+":icon:`fa-upload` :guilabel:`(upload)` icon : un document est planifié pour être téléversé."
 
 #: ../../content/applications/essentials/activities.rst:20
 msgid ""
 ":icon:`fa-pencil-square-o` :guilabel:`(request signature)` icon: a signature "
 "request is scheduled."
 msgstr ""
+":icon:`fa-pencil-square-o` :guilabel:`(request signature)` icon : une demande de signature est planifiée."
 
 #: ../../content/applications/essentials/activities.rst:23
 msgid "Schedule activities"


### PR DESCRIPTION
Adds missing French translations for Activities icon descriptions
in the Essentials documentation.

Scope intentionally limited.