### PR TITLE
[FIX] Inventory: Putaway rules for untracked products

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/product_management/configure/type.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/configure/type.rst
@@ -156,7 +156,7 @@ documents.
      - Yes
    * - :ref:`Use putaway rules <inventory/product_management/putaway>`
      - Yes
-     - No
+     - Yes
    * - :ref:`Can be manufactured, subcontracted, or used in another good's BoM
        <inventory/product_management/manufacturing>`
      - Yes


### PR DESCRIPTION
An external user noticed a discrepancy in our documentation that stated that untracked products could not use putaway rules. I've fixed the table where that information appears.

This 18.0 PR can be FWP up to master.