### PR TITLE
[IMP] sale_renting: update Gantt documentation

### DIFF
--- a/content/developer/reference/user_interface/view_architectures.rst
+++ b/content/developer/reference/user_interface/view_architectures.rst
@@ -4079,12 +4079,6 @@ take the following attributes:
   name of a field to group tasks by
 ``disable_drag_drop``
   if set to true, the gantt view will not have any drag&drop support
-``consolidation``
-  field name to display consolidation value in record cell
-``consolidation_max``
-  dictionary with the "group by" field as key and the maximum consolidation
-  value that can be reached before displaying the cell in red
-  (e.g. ``{"user_id": 100}``)
 ``consolidation_exclude``
   name of the field that describes if the task has to be excluded
   from the consolidation


### PR DESCRIPTION
- Remove consolidation and consolidation_max attributes as they are no longer used in gantt schedule view

task-6031386

For enterprise PR see: 
https://github.com/odoo/enterprise/pull/112363