### PR TITLE
[IMP] Discuss,Livechat: update canned response label used in composer actions

### DIFF
--- a/content/applications/productivity/discuss/canned_responses.rst
+++ b/content/applications/productivity/discuss/canned_responses.rst
@@ -104,7 +104,7 @@ Use a canned response
 =====================
 
 To use a canned response in a conversation, click the :icon:`fa-plus-circle` :guilabel:`(plus)` icon
-in the message window. Then, click :guilabel:`Insert a Canned Response`. This opens a list of
+in the message window. Then, click :guilabel:`Insert Canned Response`. This opens a list of
 available canned responses. Either select a response from the list, or type the appropriate
 shortcut, then click the :icon:`fa-paper-plane` :guilabel:`(send)` icon or hit :kbd:`Enter`.
 

--- a/content/applications/websites/livechat/responses.rst
+++ b/content/applications/websites/livechat/responses.rst
@@ -178,7 +178,7 @@ Use canned responses in a live chat conversation
 ------------------------------------------------
 
 To use a canned response in a conversation, click the :icon:`fa-plus-circle` :guilabel:`(plus)` icon
-in the message window. Then, click :guilabel:`Insert a Canned Response`. This opens a list of
+in the message window. Then, click :guilabel:`Insert Canned Response`. This opens a list of
 available canned responses. Either select a response from the list, or type the appropriate
 shortcut, then click the :icon:`fa-paper-plane` :guilabel:`(send)` icon or hit :kbd:`Enter`.
 


### PR DESCRIPTION
Previously, the documentation referred to the composer action as
`Insert a Canned Response`.

Now, the label has been updated to `Insert Canned Response` to match
the current UI.

See: https://github.com/odoo/odoo/pull/260137

task-[6051094](https://www.odoo.com/odoo/project/1519/tasks/6051094)