### PR TITLE
[FIX] general integrations: gmail plugin article typo fix

### DIFF
--- a/content/applications/general/integrations/mail_plugins/gmail.rst
+++ b/content/applications/general/integrations/mail_plugins/gmail.rst
@@ -59,10 +59,11 @@ the plugin.
 Connect an Odoo database
 ========================
 
-To open the plugin, on the Odoo icon in the right-hand side panel. The plugin panel opens between
-the inbox and the right-hand side panel. Click :guilabel:`Login`. Enter the Odoo database URL and
-click :guilabel:`Login`, or click :guilabel:`Sign Up` to create an Odoo account, and a pop-up window
-opens. Click :guilabel:`Allow` in the pop-up window to let the Gmail plugin connect to the database.
+To open the plugin, click on the Odoo icon in the right-hand side panel. The plugin panel opens
+between the inbox and the right-hand side panel. Click :guilabel:`Login`. Enter the Odoo database
+URL and click :guilabel:`Login`, or click :guilabel:`Sign Up` to create an Odoo account, and a
+pop-up window opens. Click :guilabel:`Allow` in the pop-up window to let the Gmail plugin connect to
+the database.
 
 .. note::
    Use the general URL for the database, not the URL of a specific page in the database. For


### PR DESCRIPTION
quick fix to add a missing word, i.e. "click" in the first sentence of the _Connect an Odoo database_ section:
> To open the plugin, \<click\> on the Odoo icon in the right-hand side panel. 

thank you @jero-odoo for pointing this out!

This saas-19.2 PR can be FWP up to master.