### PR TITLE
[FIX] administration/deploy: invalid nginx docs links

### DIFF
--- a/content/administration/on_premise/deploy.rst
+++ b/content/administration/on_premise/deploy.rst
@@ -517,10 +517,9 @@ not.
 Nevertheless, once the file has been located and the access rights verified by Odoo, it is a good
 idea to serve the file using the static web server instead of Odoo. For Odoo to delegate serving
 files to the static web server, the `X-Sendfile <https://tn123.org/mod_xsendfile/>`_ (apache) or
-`X-Accel <https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/>`_ (nginx) extensions
-must be enabled and configured on the static web server. Once it is set up, start Odoo with the
-:option:`--x-sendfile <odoo-bin --x-sendfile>` CLI flag (this unique flag is used for both
-X-Sendfile and X-Accel).
+X-Accel (nginx) extensions must be enabled and configured on the static web server. Once it is set
+up, start Odoo with the :option:`--x-sendfile <odoo-bin --x-sendfile>` CLI flag (this unique flag is
+used for both X-Sendfile and X-Accel).
 
 
 .. note::
@@ -908,9 +907,9 @@ Odoo supports the latest version of the following browsers.
 .. _CSRF: https://en.wikipedia.org/wiki/Cross-site_request_forgery
 .. _ARP spoofing: https://en.wikipedia.org/wiki/ARP_spoofing
 .. _Nginx termination example:
-    https://nginx.com/resources/admin-guide/nginx-ssl-termination/
+    https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/
 .. _Nginx proxying example:
-    https://nginx.com/resources/admin-guide/reverse-proxy/
+    https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/
 .. _socat: http://www.dest-unreach.org/socat/
 .. _PostgreSQL connection settings:
 .. _listen to network interfaces:


### PR DESCRIPTION
Some links to the nginx documentation aren't working anymore and redirect to the main commercial entity owning nginx.

Nginx doc is now hosted under https://docs.nginx.com, and the links are now adapted accordingly.