### PR TITLE
[IMP] general integrations: new gmail plugin link

### DIFF
--- a/content/applications/general/integrations/mail_plugins/gmail.rst
+++ b/content/applications/general/integrations/mail_plugins/gmail.rst
@@ -14,11 +14,19 @@ records (such as opportunities, tasks, and tickets) directly in Gmail.
 Install the Gmail Plugin
 ========================
 
+.. important::
+   Make sure to check the database version in the :menuselection:`Settings app --> General
+   Settings`, at the bottom of the page.
+
+   For database versions earlier than 19.2, see the `19.0 documentation
+   <https://www.odoo.com/documentation/19.0/applications/general/integrations/mail_plugins/gmail.html>`_
+   for installation instructions.
+
 From the Google Workspace Marketplace
 -------------------------------------
 
 To install the Odoo Gmail plugin, sign in to the Gmail account to be connected to Odoo, then go to
-the `Odoo Inbox Addin <https://workspace.google.com/marketplace/app/odoo_inbox_addin/873497133275>`_
+the `Odoo Inbox Addin <https://workspace.google.com/marketplace/app/odoo_inbox_addin/546131068990>`_
 page in the Google Workspace Marketplace. Click :guilabel:`Install` and a pop-up window appears.
 Click :guilabel:`Continue` and select the checkbox next to :guilabel:`Select all` to grant the
 necessary permissions, then click :guilabel:`Continue` one more time to confirm the installation of


### PR DESCRIPTION
documentation task card: https://www.odoo.com/odoo/project.task/6001333
17.0/18.0 PR: https://github.com/odoo/documentation/pull/16824
19.0/saas-19.1 PR: https://github.com/odoo/documentation/pull/16825

key change @ lines 17–23, 30:
- update gmail plugin link for new 19.2+ listing
- add version callout redirecting to 19.0 for old plugin

note: this is the main one out of 3 PRs for the task, due to diffs between 17.0/18.0 ↔ 19.0/saas-19.1

This saas-19.2 PR can be FWP up to master.