### PR TITLE
[FIX] germanfiscalloc: typo in url

### DIFF
--- a/content/applications/finance/fiscal_localizations/germany.rst
+++ b/content/applications/finance/fiscal_localizations/germany.rst
@@ -227,7 +227,7 @@ application.
   regular backups can be downloaded and backed up on external systems.
 
   .. seealso::
-     `Odoo Cloud Hosting - Service Level Agreement <https://www.odooo.com/cloud-sla>`_
+     `Odoo Cloud Hosting - Service Level Agreement <https://www.odoo.com/cloud-sla>`_
 
 - If the server is operated locally, it is the responsibility of the user to create the necessary
   backup infrastructure.


### PR DESCRIPTION
Fixed two typos in the German Localization docs:

- URL typo: Corrected the Odoo Cloud Hosting SLA link
- Text typo: Fixed garbled text that read "It can odooomerely"