### PR TITLE
[IMP] pos: terminology alignment pos interface, register

### DIFF
--- a/content/applications/finance/fiscal_localizations/belgium.rst
+++ b/content/applications/finance/fiscal_localizations/belgium.rst
@@ -585,8 +585,8 @@ POS.
   Configuration --> Settings`, and from the :guilabel:`Accounting` section, open the
   :guilabel:`Default Sales Tax` form by clicking the arrow next to the default sales tax field.
   There, click :guilabel:`Advanced Options` and enable :guilabel:`Included in Price`.
-- At the start of a POS session, users must click :guilabel:`Work in` to clock in. Doing so allows
-  the registration of POS orders. If users are not clocked in, they cannot make POS orders.
+- At the opening of the POS register, users must click :guilabel:`Work in` to clock in. Doing so
+  allows the registration of POS orders. If users are not clocked in, they cannot make POS orders.
   Likewise, they must click :guilabel:`Work Out` to clock out at the end of the session.
 
 .. warning::
@@ -680,6 +680,6 @@ Point of Sale`, select your POS, scroll down to the :guilabel:`Connected Device`
 VAT signing card
 ----------------
 
-When you open a POS session and make your initial transaction, you are prompted to enter the PIN
+When you open the POS register and make your initial transaction, you are prompted to enter the PIN
 provided with your :abbr:`VSC (VAT signing card)`. The card is delivered by the :abbr:`FPS (Service
 Public Federal Finances)` upon `registration <https://www.systemedecaisseenregistreuse.be/fr/enregistrement>`_.

--- a/content/applications/finance/fiscal_localizations/brazil.rst
+++ b/content/applications/finance/fiscal_localizations/brazil.rst
@@ -728,7 +728,7 @@ To generate an NFC-e, follow these steps:
    side of the screen.
 
 .. image:: brazil/l10n-br-nfce-succesfully-issued.png
-   :alt: NFC-e Success in a POS session.
+   :alt: NFC-e Success in the POS register.
 
 .. note::
    It is also possible to issue an NFC-e that identifies the customer by their CPF/CNPJ. To do
@@ -770,7 +770,7 @@ If the NFC-e returns an error, follow these steps:
 #. Click :guilabel:`Send NFC-e`.
 
 .. note::
-   If the error has been corrected and the PoS session is closed, Odoo logs the tax adjustment in
+   If the error has been corrected and the POS register is closed, Odoo logs the tax adjustment in
    the chatter of the related journal entry. The journal entry for the order indicates that the
    taxes were incorrectly calculated. In this case, reprocessing the NFC-e is required.
 

--- a/content/applications/finance/fiscal_localizations/ecuador.rst
+++ b/content/applications/finance/fiscal_localizations/ecuador.rst
@@ -868,7 +868,7 @@ Identification type and number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The P0S cashier can :ref:`create a new contact for a customer <pos/use/customers>` who requests an
-invoice from an open POS session.
+invoice from the POS register.
 
 The *Ecuadorian Module for Point of Sale* adds two new fields to the contact creation form:
 :guilabel:`Identification Type` and :guilabel:`Tax ID`.
@@ -890,7 +890,7 @@ customer as :guilabel:`Consumidor Final` and generates an electronic invoice any
 .. note::
    If the client requests a credit note due to a return of this type of purchase, the credit note
    should be made using the client's real contact information. Credit notes cannot be created for
-   *Consumidor Final* and can be managed :ref:`directly from the POS session <pos/use/refund>`.
+   *Consumidor Final* and can be managed :ref:`directly from the POS register <pos/use/refund>`.
 
 .. _localizations/ecuador/specific-customer:
 
@@ -902,4 +902,4 @@ with their fiscal information. This ensures the invoice is generated with accura
 
 .. note::
    If the client requests a credit note due to a return of this type of purchase, the credit note
-   and return process can be managed :ref:`directly from the POS session <pos/use/refund>`.
+   and return process can be managed :ref:`directly from the POS register <pos/use/refund>`.

