### PR TITLE
[FIX] howtos/website_themes: Typo (Python Model link)

### DIFF
--- a/content/developer/howtos/website_themes/layout.rst
+++ b/content/developer/howtos/website_themes/layout.rst
@@ -284,7 +284,7 @@ First, create a record to declare the field. This field has to be linked to an e
       <field name="model_id" ref="website_blog.model_blog_post"/>
    </record>
 
-.. note:: Fields creation is also possible (and recommended) through `a model using Python </developer/tutorials/backend>`_.
+.. note:: Fields creation is also possible (and recommended) through `a model using Python <../../tutorials/getting_started/04_basicmodel.html#model-fields>`_.
 
 .. _website_themes/layout/custom_fields/backend :
 


### PR DESCRIPTION
This PR fixes a broken link into the layout page (Python Model).

Task-6197487