### PR TITLE
[IMP] payment_asiapay: fix typo in docs

### DIFF
--- a/content/applications/finance/payment_providers/asiapay.rst
+++ b/content/applications/finance/payment_providers/asiapay.rst
@@ -21,9 +21,9 @@ Configuration on AsiaPay Dashboard
 #. Go to :menuselection:`Profile --> Account Information`. Copy the values of the
    :guilabel:`Currency` and :guilabel:`Secure Hash` fields and save them for later.
 #. | Go to :menuselection:`Profile --> Payment Account Settings` and enable the option
-     :guilabel:`Return Value Link (Datefeed)`;
+     :guilabel:`Return Value Link (Datafeed)`;
    | Enter your Odoo database URL followed by `/payment/asiapay/webhook` in the
-     :guilabel:`Return Value Link (Datefeed)` text field. For example:
+     :guilabel:`Return Value Link (Datafeed)` text field. For example:
      `https://yourcompany.odoo.com/payment/asiapay/webhook`;
    | Click on :guilabel:`Test` to check if the webhook is working correctly.
 #. Click on :guilabel:`Update` to finalize the configuration.


### PR DESCRIPTION
The setting in AsiaPay is "datafeed" not "datefeed".
Simple typo replacement fix.

<img width="1284" height="488" alt="image" src="https://github.com/user-attachments/assets/c371198e-717d-48eb-a39d-e24dd317bde8" />
