### PR TITLE
[IMP] skip toctree in check_early_line_breaks

### DIFF
--- a/tests/checkers/rst_style.py
+++ b/tests/checkers/rst_style.py
@@ -17,6 +17,7 @@ FORBIDDEN_HEADING_DELIMITER_RE = re.compile(
 )
 GIT_CONFLICT_MARKERS = ['<' * 7, '>' * 7]
 ALLOWED_EARLY_BREAK_RE = re.compile(r'^\s*(\.\. |:\S+:\s+)', re.IGNORECASE)  # Contains markup.
+TOCTREE_DIRECTIVE_RE = re.compile(r'^\s*\.\.\s+toctree::\s*$', re.IGNORECASE)
 
 
 @sphinxlint.checker('.rst')
@@ -136,8 +137,27 @@ def check_early_line_breaks(file, lines, options=None):
         else:
             return next_line_.split(' ', 1)[0]
 
+    # Skip indented body lines after .. toctree:: (path lists, :maxdepth:, etc.)
+    toctree_skip = set()
+    in_toctree = False
+    for i, line in enumerate(lines):
+        if TOCTREE_DIRECTIVE_RE.match(line):
+            in_toctree = True
+            continue
+        if not in_toctree:
+            continue
+        stripped = line.strip()
+        if stripped == '':
+            continue
+        if line.startswith(' ') or line.startswith('\t'):
+            toctree_skip.add(i)
+        else:
+            in_toctree = False
+
     for lno, line in enumerate(lines):
         if lno + 1 < len(lines):
+            if lno in toctree_skip or (lno + 1) in toctree_skip:
+                continue
             next_line = lines[lno + 1]
             if (
                 is_valid_line(line, ('+', '| '))


### PR DESCRIPTION
Task: https://www.odoo.com/odoo/project/3835/tasks/6065752

**Issue:** 
Make review is showing early line break errors within toctrees:
<img width="875" height="754" alt="image" src="https://github.com/user-attachments/assets/a7e6de4f-19b4-4c18-97aa-b6f3d674538f" />


**Solution:**
 Update check_early_line_breaks function to skip checking for early returns in a toctree. 

**Testing:**
Run `make review` on a file that has a toctree at the bottom. For example: `content/applications/marketing/events.rst`

Expected output should be `No problems found.`

<img width="617" height="108" alt="image" src="https://github.com/user-attachments/assets/89077d78-90a8-4937-ba48-20170de35468" />


