### PR TITLE
[IMP] general integrations: outlook mail plugin version callout, 19.0 and saas-19.1

### DIFF
--- a/content/applications/general/integrations/mail_plugins/outlook.rst
+++ b/content/applications/general/integrations/mail_plugins/outlook.rst
@@ -6,6 +6,14 @@ Outlook allows for third-party applications to connect in order to execute datab
 emails. Odoo has a plugin for Outlook that allows for the creation of an opportunity from the email
 panel.
 
+.. important::
+   Make sure to check the database version in the :guilabel:`Settings app --> General Settings`, at
+   the bottom of the page.
+
+   For database versions 19.2 and later, see the `latest documentation
+   <https://www.odoo.com/documentation/master/applications/general/integrations/mail_plugins/outlook.html>`_
+   for installation instructions.
+
 Configuration
 =============
 


### PR DESCRIPTION
documentation task card: https://www.odoo.com/odoo/my-tasks/6001333
main PR: https://github.com/odoo/documentation/pull/16689
17.0/18.0 PR: https://github.com/odoo/documentation/pull/16713

key change @ lines 9–15:
- add callout linking to 19.2 docs for versions 19.2+
    - the new plugin is installed directly from marketplace; callout specifically requested by PO

note: this is one of 3 PRs for the task, due to diffs between 17.0/18.0 ↔ 19.0/saas-19.1

This 19.0 PR can be FWP up to saas-19.1.