### PR TITLE
[IMP] developer/http: adapt references

### DIFF
--- a/content/developer/reference/backend/http.rst
+++ b/content/developer/reference/backend/http.rst
@@ -66,14 +66,14 @@ Request
 The request object is automatically set on :data:`odoo.http.request` at
 the start of the request.
 
-.. autoclass:: odoo.http.Request
+.. autoclass:: odoo.http.requestlib.Request
     :members:
     :member-order: bysource
 
-.. autoclass:: odoo.http.JsonRPCDispatcher
+.. autoclass:: odoo.http.dispatcher.JsonRPCDispatcher
     :members:
     :member-order: bysource
-.. autoclass:: odoo.http.HttpDispatcher
+.. autoclass:: odoo.http.dispatcher.HttpDispatcher
     :members:
     :member-order: bysource
 


### PR DESCRIPTION
The odoo.http module is a huge file with thousands of lines. In this work we split it in many smaller chunks. The desire to split odoo.http has been in the air for quite some time, notably with the introduction of the many facade objects.

This work only moves the constants, functions and classes in new dedicated odoo.http-submodules. For the documentation it means that a few reference had to be updated.