### PR TITLE
[IMP] add highlight fade to ref targets

### DIFF
--- a/extensions/odoo_theme/static/style.scss
+++ b/extensions/odoo_theme/static/style.scss
@@ -973,6 +973,29 @@ span.viewcode-link {
 }
 
 //------------------------------------------------------------------------------
+// Ref target highlighting
+//------------------------------------------------------------------------------
+
+span:target + h1,
+span:target + h2,
+span:target + h3,
+span:target + h4 {
+    animation: highlight-fade 5s ease-out 0s 1;
+}
+
+@keyframes highlight-fade {
+    0% {
+        background-color: lighten($warning, 15%);
+    }
+    50% {
+        background-color: lighten($warning, 15%);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+//------------------------------------------------------------------------------
 // Alerts
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
Task: https://www.odoo.com/odoo/project/3835/tasks/5970579

When a user clicks on a ref link and the page scrolls to a heading its easy to not see the specific heading. This PR adds a temporary highlight to the heading. Styling is similar to the search term highlighting that currently exists. See screenshot and example below:

![ref-highlight](https://github.com/user-attachments/assets/cadbfabe-c180-48c4-a31b-9ff5f2bcfdc2)
<img width="1175" height="872" alt="search-highlight" src="https://github.com/user-attachments/assets/4f38bb1e-8bb6-447f-92c6-03cb4b7bb49e" />
