### PR TITLE
[FIX] Update the first tip in Keyboard Shortcut to include Alt key

### DIFF
--- a/content/applications/essentials/keyboard_shortcuts.rst
+++ b/content/applications/essentials/keyboard_shortcuts.rst
@@ -6,7 +6,7 @@ Users in Odoo can utilize several keyboard shortcuts to navigate through modules
 and manage data.
 
 .. tip::
-   Hold :kbd:`Ctrl` to view the keyboard shortcuts assigned to each element on the interface.
+   Hold :kbd:`Ctrl` or :kbd:`Alt` to view the keyboard shortcuts assigned to each element on the interface.
 
    .. image:: keyboard_shortcuts/menu-shortcuts.png
       :align: center


### PR DESCRIPTION
Windows/Linux hold the Alt key to view the keyboard shortcuts assigned to each element on the interface