### PR TITLE
[REM] accounting: remove bank rec tolerance

### DIFF
--- a/content/applications/finance/accounting/bank/reconciliation.rst
+++ b/content/applications/finance/accounting/bank/reconciliation.rst
@@ -126,9 +126,6 @@ sequential order to identify and apply a match:
 
 - Exact match
 - Discounted match: for payment terms with discounts for early payments
-- Tolerance match: within 3% to account for merchant fees, rounding differences, and user errors
-- Currency match: when the transaction is in a different currency than the invoice, bill, or
-  payment (with a 3% tolerance for exchange rate differences)
 - Amount in label: if the invoice :guilabel:`Amount` is found in the transaction's
   :guilabel:`Label`
 


### PR DESCRIPTION
taskid-6005605

FP rolled back the RD task adding a tolerance setting so we'll just remove any mention of a general tolerance and the currency exchange tolerance (OLMA confirmed that it's currently 0% but it will be updated to be 3% in [this task](https://www.odoo.com/odoo/project/967/tasks/6143815)) then we'll update the doc when the RD task is deployed.