### PR TITLE
[IMP] Marketing: Reorder master pages in TOC

### DIFF
--- a/content/applications/marketing.rst
+++ b/content/applications/marketing.rst
@@ -8,9 +8,9 @@ Marketing
 .. toctree::
 
    marketing/email_marketing
-   marketing/marketing_automation
    marketing/sms_marketing
+   marketing/social_marketing
+   marketing/marketing_automation
    marketing/events
    marketing/marketing_card
    marketing/surveys
-   marketing/social_marketing


### PR DESCRIPTION
This PR reorganizes the master pages in the Marketing TOC for better navigation. No content has been added. Only the ordering of the pages has been changed.

As discussed with @larm-odoo, this is only an initial step leading up to a more substantial restructuring of the Marketing section as a whole. Beyond just reordering the pages in the TOC, more work is planned to identify overlapping functional/conceptual areas or broader user workflows around which to reorganize/revise topic pages.

**Changelog**
- 'Email Marketing', 'SMS Marketing', and 'Social Marketing' grouped together for conceptual similarity as different *forms* of marketing campaigns, followed by 'Marketing Automation' as a workflow orchestrator
- 'Events', followed by 'Marketing Card' bc of its integration with events
- 'Surveys' last

**Version Scope**
This 18.0 PR should be FWP to master. A separate 17.0 PR may be created separately due to differences in existing structure.