### PR TITLE
[IMP] web: document show_week_numbers option for datetime widget

### DIFF
--- a/content/developer/reference/frontend/javascript_reference.rst
+++ b/content/developer/reference/frontend/javascript_reference.rst
@@ -777,6 +777,13 @@ Date & Time (`datetime`)
 
             <field name="datetimefield" widget="datetime" options="{'show_time': false}" />
 
+    - `show_week_numbers`: when set to false, it hides the week number column from the
+      date picker calendar (default: `true`).
+
+        .. code-block:: xml
+
+            <field name="datetimefield" widget="datetime" options="{'show_week_numbers': false}" />
+
     - `show_date`: when set to false, it hides the date part from the datetime field.
       The field will still accept datetime values, but the date part will be hidden in
       the UI (default: `true`).


### PR DESCRIPTION
This commit adds the documentation of the newly introduced 
show_week_numbers option for datetime widget [1].

[1] https://github.com/odoo/odoo/pull/261566

task-5149047