### PR TITLE
[FIX] Events: update to multi-slots cross-ref link

### DIFF
--- a/content/applications/marketing/events/attendee_experience/multi_slots.rst
+++ b/content/applications/marketing/events/attendee_experience/multi_slots.rst
@@ -118,8 +118,8 @@ Deleting and editing slots
 Registering for slots as an attendee
 ====================================
 
-The process of registering for a slot as an attendee is similar to :doc:`registering for regular
-events <../promote_monetize/sell_tickets>` via the *Website* app.
+The process of registering for a slot as an attendee is similar to :ref:`registering for regular
+events <events/sell-tickets/website>` via the **Website** app.
 
 To register, visitors on the website navigate to the desired event. Next, they click the
 :guilabel:`Register` button to open a :guilabel:`Slots` pop-up window. Then, they select their


### PR DESCRIPTION
Follow-up to [this PR](https://github.com/odoo/documentation/pull/18050#event-25823135857). Update an RST cross-reference link in the Events 'Multi-slots' page to open the correct section.

**Changelog**
- Quick change to link in 'Multi-slots' doc
- Minor correction: bold app name

**Version Scope**
This 19.0 PR should be FWP up to master.