### PR TITLE
[FIX] phone: didww credentials correction

### DIFF
--- a/content/applications/productivity/phone/didww.rst
+++ b/content/applications/productivity/phone/didww.rst
@@ -102,10 +102,10 @@ app --> Users & Companies --> Users` select the user, and click the **VoIP** tab
 
 Add the following credentials for the user:
 
-- :guilabel:`Username`: the user's DIDWW username.
-- :guilabel:`Secret`: the user's password.
+- :guilabel:`Username`: the user's SIP username.
+- :guilabel:`Secret`: the user's SIP password.
 
-Once the DIDWW credentials have been saved, the user can make calls with Odoo **Phone** by clicking
+Once the SIP credentials have been saved, the user can make calls with Odoo **Phone** by clicking
 the :icon:`oi-voip` :guilabel:`(Show Softphone)` icon in the top-right corner of Odoo.
 
 .. seealso::


### PR DESCRIPTION
documentation task card: https://www.odoo.com/odoo/project.task/6129844

FIX: correct section at end of page to say "SIP credentials" instead of "DIDWW credentials"

This 19.0 PR can be FWP up to master.