### PR TITLE
[IMP] ai: add documentation about pgvector

### DIFF
--- a/content/administration/on_premise/source.rst
+++ b/content/administration/on_premise/source.rst
@@ -264,6 +264,127 @@ PostgreSQL user.
          Because the PostgreSQL user has the same name as the Unix login, it is possible to connect
          to the database without a password.
 
+.. note::
+   If you want to use **Odoo's AI features**, the `pg-vector` PostgreSQL extension is required.
+
+   Note that `pg-vector` is available only for PostgreSQL version 15 and up.
+
+   .. tabs::
+
+      .. group-tab:: Linux
+
+         #. Navigate to your temporary folder
+
+            .. code-block:: console
+
+               $ cd /tmp
+
+         #. Clone the `pg-vector` `GitHub repository <https://github.com/pgvector/pgvector>`_:
+
+            .. code-block:: console
+
+               $ git clone https://github.com/pgvector/pgvector.git
+
+         #. Navigate into the directory:
+
+            .. code-block:: console
+
+               $ cd pgvector
+
+         #. Compile the extension:
+
+            .. code-block:: console
+
+               $ make
+
+         #. Install the extension:
+
+            .. code-block:: console
+
+               $ sudo make install
+
+         If you run into any issues during installation, make sure to check the official
+         `installation notes <https://github.com/pgvector/pgvector#installation-notes---linux-and-mac>`__.
+
+      .. group-tab:: Mac OS
+
+         #. Navigate to your temporary folder
+
+            .. code-block:: console
+
+               $ cd /tmp
+
+         #. Clone the `pg-vector` `GitHub repository <https://github.com/pgvector/pgvector>`_:
+
+            .. code-block:: console
+
+               $ git clone https://github.com/pgvector/pgvector.git
+
+         #. Navigate into the directory:
+
+            .. code-block:: console
+
+               $ cd pgvector
+
+         #. Compile the extension:
+
+            .. code-block:: console
+
+               $ make
+
+         #. Install the extension:
+
+            .. code-block:: console
+
+               $ sudo make install
+
+         If you run into any issues during installation, make sure to check the official
+         `installation notes <https://github.com/pgvector/pgvector#installation-notes---linux-and-mac>`__.
+
+      .. group-tab:: Windows
+
+         #. Navigate to your temporary folder
+
+            .. code-block:: console
+
+               $ cd %TEMP%
+
+         #. Clone the `pg-vector` `GitHub repository <https://github.com/pgvector/pgvector>`_:
+
+            .. code-block:: console
+
+               $ git clone https://github.com/pgvector/pgvector.git
+
+         #. Navigate into the directory:
+
+            .. code-block:: console
+
+               $ cd pgvector
+
+         #. Ensure C++ support in Visual Studio is installed and run `x64 Native Tools
+            Command Prompt for VS [version]` as administrator.
+
+         #. Set your `PGROOT` environment variable:
+
+            .. code-block:: console
+
+               $ set "PGROOT=C:\Program Files\PostgreSQL\[Your PostgreSQL Version]"
+
+         #. Compile the extension:
+
+            .. code-block:: console
+
+               $ nmake /F Makefile.win
+
+         #. Install the extension:
+
+            .. code-block:: console
+
+               $ nmake /F Makefile.win install
+
+         If you run into any issues during installation, make sure to check the official
+         `installation notes <https://github.com/pgvector/pgvector#installation-notes---windows>`__.
+
 .. _install/dependencies:
 
 Dependencies


### PR DESCRIPTION
The PostgreSQL extention `pgvector` is required in order for users to use the AI features when they are self hosting Odoo. The documentation did not mention `pgvector` at all though,

In this commit we add some installation instructions for pgvector.

Issue-17800