### PR TITLE
[IMP] POS: Update Mercado Pago Scope

### DIFF
--- a/content/applications/sales/point_of_sale/payment_methods/terminals/mercado_pago.rst
+++ b/content/applications/sales/point_of_sale/payment_methods/terminals/mercado_pago.rst
@@ -6,8 +6,8 @@ Connecting a payment terminal allows you to offer a fluid payment flow to your c
 the work of your cashiers.
 
 .. important::
-   Only **Point Smart** payment terminals in Argentina, Brazil, Chile, Colombia, Mexico, Peru, and
-   Uruguay are supported. They can be purchased on `Mercado Pago's website
+   Only **Point Smart** payment terminals in Argentina, Brazil, and Mexico. 
+   They can be purchased on `Mercado Pago's website
    <https://www.mercadopago.com.mx/herramientas-para-vender/lectores-point>`_.
 
 .. seealso::


### PR DESCRIPTION
The current list of covered countries by Marcado Pago is incorrect, as this terminal is only supported in three countries.

This PR removes the countries that are out of the scope. 