### PR TITLE
[IMP] howtos/website_themes: Bundles description + header/footer templates

### DIFF
--- a/content/developer/howtos/website_themes/layout.rst
+++ b/content/developer/howtos/website_themes/layout.rst
@@ -432,7 +432,7 @@ Enable one of the header default templates.
             <field name="active" eval="False" />
          </record>
 
-Explicitly set the desired template in the `primary_variables.scss` file.
+Explicitly set the desired template in the :file:`primary_variables.scss` file.
 
 .. code-block:: scss
    :caption: ``/website_airproof/static/src/scss/primary_variables.scss``
@@ -510,14 +510,14 @@ Use the following code to add an option for your new custom header on the Websit
    * - views
      - The template(s) to enable
    * - vars
-     - The name given to the variable (same as used into `primary_variables.scss`)
+     - The name given to the variable (same as used into :file:`primary_variables.scss`)
    * - checkVars
      - Determine if `vars` are compared to set the option status.
    * - src (in `Img`)
      - The thumbnail of the custom template shown in the templates selection on the Website Builder
 
-Now you have to explicitly define that you want to use your custom template in the Odoo SASS
-variables.
+Now add this file to your :file:`__manifest__.py` in the bundle `website.website_builder_assets` and
+define explicitly the custom template as the header template in the Odoo SASS variables.
 
 .. code-block:: scss
    :caption: ``/website_airproof/static/src/scss/primary_variables.scss``
@@ -739,9 +739,11 @@ active footer template first.
    * - view
      - Template that is enabled.
    * - varName
-     - Value used in `primary_variables.scss` under `footer-template`.
+     - Value used in :file:`primary_variables.scss` under `footer-template`.
    * - imgSrc
      - The thumbnail of the custom template shown in the templates selection on the Website Builder
+
+Add it to your :file:`__manifest__.py` in the bundle `website.website_builder_assets`.
 
 **Declaration**
 

--- a/content/developer/howtos/website_themes/theming.rst
+++ b/content/developer/howtos/website_themes/theming.rst
@@ -879,8 +879,8 @@ This is a non-exhaustive list of the frequently used bundles for a website:
    * - web.assets_frontend
      - Provides the base assets required to render and interact with Odoo's frontend. You can add
        all your custom SCSS, JS or client-side QWeb templates.
-   * - website.assets_wysiwyg
-     - Provides the assets loaded into the web editor context, including edit-mode styles, custom
+   * - website.website_builder_assets
+     - Provides the assets loaded into the Website Builder context, including edit-mode styles, custom
        method for a custom building block, etc).
    * - web._assets_bootstrap
      - If you need to extend Boostrap through the Bootstrap Utilities API, for example


### PR DESCRIPTION
This commits pursues #18556 and refines the description of the `website.website_builder_assets` bundle.

It also adds explicit information about the bundle within which the header/footer template option has to be loaded.

Task-6316683