### PR TITLE
[FIX] developer/tutorials: Button example without deprecated attrs

### DIFF
--- a/content/developer/tutorials/server_framework_101/09_actions.rst
+++ b/content/developer/tutorials/server_framework_101/09_actions.rst
@@ -1,6 +1,6 @@
-==================================
+=================================
 Chapter 9: Ready For Some Action?
-==================================
+=================================
 
 So far we have mostly built our module by declaring fields and views. We just introduced business
 logic in the :doc:`previous chapter <08_compute_onchange>` thanks to
@@ -93,7 +93,7 @@ Finally, a public method should always return something so that it can be called
 When in doubt, just ``return True``.
 
 There are hundreds of examples in the Odoo source code. One example is this
-`button in a view <https://github.com/odoo/odoo/blob/cd9af815ba591935cda367d33a1d090f248dd18d/addons/crm/views/crm_lead_views.xml#L9-L11>`__
+`button in a view <https://github.com/odoo/odoo/blob/55cccddeb12a2096730e4fadc84c52fa838b1aec/addons/crm/views/crm_lead_views.xml#L9-L11>`__
 and its
 `corresponding Python method <https://github.com/odoo/odoo/blob/cd9af815ba591935cda367d33a1d090f248dd18d/addons/crm/models/crm_lead.py#L746-L760>`__
 


### PR DESCRIPTION
Using attrs to make a button invisible is deprecated since 17.0 but the button example hyperlink sends to a commit that used it so it induces people following the tutorial to use attrs which shouldn't be done anymore.

This commit replaces the link with the commit that replaced the `attrs=""` to the plain `invisible=""` use on the exact same button. (And adjusts the size of the delimiter to respect documentation guidelines.)