### PR TITLE
[IMP] PLM: Add PLM installation instructions

### DIFF
--- a/content/applications/inventory_and_mrp/plm.rst
+++ b/content/applications/inventory_and_mrp/plm.rst
@@ -13,6 +13,20 @@ post-launch support stages.
 
 With approvals, key stakeholders can review changes before implementation.
 
+Install PLM
+===========
+
+Despite being used to iterate on **Manufacturing** bills of materials, **PLM** is **not** installed
+by default when installing the **Manufacturing** app. It must be installed separately to take
+advantage of its benefits.
+
+To install **PLM**, open the :menuselection:`Apps` app. Search for `PLM`, then click
+:guilabel:`Install` on the :guilabel:`Product Lifecycle Management (PLM)` card.
+
+.. note::
+   Adding or removing apps can affect other apps and modify subscription costs. See
+   :doc:`../general/apps_modules` to learn more.
+
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
PLM is not installed by default when the Manufacturing app is installed, despite existing exclusively to interact with the Manufacturing app and bills of materials. I've added instructions for installing it on the app's landing page because it doesn't warrant a separate document.