### PR TITLE
[FIX] Attendances - Update location coordinate details

### DIFF
--- a/content/applications/hr/attendances.rst
+++ b/content/applications/hr/attendances.rst
@@ -238,10 +238,9 @@ sections.
 - :guilabel:`IP Address`: the IP address for the computer the employee used to log in or out.
 - :guilabel:`Browser`: the web browser the employee used to log in or out.
 - :guilabel:`Localization`: the city and country associated with the computer's IP address.
-- :guilabel:`GPS Coordinates`: the specific coordinates when the user logged in or out. To view the
-  specific coordinates on a map, click the :guilabel:`→ View on Maps` button beneath the
-  :guilabel:`GPS Coordinates`. This opens a map in a new browser tab, with the specific location
-  pointed out.
+- :guilabel:`GPS Coordinates`: the coordinates when the user logged in or out. To view the
+  coordinates on a map, click the :guilabel:`→ View on Maps` button beneath the GPS coordinates.
+  This opens a map in a new browser tab, with the location pointed out.
 
 .. image:: attendances/details.png
    :align: center


### PR DESCRIPTION
Requested to remove "specific" from "specific coordinates" from this [task card](https://github.com/odoo/project.task/5250650). Apparently, computer settings and the network users use to log in may affect their coordinates, and imply they are logging in from a place different from what is expected. Since Odoo cannot change to fix this issue/show accurate location info, removing the word "specific" to keep the information accurate.

The documentation from 17, 18, and 19 have changed significantly, so making separate PR's for each version.

Original [task card](https://www.odoo.com/odoo/project/3835/tasks/5980920) for this PR.