--- a/content/applications/finance/fiscal_localizations/france.rst
+++ b/content/applications/finance/fiscal_localizations/france.rst
@@ -697,8 +697,8 @@ To access closings, either go to :menuselection:`Point of Sales --> Reporting --
 .. note::
    - Closings compute the totals for journal entries of sales journals (Journal Type = Sales).
    - For multi-companies environments, such closings are performed by company.
-   - POS orders are posted as journal entries at the closing of the POS session. Closing a POS
-     session can be done anytime. To prompt users to do it daily, the module prevents them from
+   - POS orders are posted as journal entries at the closing of the POS register. Closing the POS
+     register can be done at any time. To prompt users to do it daily, the module prevents them from
      resuming a session that was opened more than 24 hours ago. Such a session must be closed before
      selling again.
    - A period’s total is computed from all the journal entries posted after the previous closing of

--- a/content/applications/finance/fiscal_localizations/germany.rst
+++ b/content/applications/finance/fiscal_localizations/germany.rst
@@ -315,7 +315,7 @@ Once the creation of the TSS is successful, you can find the:
 DSFinV-K export
 ~~~~~~~~~~~~~~~
 
-Whenever you close a PoS session, the details of the orders are sent to the :abbr:`DSFinV-K
+Whenever you close the POS register, the details of the orders are sent to the :abbr:`DSFinV-K
 (Digitale Schnittstelle der Finanzverwaltung für Kassensysteme)` service of fiskaly.
 
 In case of an audit, you can export the data sent to DSFinV-K by going to :menuselection:`Point of

--- a/content/applications/finance/fiscal_localizations/mexico.rst
+++ b/content/applications/finance/fiscal_localizations/mexico.rst
@@ -1383,7 +1383,7 @@ Point of sale
 =============
 
 The :doc:`Point of sale <../../sales/point_of_sale>` adaptation of the Mexican Localization enables
-the creation of invoices that comply with the |SAT| requirements directly in the **POS session**,
+the creation of invoices that comply with the |SAT| requirements directly from the **POS register**,
 with the added benefit of creating receipt tickets that allow *self-invoicing* in a special portal
 and creating global invoices.
 
@@ -1464,7 +1464,7 @@ account for the new invoices.
 Global invoice
 --------------
 
-As with regular sales orders, global invoices can also be created from a POS session.
+As with regular sales orders, global invoices can also be created from the POS register.
 
 For this, make sure not to select a customer or the invoice option in the payment menu and go to
 :menuselection:`Point of Sale --> Orders --> Orders`. There, select all the orders to invoice, click
@@ -1476,7 +1476,7 @@ This attaches an XML file to each of the selected orders. The XML files can be d
 to the :guilabel:`CFDI` tab. If needed, it is possible to cancel the invoice from the same tab.
 
 If eventually any of the orders that are part of the global invoice need to be addressed to a
-customer, it is still possible to send an invoice by entering a new POS session, clicking the
+customer, it is still possible to send an invoice by opening the POS register, clicking the
 :icon:`fa-bars` :guilabel:`(drop-down menu)`, then click :guilabel:`Orders`. Change the
 :guilabel:`All active orders` filter to :guilabel:`Paid`, select the order, and click the
 :icon:`fa-file-text-o` :guilabel:`Invoice` button.

--- a/content/applications/finance/fiscal_localizations/peru.rst
+++ b/content/applications/finance/fiscal_localizations/peru.rst
@@ -68,8 +68,8 @@ Peruvian localization.
        electronic invoices.
    * - :guilabel:`Peruvian - Point of Sale with PE Doc`
      - `l10n_pe_pos`
-     - Enables contact fiscal information to be editable from a PoS Session to generate electronic
-       invoices and refunds.
+     - Enables contact fiscal information to be editable from the POS register to generate
+       electronic invoices and refunds.
 
 .. note::
    - Odoo automatically installs the appropriate package for the company according to the country

--- a/content/applications/sales/point_of_sale/employee_login.rst
+++ b/content/applications/sales/point_of_sale/employee_login.rst
@@ -45,9 +45,9 @@ settings <pos/use/settings>`. Then,
 
       Employees with minimal rights can perform the following actions within the POS:
 
-      **Session management:**
+      **Register management:**
 
-      - Lock and unlock an open POS session.
+      - Lock and unlock an open POS register.
       - Reload data.
 
       **Sales transactions:**
