### PR TITLE
[FIX] Referrals: Update points definition

### DIFF
--- a/content/applications/hr/referrals/share_jobs.rst
+++ b/content/applications/hr/referrals/share_jobs.rst
@@ -30,7 +30,7 @@ Each job position card contains the following information:
   form.
 - The number of :guilabel:`Open Positions` being recruited. This information is taken from the
   *Expected New Employees* field of the *Recruitment* tab of the job form.
-- The points a user earns when an applicant applies for the position.
+- The total points a user earns when a referred applicant is hired for the position.
 - The job description detailing the job position. This information is taken from the *Job Position*
   tab of the job form.
 


### PR DESCRIPTION
The text for what the points mean is incorrect - it is not what they earn when an applicant applies (the original text) but it's the TOTAL points once the applicant is HIRED. 

This PR is for version 17.0 ONLY.

[Task card](https://www.odoo.com/odoo/project/3835/tasks/5497963) for this PR.

No points for this fix PR.