### PR TITLE
[FIX] Referrals: Incorrect definition of points

### DIFF
--- a/content/applications/hr/referrals/share_jobs.rst
+++ b/content/applications/hr/referrals/share_jobs.rst
@@ -33,7 +33,8 @@ Each job position card contains the following information:
   form.
 - The number of :guilabel:`Open Positions` being recruited. This information is taken from the
   *Expected New Employees* field of the *Recruitment* tab of the job form.
-- The :doc:`points <points>` a user earns when an applicant applies for the position.
+- The total :doc:`points <points>` a user earns when the referred applicant is hired for the
+  position.
 - The job description detailing the job position. This information is taken from the *Job Position*
   tab of the job form.
 


### PR DESCRIPTION
The text for what the points mean is incorrect - it is not what they earn when an applicant applies (the original text) but it's the TOTAL points once the applicant is HIRED. 

Original [task card](https://www.odoo.com/odoo/project/3835/tasks/5497790) for this PR.