### PR TITLE
[FIX] avalara: add redirections from old avalara pages

### DIFF
--- a/redirects/saas-19.3.txt
+++ b/redirects/saas-19.3.txt
@@ -1,3 +1,10 @@
 # applications/essentials
 
 applications/inventory_and_mrp/inventory/warehouses_storage/inventory_management/product_catalog.rst applications/essentials/product_catalog.rst # Move the product catalog from Inventory to the Essentials section
+
+# applications/accounting
+
+applications/finance/accounting/taxes/avatax.rst applications/finance/accounting/taxes/avalara.rst
+applications/finance/accounting/taxes/avatax/avalara_included.rst applications/finance/accounting/taxes/avalara.rst
+applications/finance/accounting/taxes/avatax/avatax_use.rst applications/finance/accounting/taxes/avalara/avatax_use.rst
+applications/finance/accounting/taxes/avatax/avatax_portal.rst applications/finance/accounting/taxes/avalara/avalara_portal.rst


### PR DESCRIPTION
The [restructure of avalara PR](https://github.com/odoo/documentation/pull/18465) didn't include redirections. This PR adds them to avoid broken links.