### PR TITLE
[FIX] Events: update redirect rules for reporting 18.0

### DIFF
--- a/redirects/18.0.txt
+++ b/redirects/18.0.txt
@@ -63,6 +63,10 @@ applications/websites/website/pages/seo.rst applications/websites/website/struct
 applications/websites/ecommerce/products/price_management.rst applications/websites/ecommerce/products/prices.rst
 applications/websites/ecommerce/cart.rst applications/websites/ecommerce/checkout.rst
 
+# applications/marketing/events
+applications/marketing/events/attendees_report.rst applications/marketing/events/event_reporting/attendees_report.rst
+applications/marketing/events/revenues_report.rst applications/marketing/events/event_reporting/revenues_report.rst
+
 # applications/services
 
 applications/services/timesheets/overview/time_off.rst applications/services/timesheets/time_off.rst


### PR DESCRIPTION
Quick update to the redirect rule after moving the `applications/marketing/events/attendees_report.rst` and `applications/marketing/events/revenues_report.rst` into `applications/marketing/event_reporting/`.

FWP up to master.