### PR TITLE
[REM] accounting: remove tax scope

### DIFF
--- a/content/applications/finance/accounting/taxes.rst
+++ b/content/applications/finance/accounting/taxes.rst
@@ -276,12 +276,6 @@ The :guilabel:`Tax Type` determines the tax application, which also restricts wh
    You can use :guilabel:`None` for taxes that you want to include in a :ref:`Group of Taxes
    <taxes/computation>` but that you do not want to list along with other sales or purchase taxes.
 
-Tax scope
-~~~~~~~~~
-
-The :guilabel:`Tax Scope` restricts the use of taxes to a type of product, either **goods** or
-**services**.
-
 .. _taxes/definition-tab:
 
 Definition tab


### PR DESCRIPTION
The Tax Scope (goods vs services) feature apparently does not have any effect. POs will discuss if the feature itself should change or be removed entirely.

To be merged up to 17.4. 18.0 and above will be handled in a separate PR.