### PR TITLE
[FIX] tests: catch early line breaks in substitutions

### DIFF
--- a/tests/checkers/rst_style.py
+++ b/tests/checkers/rst_style.py
@@ -140,8 +140,8 @@ def check_early_line_breaks(file, lines, options=None):
         if lno + 1 < len(lines):
             next_line = lines[lno + 1]
             if (
-                is_valid_line(line, ('+', '|'))
-                and is_valid_line(next_line, ('+', '|', '- ', '* ', '#. '))
+                is_valid_line(line, ('+', '| '))
+                and is_valid_line(next_line, ('+', '| ', '- ', '* ', '#. '))
             ):
                 current_line_remaining_space = options.max_line_length - len(line.rstrip())
                 next_line_first_word = get_next_line_first_word(next_line).rstrip()


### PR DESCRIPTION
[Task](https://www.odoo.com/odoo/project/6050/tasks/5412665)

Output:
<img width="981" height="425" alt="jan-2026-01-05-4614" src="https://github.com/user-attachments/assets/86d85ea3-113f-42c3-ab88-4ad8cae23e5d" />
