### PR TITLE
[IMP] 2fa: explain that some localizations require 2fa

### DIFF
--- a/content/applications/finance/fiscal_localizations/australia.rst
+++ b/content/applications/finance/fiscal_localizations/australia.rst
@@ -39,6 +39,10 @@ Configuration
      - `l10n_au_keypay`
      - Synchronises all pay runs from Employment Hero with Odoo’s journal entries.
 
+.. note::
+   It is not possible for users of the Australian fiscal localization to deactivate :doc:`two-factor
+   authentication (2FA) <../../general/users/2fa>` as it is required by the Australian government.
+
 .. _australia/coa:
 
 Chart of Accounts

--- a/content/applications/general/users/2fa.rst
+++ b/content/applications/general/users/2fa.rst
@@ -14,6 +14,11 @@ exchanging a code from the authenticator when trying to log in.
 This means an unauthorized user would need to guess the account password *and* have access to the
 authenticator, which is a more difficult proposition.
 
+.. note::
+   Some governments, such as the :doc:`Australian <../../finance/fiscal_localizations/australia>`
+   government, require |2fa|. For these :doc:`fiscal localizations
+   <../../finance/fiscal_localizations>`, it is not possible to deactivate |2fa|.
+
 Requirements
 ============
 
@@ -32,7 +37,7 @@ Phone-based authenticators are the easiest and most commonly used. Examples incl
 Password managers are another option. Common examples include:
 
 - `1Password <https://support.1password.com/one-time-passwords/>`_
-- `Bitwarden <https://bitwarden.com/help/article/authenticator-keys/>`_,
+- `Bitwarden <https://bitwarden.com/help/article/authenticator-keys/>`_
 
 .. note::
    The remainder of this document uses Google Authenticator as an example, as it is one of the most


### PR DESCRIPTION
task-5816163

Mention that some governments, such as Australia, require two factor authentication and that in these localizations, it is not possible to deactivate 2FA.