### PR TITLE
Added warning that product images with google images has been removed

### DIFF
--- a/content/applications/sales/sales/products_prices/products/product_images.rst
+++ b/content/applications/sales/sales/products_prices/products/product_images.rst
@@ -2,6 +2,9 @@
 Product images with Google Images
 =================================
 
+.. warning::
+   Product images with Google Images has been removed as of Odoo 19 in favor of images imported through barcode lookup. 
+
 Having appropriate product images in Odoo is useful for a number of reasons. However, if a lot of
 products need images, assigning them can become incredibly time-consuming.
 


### PR DESCRIPTION
A warning would be helpful that this feature has been removed. I'm new here and not sure of the standard method of documenting deprecated features, but this is my attempt at something helpful for others that might try to setup the integration and get partial way through it before finding out that the feature is no longer supported.