### PR TITLE
[IMP]  Add tabs nesting check for RST

### DIFF
--- a/tests/checkers/rst_style.py
+++ b/tests/checkers/rst_style.py
@@ -18,6 +18,37 @@ FORBIDDEN_HEADING_DELIMITER_RE = re.compile(
 GIT_CONFLICT_MARKERS = ['<' * 7, '>' * 7]
 ALLOWED_EARLY_BREAK_RE = re.compile(r'^\s*(\.\. |:\S+:\s+)', re.IGNORECASE)  # Contains markup.
 TOCTREE_DIRECTIVE_RE = re.compile(r'^\s*\.\.\s+toctree::\s*$', re.IGNORECASE)
+# sphinx-tabs: tab-like directives must be nested under .. tabs:: (see tests/main.py CUSTOM_RST_DIRECTIVES).
+TABS_DIRECTIVE_RE = re.compile(r'^(\s*)\.\.\s+tabs::\s*')
+TAB_CHILD_DIRECTIVE_RE = re.compile(
+    r'^(\s*)\.\.\s+(tab|group-tab|code-tab)::\s*'
+)
+
+
+@sphinxlint.checker('.rst')
+def check_tabs_directive_nesting(file, lines, options=None):
+    """ Check that .. tab:: / .. group-tab:: / .. code-tab:: are nested under .. tabs::. """
+    tabs_indent_stack = []
+
+    for lno, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        indent_match = re.match(r'^(\s*)', line)
+        indent = len(indent_match.group(1)) if indent_match else 0
+
+        while tabs_indent_stack and indent <= tabs_indent_stack[-1]:
+            tabs_indent_stack.pop()
+
+        if TABS_DIRECTIVE_RE.match(line):
+            tabs_indent_stack.append(indent)
+        elif TAB_CHILD_DIRECTIVE_RE.match(line):
+            if not tabs_indent_stack or indent <= tabs_indent_stack[-1]:
+                yield lno + 1, (
+                    "tab directive must be nested under .. tabs:: (indent it under a parent "
+                    ".. tabs:: block)"
+                )
 
 
 @sphinxlint.checker('.rst')


### PR DESCRIPTION
Task: https://www.odoo.com/odoo/project/3835/tasks/6083413

**Issue:**

Forgetting a parent `.. tab::` in a group of tabs causes make fast issues
<img width="1920" height="1344" alt="image" src="https://github.com/user-attachments/assets/070e0db6-6a2d-48d9-b082-0399d59a3c11" />

**Solution:**
Add checker to detect incorrect nesting in tabs

**Testing:**
Edit an RST file with tabs example: content/applications/marketing/events/event_reporting/attendees_report.rst and delete `.. tabs::` on line 22

Run `make fast` and reproduce errors

Run `make review` on content/applications/marketing/events/event_reporting/attendees_report.rst 

Expected output should be:
```
Enter relative content path: content/applications/marketing/events/event_reporting/attendees_report.rst 
Enter max line length (default: 100): 
content/applications/marketing/events/event_reporting/attendees_report.rst:24: tab directive must be nested under .. tabs:: (indent it under a parent .. tabs:: block) (tabs-directive-nesting)
content/applications/marketing/events/event_reporting/attendees_report.rst:42: tab directive must be nested under .. tabs:: (indent it under a parent .. tabs:: block) (tabs-directive-nesting)
content/applications/marketing/events/event_reporting/attendees_report.rst:58: tab directive must be nested under .. tabs:: (indent it under a parent .. tabs:: block) (tabs-directive-nesting)
content/applications/marketing/events/event_reporting/attendees_report.rst:78: tab directive must be nested under .. tabs:: (indent it under a parent .. tabs:: block) (tabs-directive-nesting)
content/applications/marketing/events/event_reporting/attendees_report.rst:94: tab directive must be nested under .. tabs:: (indent it under a parent .. tabs:: block) (tabs-directive-nesting)
make: *** [review] Error 1
```

Re-add parent `.. tab::` and run make review. Expected output should be: `No problems found.`

