### PR TITLE
[REM] applications: warning about deactivating the admin user

### DIFF
--- a/content/applications/general/users.rst
+++ b/content/applications/general/users.rst
@@ -86,12 +86,6 @@ After selecting the appropriate user to be archived, click the :guilabel:`⚙️
 select :guilabel:`Archive` from the resulting drop-down menu. Then, click :guilabel:`OK` from the
 :guilabel:`Confirmation` pop-up window that appears.
 
-.. danger::
-   **Never** deactivate the main/administrator user (admin). Making changes to admin users can have
-   a detrimental impact on the database. This includes *impotent admin*, which means that no user in
-   the database can make changes to the access rights. For this reason, Odoo recommends contacting
-   an Odoo Business Analyst, or our Support Team, before making changes.
-
 Error: too many users
 ---------------------
 


### PR DESCRIPTION
The warning is redundant because Odoo prevents you from archiving the currently logged in user. The only way you'd be able to remove access from a database by archiving an admin user would be to do so for all admin users as the superuser. The superuser section of the access rights page warns against locking yourself out that way:
https://www.odoo.com/documentation/19.0/applications/general/users/access_rights.html#superuser-mode

It also causes confusion, because Odoo has a default admin user with an id defined in the external reference `base.user_admin`. If code relies on that user being present, it can indeed cause problems when archived. But Odoo should support that use case, and be robust against it. You should be able to archive the default admin user. See the discussion in https://github.com/odoo/odoo/pull/264352 .

If you ask odoo.com/help if you should be able to archive the default admin user, it'll say you should never do that citing this section.

Hence this change removes the section altogether. The main risk for locking yourself out of your database is changing access rights, and the documentation page for that has multiple warnings about it. Unless you are the superuser or use direct SQL, you should not be able to lock all admin users out of the database through archiving in the UI.