### PR TITLE
[IMP] accounting: snailmail page limit

### DIFF
--- a/content/applications/finance/accounting/customer_invoices/snailmail.rst
+++ b/content/applications/finance/accounting/customer_invoices/snailmail.rst
@@ -40,6 +40,7 @@ your customer’s address is set correctly, including the country, before sendin
      <snailmail/snailmail-template.pdf>` for more details).
    - Pingen (Odoo Snailmail service provider) scans the area to process the address, so if something
      gets written outside the area, it is not counted as part of the address.
+   - The document must not contain more than 8 physical pages.
 
 Pricing
 =======


### PR DESCRIPTION
Currently we only allow sending documents that are a maximum of 8 physical pages (regardless of the limits set by the snailmail provider / Pingen).

Every now and then we get tickets because of that.

To avoid confusion due to the page limits given in the "Pingen's layout requirements" linked below we add a line stating the current limits.

The limit has been in place for 4 years and is unlikely to be (just) increased since we charge the same number of credits per document while Pingen charges dependent on the length of the document.

opw-6200661