### PR TITLE
[FIX] saudi_arabia: add warning about company name length

### DIFF
--- a/content/applications/finance/fiscal_localizations/saudi_arabia.rst
+++ b/content/applications/finance/fiscal_localizations/saudi_arabia.rst
@@ -40,7 +40,8 @@ Company information
 Go to :menuselection:`Settings --> General Settings --> Companies`, click :guilabel:`Update info`,
 and ensure the following company information is complete and up-to-date.
 
-- The full :guilabel:`Company Name`.
+- The :guilabel:`Company Name`, limited to a maximum of 63 characters to comply with ZATCA
+  requirements.
 - All relevant :guilabel:`Address` fields, including the :guilabel:`Building Number` and
   :guilabel:`Plot Identification` (four digits each).
 - Select an enterprise :guilabel:`Identification Scheme`. It is recommended to use the


### PR DESCRIPTION
We have had lots of tickets recently about failed ZATCA onboarding. One of the most common reasons is that the company or branch name is too long compared to the strict limits imposed by zatca.

As for the limits, they are technical, imposed by the QR code generated for every invoice.

The limit itself is 127 bytes, which depending on the exact arabic characters used can range from 42 to 63 arabic characters. 63 is in the best-case scenario where we can encode all characters on 2 bytes.
42 characters is the worst-case scenario where special characters requiring 3 bytes are used.

In an effort to keep our documentation concise and clear, we chose to stick to the best-case scenario of 63 characters, assuming that would be the most common scenario.
Pull requests have been made in the main codebase to make the error messages clearer upon failed onboarding, which should cover the "42 characters edge cases".