### PR TITLE
[IMP] contributing/development: naming for relational fields

### DIFF
--- a/content/contributing/development/coding_guidelines.rst
+++ b/content/contributing/development/coding_guidelines.rst
@@ -896,8 +896,8 @@ Symbols and Conventions
     partners = Partner.browse(ids)
     partner_id = partners[0].id
 
-- ``One2Many`` and ``Many2Many`` fields should always have *_ids* as suffix (example: sale_order_line_ids)
-- ``Many2One`` fields should have *_id* as suffix (example : partner_id, user_id, ...)
+- ``One2Many`` and ``Many2Many`` fields should always have *_ids* as suffix, and the base name should be plural (example: sale_order_lines_ids)
+- ``Many2One`` fields should have *_id* as suffix, and the base name should be singular (example : partner_id, user_id, ...)
 - Method conventions
     - Compute Field : the compute method pattern is *_compute_<field_name>*
     - Search method : the search method pattern is *_search_<field_name>*


### PR DESCRIPTION
The convention in Odoo requiring to suffix One2many and Many2many fields with _ids, and Many2one fields with _id, is enough for a human or an AI to know if a relational variable can hold several or just one record, respectively. The argument against to name the part before the suffix (the base name) in plural when the relational field can point to several records, e.g. partner_ids instead of partners_ids, is made on the basis that this double plural adds nothing in terms of readability.

This PR advocates for the contrary: that plurals should be used for the base name when naming relational variables capable of referencing several records, for two reasons:

1. Automatic string generation: The method _setup_attrs__() of the class Field automatically sets up a string if the attribute's string is missing from the definition of a field by removing its suffix. Forcing a One2many or Many2many field to be named in singular forces the user to redefine each time the string. For example, instead of writing:

      partners_ids = fields.One2many('res.partner')

   it has to be written as:

      partner_ids = fields.One2many('res.partner', string='Partners')

   for the UI to show 'Partners' instead of 'Partner'. You can't leverage _setup_attrs__() if you name the One2many or Many2many variables in singular, and this makes the definition of the fields cluttered.

2. Semantic alignment with Python variables. When a developer retrieves the contents of a relational field, the variable name is in plural (as it should be):

      partners = record.partner_ids

   with the proposed convention, the field's name and its retriever variable align:

      partners = record.partners_ids

   making the naming conventions more consistent.