### PR TITLE
[IMP] Time Off - Incorrect example for public holiday included

### DIFF
--- a/content/applications/hr/time_off.rst
+++ b/content/applications/hr/time_off.rst
@@ -153,19 +153,18 @@ off is visible to other users, and how the time off affects the **Payroll** app.
      request would be for three hours, since the two extra worked hours are used first, and deducted
      from the request.
 
-- :guilabel:`Public Holiday Included`: Enable this option if public holidays should be included in
-  time off requests.
+- :guilabel:`Public Holiday Included`: Enable this option if employees must use their own time off
+  balance for public holidays included in a time off request.
 
   .. example::
-     An employee in the United States requests time off for the week of July 4th, for a total of
-     five days. Since the 4th of July is a holiday in the United States, the time off request is
-     automatically modified to use four vacation days and one public holiday, instead of five
-     vacation days. That is because the holiday is included, and the user does not need to use their
-     own vacation time for a public holiday.
+     The 4th of July is a public holiday in the United States. An employee requests time off for the
+     full business week, including July 4th.
 
-     This option reduces extra work for users, enabling them to make only one time off request for
-     the entire week, instead of making two separate requests, one for the days *before* the
-     holiday, and another one for the days *after* the holiday.
+     - If :guilabel:`Public Holiday Included` is enabled, the public holiday is *included* in the
+       employee's time off request. The employee uses five vacation days.
+
+     - If :guilabel:`Public Holiday Included` is disabled, the public holiday is *not* included in
+       the employee's time off request. The employee only uses four vacation days.
 
 - :guilabel:`Allow To Attach Supporting Document`: Enable this option to allow the employee to
   attach documents to the time off request. This is useful in situations where documentation is

--- a/content/applications/hr/time_off.rst
+++ b/content/applications/hr/time_off.rst
@@ -153,19 +153,19 @@ off is visible to other users, and how the time off affects the **Payroll** app.
      request would be for three hours, since the two extra worked hours are used first, and deducted
      from the request.
 
-- :guilabel:`Public Holiday Included`: Enable this option if public holidays should be included in
-  time off requests.
+- :guilabel:`Public Holiday Included`: Enable this option if public holidays should be *included* in
+  time off requests, meaning the employee must use their own time off for a public holiday when a
+  request overlaps.
 
   .. example::
-     An employee in the United States requests time off for the week of July 4th, for a total of
-     five days. Since the 4th of July is a holiday in the United States, the time off request is
-     automatically modified to use four vacation days and one public holiday, instead of five
-     vacation days. That is because the holiday is included, and the user does not need to use their
-     own vacation time for a public holiday.
+     The 4th of July is a public holiday in the United States. An employee creates a time off
+     request for the week of July 4th, totaling five days.
 
-     This option reduces extra work for users, enabling them to make only one time off request for
-     the entire week, instead of making two separate requests, one for the days *before* the
-     holiday, and another one for the days *after* the holiday.
+     When :guilabel:`Public Holiday Included` is active, the request is for the full five days
+     instead of four, because the holiday is *included* in the request. If :guilabel:`Public Holiday
+     Included` is *not* active, the request is modified to only four days, because the public
+     holiday is *excluded* when calculating the time off request, and doesn't use their employee's
+     vacation time.
 
 - :guilabel:`Allow To Attach Supporting Document`: Enable this option to allow the employee to
   attach documents to the time off request. This is useful in situations where documentation is


### PR DESCRIPTION
CLCAR discovered an incorrect/inconsistent definition for time off setting - 'Include Public Holiday'. Example and definition have been updated.  Wording for versions 19 and up changed, so this is a PR for version 18 ONLY.

Original [task card](https://www.odoo.com/odoo/project.task/6075670) for this request