### PR TITLE
[FIX] iot: no bluetooth printers via IoT

### DIFF
--- a/content/applications/general/iot/devices/printer.rst
+++ b/content/applications/general/iot/devices/printer.rst
@@ -15,7 +15,7 @@ control point or a quality check.
 Connection
 ==========
 
-IoT systems support printers connected through USB, network connection, or Bluetooth.
+IoT systems support printers connected through USB or network connection.
 `Supported printers <https://www.odoo.com/page/iot-hardware>`_ are detected automatically, and
 appear in the :guilabel:`Devices` list of the IoT app.
 


### PR DESCRIPTION
This PR removes the mention of support of bluetooth printers via iot. Bluetooth printers aren't currently supported at all on raspberry pi iot boxes and can be supported on virtual/windows iot boxes if the windows printing server allows it but this isn't tested / recommended so we remove it altogether from the documentation.