### PR TITLE
[FIX] payment_methods/terminals/mercado_pago: Correct supported countries

### DIFF
--- a/content/applications/sales/point_of_sale/payment_methods/terminals/mercado_pago.rst
+++ b/content/applications/sales/point_of_sale/payment_methods/terminals/mercado_pago.rst
@@ -6,9 +6,13 @@ Connecting a payment terminal allows you to offer a fluid payment flow to your c
 the work of your cashiers.
 
 .. important::
-   Only **Point Smart** payment terminals in Argentina, Brazil, Chile, Colombia, Mexico, Peru, and
-   Uruguay are supported. They can be purchased on `Mercado Pago's website
-   <https://www.mercadopago.com.mx/herramientas-para-vender/lectores-point>`_.
+   - Odoo is compatible with Point Smart 1 or Point Smart 2 payment terminals, which can be
+     purchased on the Mercado Pago website in `Argentina
+     <https://www.mercadopago.com.ar/herramientas-para-vender/lectores-point>`_, `Brazil
+     <https://www.mercadopago.com.br/ferramentas-para-vender/maquininhas-point>`_, and `Mexico
+     <https://www.mercadopago.com.mx/herramientas-para-vender/lectores-point>`_.
+   - Mercado Pago payment terminals do not require an :doc:`IoT Box </applications/general/iot>` to
+     operate.
 
 .. seealso::
    `Mercado Pago online payments


### PR DESCRIPTION
The documentation for the Mercado Pago terminal is correct from versions `19.0` to `master`.

Still documentation for version `17.0` and `18.0` incorrectly state that the integration works also for Colombia, Peru, Chile and Uruguay, which is misleading clients, generating tickets and causing general confusion.

With this PR, the objective is to change documentation in these versions to match the correct supported countries (only Mexico, Argentina and Brazil).