### PR TITLE
[IMP] MRP Shop Floor: Update MO card disappearance in Shop Floor docs

### DIFF
--- a/content/applications/inventory_and_mrp/manufacturing/shop_floor/shop_floor_overview.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/shop_floor/shop_floor_overview.rst
@@ -100,9 +100,8 @@ the |MO| once production is completed. However, if there are any quality checks 
 instead. Clicking :guilabel:`Quality Checks` opens a pop-up window, from which any required quality
 checks can be completed.
 
-After clicking :guilabel:`Close Production`, the |MO| card begins to fade away, and an
-:guilabel:`Undo` button appears on the footer. Clicking :guilabel:`Undo` causes the |MO| to remain
-open. Once the |MO| card disappears completely, the work order is closed.
+After clicking :guilabel:`Close Production`, the |MO| card disappears completely and the work order
+is closed.
 
 On the right side of the footer is an :guilabel:`⋮ (options)` button, which opens a pop-up window
 with additional options for the |MO|:


### PR DESCRIPTION
Documentation task card: [https://www.odoo.com/odoo/project.task/6015252](https://www.odoo.com/odoo/project.task/6015252)

This PR addresses an outdated line in the Shop Floor docs about an MO card "fading away" upon clicking the `Close Production` button in the Shop Floor app. This feature is no longer supported from 19.0 and beyond.

Change is a single-line fix.

This 19.0 PR should be FWP up to master.