### PR TITLE
[IMP] web: adds new many2many tag widget parameter

### DIFF
--- a/content/developer/reference/frontend/javascript_reference.rst
+++ b/content/developer/reference/frontend/javascript_reference.rst
@@ -1377,6 +1377,13 @@ Many2many Tags (`many2many_tags`)
 
             <field name="category_id" widget="many2many_tags" options="{'edit_tags': true}" />
 
+    - `tag_limit`: Number of tags to display. Set to 0 to always display all tags.
+      (default: `8`).
+
+        .. code-block:: xml
+
+            <field name="category_id" widget="many2many_tags" options="{'tag_limit': 20}" />
+
 Many2many Tags - Form View (`form.many2many_tags`)
     Specialization of `many2many_tags` widget for form views. It has some extra
     code to allow editing the color of a tag.
@@ -1384,7 +1391,7 @@ Many2many Tags - Form View (`form.many2many_tags`)
     - Supported field types: `many2many`
 
 Many2many Tags - Kanban View (`kanban.many2many_tags`)
-    Specialization of `many2many_tags` widget for kanban views.
+    A read-only specialization of `many2many_tags` widget for kanban views.
 
     - Supported field types: `many2many`
 


### PR DESCRIPTION
Currently we don't have a way to limit the number of m2m tags displayed, which can lead to ugly UI. This commit introduces such a limit, making it editable via studio.

BEFORE: All tags were displayed.

NOW: If there are more tags the limit, we only the display the "x" first tags, as well a a new tag with "+yy", where y represents the number of hidden tags. The "+yy" tag can be clicked to display all tags and has a tooltip: "Click to show more".

We use 8 as a default number of m2m tags displayed (which is also the number of records we display in m2m dropdowns). Setting a value of 0 can be used to display all tags regardless of how many they are.

Community PR: odoo/odoo#251159
Enterprise PR: odoo/enterprise#109040

task#5799365