### PR TITLE
[IMP] Sales: Added 'product catalog' link to page

### DIFF
--- a/content/applications/sales/sales/sales_quotations/create_quotations.rst
+++ b/content/applications/sales/sales/sales_quotations/create_quotations.rst
@@ -164,6 +164,7 @@ shipping`.
    - :doc:`../products_prices/ewallets_giftcards`
    - :doc:`../products_prices/loyalty_discount`
    - :doc:`../products_prices/prices/pricing`
+   - :doc:`../../../essentials/product_catalog`
 
 Optional Products tab
 ---------------------


### PR DESCRIPTION
This 1-pt PR adds a new doc link to the "Create quotation" subheading of the "Create quotations" page and points towards the newly created "Product catalog" page in the Essentials section. There are no other changes to the page.

This 18.0 PR can be FWP up to master.