### PR TITLE
[IMP] general integrations: new gmail plugin link, 17.0 and 18.0

### DIFF
--- a/content/applications/general/integrations/mail_plugins/gmail.rst
+++ b/content/applications/general/integrations/mail_plugins/gmail.rst
@@ -5,6 +5,14 @@ Gmail Plugin
 The *Gmail Plugin* integrates an Odoo database with a Gmail inbox, so users can keep track of all
 their work between Gmail and Odoo, without losing any information.
 
+.. important::
+   Make sure to check the database version in the :menuselection:`Settings app --> General Settings`, at
+   the bottom of the page.
+
+   For database versions 19.2 and later, see the `latest documentation
+   <https://www.odoo.com/documentation/master/applications/general/integrations/mail_plugins/gmail.html>`_
+   for installation instructions.
+
 Odoo Online users
 =================
 

--- a/content/applications/general/integrations/mail_plugins/outlook.rst
+++ b/content/applications/general/integrations/mail_plugins/outlook.rst
@@ -6,6 +6,16 @@ Outlook allows for third-party applications to connect in order to execute datab
 emails. Odoo has a plugin for Outlook that allows for the creation of an opportunity from the email
 panel.
 
+.. note::
+   The Outlook plugin is available for both the desktop and web versions of Outlook. See
+   `Microsoft's add-in article
+   <https://support.microsoft.com/en-us/office/use-add-ins-in-outlook-1ee261f9-49bf-4ba6-b3e2-2ba7bcab64c8>`_.
+
+Configuration
+=============
+
+The Outlook :doc:`Mail Plugin <../mail_plugins>` needs to be configured both on Odoo and Outlook.
+
 .. important::
    Make sure to check the database version in the :guilabel:`Settings app --> General Settings`, at
    the bottom of the page.
@@ -13,11 +23,6 @@ panel.
    For database versions 19.2 and later, see the `latest documentation
    <https://www.odoo.com/documentation/master/applications/general/integrations/mail_plugins/outlook.html>`_
    for installation instructions.
-
-Configuration
-=============
-
-The Outlook :doc:`Mail Plugin <../mail_plugins>` needs to be configured both on Odoo and Outlook.
 
 .. _mail-plugin/outlook/enable-mail-plugin:
 
@@ -102,8 +107,8 @@ The right-side panel can now display **Company Insights**. At the bottom, click 
 
    For Google Chrome, change the browser cookie settings by following the guide at:
    `https://support.google.com/chrome/answer/95647
-   <https://support.google.com/chrome/answer/95647>`_
-   and adding `download.odoo.com` to the list of :guilabel:`Sites that can always use cookies`.
+   <https://support.google.com/chrome/answer/95647>`_ and adding `download.odoo.com` to the list of
+   :guilabel:`Sites that can always use cookies`.
 
    Once this is complete, the Outlook panel needs to be opened again.
 


### PR DESCRIPTION
documentation task card: https://www.odoo.com/odoo/project.task/6001333
main pr: https://github.com/odoo/documentation/pull/16823
19.0/saas-19.1 PR: https://github.com/odoo/documentation/pull/16825

key change @ `gmail.rst` lines 17–23, 30:
- add version callout redirecting to master for new plugin

other changes @ `outlook.rst` lines 9–25:
- add outlook desktop/web callout to match 19.2+
- shuffle version redirect callout down to config section
 
note: this is one of 3 PRs for the task, due to diffs between 17.0/18.0 ↔ 19.0/saas-19.1


This 17.0 PR can be FWP up to 18.0.