### PR TITLE
[FIX] howtos/website_themes: Typo (Theming, layout and pages)

### DIFF
--- a/content/developer/howtos/website_themes/layout.rst
+++ b/content/developer/howtos/website_themes/layout.rst
@@ -228,10 +228,10 @@ below:
       .. code-block:: xml
 
          <xpath expr="//*[hasclass('o_wsale_products_main_row')]" position="before">
-         <xpath expr="//t[@t-if='opt_wsale_categories_top']" position="move" />
+            <xpath expr="//t[@t-if='opt_wsale_categories_top']" position="move" />
          </xpath>
          <xpath expr="//*[hasclass('o_wsale_products_main_row')]" position="before">
-         <div><!-- Content --></div>
+            <div><!-- Content --></div>
          </xpath>
 
       | **Bad example:**
@@ -239,8 +239,8 @@ below:
       .. code-block:: xml
 
          <xpath expr="//*[hasclass('o_wsale_products_main_row')]" position="before">
-         <xpath expr="//t[@t-if='opt_wsale_categories_top']" position="move" />
-         <div><!-- Content --></div>
+            <xpath expr="//t[@t-if='opt_wsale_categories_top']" position="move" />
+            <div><!-- Content --></div>
          </xpath>
 
 
@@ -729,7 +729,7 @@ Responsive
 ==========
 
 Odoo in general relies on the Bootstrap framework which eases the responsiveness of your website on
- desktop and mobile. On Odoo 16, you can mainly take action on 3 aspects:
+desktop and mobile. You can mainly take action on 3 aspects:
 
 #. Automatic computed font sizes depending on the device
 #. Column sizes on desktop (the columns are automatically stacked on mobile)

--- a/content/developer/howtos/website_themes/pages.rst
+++ b/content/developer/howtos/website_themes/pages.rst
@@ -100,7 +100,7 @@ Alternatively, replace the default content of these pages using XPath.
 
    <template id="404" inherit_id="http_routing.404">
        <xpath expr="//*[@id='wrap']" position="replace">
-           <t t-set="additional_title" t-value="'404 - Not found'"/>
+           <t t-set="additional_title">404 - Not found</t>
 
            <div id="wrap" class="oe_structure">
                <!-- Content -->

--- a/content/developer/howtos/website_themes/theming.rst
+++ b/content/developer/howtos/website_themes/theming.rst
@@ -661,7 +661,7 @@ This is a non-exhaustive list of the frequently used bundles for a website:
    * - website.assets_wysiwyg
      - Add your JS files related to the Website Builder options behaviors (for instance, a custom
        method for your custom building block)
-   * - website.assets_wysiwyg
+   * - website._assets_bootstrap
      - If you need to extend Boostrap through the Bootstrap Utilities API, for example
 
 .. _theming/assets/styles:
@@ -738,7 +738,7 @@ brings the benefit of a better developer experience with better integration with
 
 .. tip::
    - Use a linter (JSHint, ...).
-   - Never add minified JavaScript libraries.
+   - Always add minified JavaScript libraries.
    - Add `'use strict';` at the top of every old-style module (this is automatic for new-style
      modules).
    - Use `js_` prefixed CSS classes on elements you target with JavaScript.


### PR DESCRIPTION
- Theming: bundle _assets_bootstrap
- Theming: Minified external libs
- Layout: Move example - indentation
- Layout: Remove useless version number
- Pages: 404 additional_title

Task-5960491