### PR TITLE
[IMP] marketing/events: add Badge Printer note

### DIFF
--- a/content/applications/marketing/events/event_setup/create_events.rst
+++ b/content/applications/marketing/events/event_setup/create_events.rst
@@ -109,6 +109,11 @@ Optionally, to create event badges for attendees, fill in the following fields:
 - :guilabel:`Badge Background`: The custom background image for the badges. Click the
   :guilabel:`Upload your file` button to upload an image.
 
+.. note::
+   If you have the :doc:`IoT<../../../general/iot>` module installed, you will also see the option
+   :guilabel:`96x82mm (Badge Printer)`. This badge format requires an EPSON ColorWorks printer
+   linked to an IoT Box, and is designed for Nakagawa 96x82mm butterfly-style badge paper.
+
 Additional event configurations
 ===============================
 


### PR DESCRIPTION
This commit adds a mention of the badge paper format that becomes available in the Events app if the IoT module is installed.

task-4229115