@@ -64,7 +64,7 @@ settings <pos/use/settings>`. Then,
 
       In addition to the minimal rights, employees with basic rights can also:
 
-      **Session management:**
+      **Register management:**
 
       - :ref:`Open the POS register <pos/use/open-register>`.
       - :ref:`Perform cash-in and cash-out operations <pos/use/cash-register>`.
@@ -111,10 +111,11 @@ their name from the list of authorized users, or by entering :ref:`their PIN cod
 <pos/employee_login/pin>` in the :guilabel:`Enter your PIN` field.
 
 .. image:: employee_login/log-in.png
-   :alt: Login window to open a register when the multiple cashiers feature is active
+   :alt: Login window to open the register when the multiple cashiers feature is active
 
-To switch between users from the :ref:`interface <pos/use/open-register>`, click on the currently
-logged-in employee's name at the top right of the POS screen and select the user to switch to.
+To switch between users from the :ref:`POS interface <pos/use/open-register>`, click on the
+currently logged-in employee's name at the top right of the POS screen and select the user to
+switch to.
 
 .. tip::
    In the absence of a scanner, click the :icon:`fa-barcode` icon (:guilabel:`barcode`) to scan
@@ -137,9 +138,9 @@ the employee's profile in the **Employees** module:
    - Click :guilabel:`Generate` to create a unique badge ID automatically.
 #. Click :guilabel:`Print Badge` to generate a barcode representation of the assigned badge ID.
 
-To switch users from the :ref:`interface <pos/use/open-register>`, using a badge, you must first
-lock the register. To do so, click the :icon:`fa-lg fa-lock` icon (:guilabel:`lock`) to return to
-the login screen. Then, the new employee can scan their badge to log in.
+To switch between users from the :ref:`POS interface <pos/use/open-register>`, using a badge, you
+must first lock the register. To do so, click the :icon:`fa-lg fa-lock` icon (:guilabel:`lock`) to
+return to the login screen. Then, the new employee can scan their badge to log in.
 
 .. _pos/employee_login/pin:
 

--- a/content/applications/sales/point_of_sale/payment_methods/customer_credit.rst
+++ b/content/applications/sales/point_of_sale/payment_methods/customer_credit.rst
@@ -68,13 +68,13 @@ Debt tracking
 
 When a customer pays using their customer account, the purchase amount is recorded as debt until it
 is paid off. To keep track of a customer’s debt, consult their customer statement in the backend or
-their profile in an open session.
+their customer profile from the POS register.
 
 To access the :guilabel:`Customer Statement` report, go to :menuselection:`Point of Sale --> Orders
 --> Customers`, select a customer to open their form, and click the :guilabel:`Customer Statements`
 smart button.
 
-To view the total amount due or deposited by a customer from an open session, access the customer
+To view the total amount due or deposited by a customer from the POS register, access the customer
 list by clicking :guilabel:`Customer` and search for the desired customer; the amount due or
 deposited is displayed next to their name.
 

--- a/content/applications/sales/point_of_sale/pos_hardware.rst
+++ b/content/applications/sales/point_of_sale/pos_hardware.rst
@@ -164,7 +164,7 @@ Using a scale in PoS
 --------------------
 
 #. :ref:`Access the POS register <pos/use/open-register>`.
-#. Select the product to weigh on the order screen or scan its barcode.
+#. Select the product to weigh in the POS register or scan its barcode.
 #. Place the product on the scale and wait for the weight to be displayed in the popup window.
 #. Once the weight is determined, the price is automatically computed.
 #. Click :guilabel:`Order` :icon:`fa-angle-double-right` to add the product to the cart.

--- a/content/applications/sales/point_of_sale/pricing/discounts.rst
+++ b/content/applications/sales/point_of_sale/pricing/discounts.rst
@@ -21,7 +21,7 @@ products inside an order.
 Apply a discount on a product
 -----------------------------
 
-From your PoS session interface, use the *Disc* button.
+From the POS register, use the *Disc* button.
 
 .. image:: discounts/discounts_01.png
    :align: center

--- a/content/applications/sales/point_of_sale/self_order.rst
+++ b/content/applications/sales/point_of_sale/self_order.rst
@@ -202,8 +202,8 @@ Usage guidelines
          :alt: Popup window to open the kiosk
 
       .. note::
-         - Once a session is open, :guilabel:`Start Kiosk` switches to :guilabel:`Open Kiosk` on the
-           POS card.
+         - Once the register is open, :guilabel:`Start Kiosk` switches to :guilabel:`Open Kiosk` on
+           the POS card.
          - Click :guilabel:`Open Kiosk` on the POS card to reopen the popup window and access the
            self-ordering interface.
 
@@ -219,6 +219,6 @@ Usage guidelines
          :scale: 65 %
 
 .. important::
-   - A POS session must be open for customers to place an order.
+   - The POS register must be open for customers to place an order.
    - Once an order is placed, it is automatically sent to :doc:`the preparation screen
      <preparation>` and added to the list of POS orders.

--- a/content/applications/sales/point_of_sale/shop/barcode.rst
+++ b/content/applications/sales/point_of_sale/shop/barcode.rst
@@ -4,7 +4,7 @@ Barcodes
 
 Using a barcode scanner to process point-of-sale orders improves your efficiency in providing
 quicker customer service. Barcode scanners can be used both to scan products or to log employees
-into a POS session.
+into the POS register.
 
 Configuration
 =============

--- a/content/applications/sales/point_of_sale/shop/sales_order.rst
+++ b/content/applications/sales/point_of_sale/shop/sales_order.rst
@@ -9,7 +9,7 @@ sales order and pay for it directly from your point of sale.
 Select a sales order
 ====================
 
-From the **Point of Sale** application, open a new session. Then, click on
+From the **Point of Sale** application, open the POS register. Then, click on
 :guilabel:`Quotations/Orders` to get the complete list of quotations and sales orders created on the
 sales application.
 


### PR DESCRIPTION
task-5033527

I did not update the terminology from the POS homepage et configuration since they were [updated in this PR.](https://github.com/odoo/documentation/pull/13761)
Same goes for the "session-start" and "session-close" anchors