### PR TITLE
[IMP] web: Add 'days' unit in duration

### DIFF
--- a/content/developer/reference/frontend/javascript_reference.rst
+++ b/content/developer/reference/frontend/javascript_reference.rst
@@ -667,7 +667,7 @@ Time (`float_time`)
 
     - `unit`: specify what is the unit of time of the float value (`"hours"` by default)
 
-        The units of time available are: `"hours"`, `"minutes"` and `"seconds"`.
+        The units of time available are: `"days"`, `"hours"`, `"minutes"` and `"seconds"`.
 
         .. code-block:: xml
 


### PR DESCRIPTION
The unit "days" is added in the human readable durations.