### PR TITLE
[IMP] developer/backend: switch Warning to UserError

### DIFF
--- a/content/developer/reference/backend/actions.rst
+++ b/content/developer/reference/backend/actions.rst
@@ -329,7 +329,7 @@ server actions:
 * ``env`` Odoo Environment
 * ``datetime``, ``dateutil``, ``time``, ``timezone`` corresponding Python modules
 * ``log: log(message, level='info')`` logging function to record debug information in ir.logging table
-* ``Warning`` constructor for the ``Warning`` exception
+* ``UserError`` constructor for the ``UserError`` exception
 
 .. _reference/actions/report:
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/98138, Warning has been removed from the action's evaluation context, UserError is used instead