### PR TITLE
[FIX] developer/external_api: xmlrpc removal postponed to 21.1/22

### DIFF
--- a/content/developer/reference/external_api.rst
+++ b/content/developer/reference/external_api.rst
@@ -380,7 +380,7 @@ Migrating from XML-RPC / JSON-RPC
 =================================
 
 Both the XML-RPC and JSON-RPC APIs at endpoints ``/xmlrpc``, ``/xmlrpc/2`` and ``/jsonrpc`` are
-scheduled for removal in Odoo 20 (fall 2026). Both RPC APIs expose the three same services: common,
+scheduled for removal in Odoo 22 (fall 2028). Both RPC APIs expose the three same services: common,
 db (database) and object. All three services are deprecated.
 
 .. note::

--- a/content/developer/reference/external_rpc_api.rst
+++ b/content/developer/reference/external_rpc_api.rst
@@ -7,7 +7,8 @@ External RPC API
    .. deprecated:: 19.0
 
    Both the XML-RPC and JSON-RPC APIs at endpoints ``/xmlrpc``, ``/xmlrpc/2`` and ``/jsonrpc`` are
-   scheduled for removal in Odoo 20 (fall 2026). The :doc:`external_api` acts as a replacement.
+   scheduled for removal in Odoo 22 (fall 2028) and Online 21.1 (winter 2027). The
+   :doc:`external_api` acts as a replacement.
 
    The other controllers ``@route(type='jsonrpc')`` (known until Odoo 18 as ``type='json'``) are not
    subject to this deprecation notice.


### PR DESCRIPTION
The "rpc service" API (xmlrpc/jsonrpc) have been deprecated in 19.0, JSON-2 acting as replacement. It was at first planned to be removed in 19.1/20 but we succeeded in convicing the management It Was A Bad Idea.

The removal is postponed to Odoo 21.1/22. This makes so that if the [Standard and extended support] policy remains the same until the release of Odoo 22, all versions supported with no additional fees (20, 21, 22) at that time will have JSON-2:

| version | supported at 22 release | rpc services          | JSON-2 |
| ------- | ----------------------- | --------------------- | ------ |
| 18.0    | no[^1]                  | active                | absent |
| 19.0    | no[^1]                  | active but deprecated | active |
| 20.0    | yes                     | active but deprecated | active |
| 21.0    | yes                     | active but deprecated | active |
| 22.0    | yes                     | absent                | active |

[Standard and extended support]: https://www.odoo.com/documentation/19.0/administration/standard_extended_support.html

[^1]: with no additionnal fees.
