### PR TITLE
[IMP] developer/view_architectures: remove dropped map view attributes

### DIFF
--- a/content/developer/reference/user_interface/view_architectures.rst
+++ b/content/developer/reference/user_interface/view_architectures.rst
@@ -4199,10 +4199,6 @@ The view's root element is ``<map>``. It can have the following attributes:
     if ``1`` hide the name from the pin's popup (default: ``0``).
 ``hide_address``
     if ``1`` hide the address from the pin's popup (default: ``0``).
-``hide_title``
-    if ``1`` hide the title from the pin list (default: ``0``).
-``panel_title``
-    String to display as title of the pin list. If not provided, the title is the action's name or "Items" if the view is not in an action.
 ``limit``
     Maximum number of records to fetch (default: ``80``). It must be a positive integer.
 


### PR DESCRIPTION
In master we refactor the base map ui view, removing
some options from the sidepanel such as the panel title.

In this commit we remove the attributes linked to
the panel title: `hide_title` and `panel_title`

see odoo/enterprise#104618
task#5259181