### PR TITLE
[IMP] odoo_theme: add rotation classes

### DIFF
--- a/extensions/odoo_theme/static/scss/_font_awesome.scss
+++ b/extensions/odoo_theme/static/scss/_font_awesome.scss
@@ -82,27 +82,17 @@
     transform: rotate(359deg);
   }
 }
-.fa-rotate-90 {
-  transform: rotate(90deg);
-}
-.fa-rotate-180 {
-  transform: rotate(180deg);
-}
-.fa-rotate-270 {
-  transform: rotate(270deg);
+/* Generate rotation classes from 0 to 360 degrees in 5 degree increments */
+@for $i from 0 through 72 {
+  .fa-rotate-#{$i * 5} {
+    transform: rotate(#{$i * 5}deg);
+  }
 }
 .fa-flip-horizontal {
   transform: scale(-1, 1);
 }
 .fa-flip-vertical {
   transform: scale(1, -1);
-}
-:root .fa-rotate-90,
-:root .fa-rotate-180,
-:root .fa-rotate-270,
-:root .fa-flip-horizontal,
-:root .fa-flip-vertical {
-  filter: none;
 }
 .fa-stack {
   position: relative;


### PR DESCRIPTION
For 19.0 and up there is a need to adjust the rotation of the font awesome icons (specifically fa-phone) to match the ui in the Odoo phone app. 

Rather than creating a one off class for the phone icon, I used a sass loop to generate rotation classes in 5 degree increments so future icon adjustments can happen easily. 

Also removed some old CSS that was for internet explorer 9 with rotation issues. 

<img width="1705" height="1042" alt="image" src="https://github.com/user-attachments/assets/39b44197-177f-4874-92ad-c03a67b7e8f7" />
