### PR TITLE
Fix SQL constraint example

### DIFF
--- a/content/developer/tutorials/server_framework_101/10_constraints.rst
+++ b/content/developer/tutorials/server_framework_101/10_constraints.rst
@@ -40,8 +40,8 @@ Simple example:
 .. code-block:: python
 
     _check_percentage = models.Constraint(
-        'CHECK(percentage >= 0 AND percentage <= 100)',
-        'The percentage of an analytic distribution should be between 0 and 100.',
+        'CHECK(percentage >= 0 AND percentage <= 1)',
+        'The percentage of an analytic distribution should be between 0 and 100%.',
     )
 
 .. exercise:: Add SQL constraints.


### PR DESCRIPTION
The example SQL constraint is wrong. 100% corresponds to the float value 1. So to ensure that the value is between 0 and 100%, you need to check that the float is between 0 and 1