### PR TITLE
[IMP] mrp: consolidate 'produce all' button

### DIFF
--- a/content/applications/inventory_and_mrp/manufacturing/basic_setup/mo_costs.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/basic_setup/mo_costs.rst
@@ -166,11 +166,10 @@ used than was listed on the |MO|, the duration of a work order is different than
 hourly cost of the employee performing a work order differs from the employee cost set on the work
 center.
 
-Once the |MO| has been completed by clicking :guilabel:`Produce All`, the values in the
-:guilabel:`MO Cost` column update to match those displayed in the :guilabel:`Real Cost` column.
+Once the |MO| has been completed by clicking :guilabel:`Produce`, the values in the :guilabel:`MO
+Cost` column update to match those displayed in the :guilabel:`Real Cost` column.
 
 .. image:: mo_costs/overview.png
-   :align: center
    :alt: The MO Overview page.
 
 .. _manufacturing/mo-costs/average-manufacturing-cost:

--- a/content/applications/inventory_and_mrp/manufacturing/basic_setup/one_step_manufacturing.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/basic_setup/one_step_manufacturing.rst
@@ -24,7 +24,6 @@ them to and from inventory is not tracked.
    store products (3 steps)`.
 
    .. image:: one_step_manufacturing/manufacturing-type.png
-      :align: center
       :alt: The Manufacture radio input field on a warehouse configuration page.
 
 .. _manufacturing/basic_setup/create-mo:
@@ -67,18 +66,16 @@ that needs to be completed, click the :guilabel:`Start` button for that work ord
 *Manufacturing* then starts a timer that keeps track of how long the work order takes to complete.
 
 .. image:: one_step_manufacturing/start-button.png
-   :align: center
    :alt: The Start button for an operation on a manufacturing order.
 
 When the work order is completed, click the :guilabel:`Done` button for that work order. Repeat the
 same process for each work order listed on the :guilabel:`Work Orders` tab.
 
 .. image:: one_step_manufacturing/done-button.png
-   :align: center
    :alt: The Done button for an operation on a manufacturing order.
 
-After completing all of the work orders, click :guilabel:`Produce All` at the top of the screen to
-mark the |MO| as :guilabel:`Done`, and register the manufactured product(s) into inventory.
+After completing all of the work orders, click :guilabel:`Produce` at the top of the screen to mark
+the |MO| as :guilabel:`Done`, and register the manufactured products into inventory.
 
 Shop Floor workflow
 -------------------
@@ -95,7 +92,6 @@ On the pop-up window, select the :guilabel:`Open Shop Floor` button at the top-l
 open the *Shop Floor* module.
 
 .. image:: one_step_manufacturing/shop-floor-button.png
-   :align: center
    :alt: The Open Shop Floor button for a work order on a manufacturing order.
 
 When accessed directly from a specific work order within an |MO|, *Shop Floor* defaults to the page
@@ -104,7 +100,6 @@ the work order that displays the |MO| number, the product and number of units to
 the steps required to complete the work order.
 
 .. image:: one_step_manufacturing/work-order-card.png
-   :align: center
    :alt: A work order card on a work center page in the Shop Floor module.
 
 A work order is processed by completing each step listed on its card. This can be done by clicking

--- a/content/applications/inventory_and_mrp/manufacturing/basic_setup/three_step_manufacturing.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/basic_setup/three_step_manufacturing.rst
@@ -68,7 +68,6 @@ Finally, return to the |MO| by clicking the :guilabel:`WH/MO/XXXXX` breadcrumb a
 page.
 
 .. image:: three_step_manufacturing/mo-bread-crumb.png
-   :align: center
    :alt: The manufacturing order bread crumb on a pick components transfer.
 
 Process manufacturing order
@@ -88,18 +87,16 @@ that needs to be completed, click the :guilabel:`Start` button for that work ord
 *Manufacturing* then starts a timer that keeps track of how long the work order takes to complete.
 
 .. image:: three_step_manufacturing/start-button-2.png
-   :align: center
    :alt: The Start button for a work order on a manufacturing order.
 
 When the work order is completed, click the :guilabel:`Done` button for that work order. Repeat the
 same process for each work order listed on the :guilabel:`Work Orders` tab.
 
 .. image:: three_step_manufacturing/done-button.png
-   :align: center
    :alt: The Done button for an work order on a manufacturing order.
 
-After completing all of the work orders, click :guilabel:`Produce All` at the top of the screen to
-mark the |MO| as :guilabel:`Done`, and register the manufactured product(s) into inventory.
+After completing all of the work orders, click :guilabel:`Produce` at the top of the screen to mark
+the |MO| as :guilabel:`Done`, and register the manufactured products into inventory.
 
 Shop Floor workflow
 -------------------
@@ -116,7 +113,6 @@ On the pop-up window, select the :guilabel:`Open Shop Floor` button at the top-l
 open the *Shop Floor* module.
 
 .. image:: three_step_manufacturing/shop-floor-button.png
-   :align: center
    :alt: The Open Shop Floor button for a work order on a manufacturing order.
 
 When accessed directly from a specific work order within an |MO|, *Shop Floor* defaults to the page
@@ -125,7 +121,6 @@ the work order that displays the |MO| number, the product and number of units to
 the steps required to complete the work order.
 
 .. image:: three_step_manufacturing/work-order-card.png
-   :align: center
    :alt: A work order card on a work center page in the Shop Floor module.
 
 A work order is processed by completing each step listed on its card. This can be done by clicking

--- a/content/applications/inventory_and_mrp/manufacturing/basic_setup/two_step_manufacturing.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/basic_setup/two_step_manufacturing.rst
@@ -24,7 +24,6 @@ from inventory is not tracked.
    store products (3 steps)`.
 
    .. image:: two_step_manufacturing/manufacturing-type.png
-      :align: center
       :alt: The Manufacture radio input field on a warehouse configuration page.
 
 Create manufacturing order
@@ -65,7 +64,6 @@ Finally, return to the |MO| by clicking the :guilabel:`WH/MO/XXXXX` breadcrumb a
 page.
 
 .. image:: two_step_manufacturing/mo-bread-crumb.png
-   :align: center
    :alt: The manufacturing order bread crumb on a pick components transfer.
 
 Process manufacturing order
@@ -85,18 +83,16 @@ that needs to be completed, click the :guilabel:`Start` button for that operatio
 *Manufacturing* then starts a timer that keeps track of how long the work order takes to complete.
 
 .. image:: two_step_manufacturing/start-button.png
-   :align: center
    :alt: The Start button for an work order on a manufacturing order.
 
 When the work order is completed, click the :guilabel:`Done` button for that work order. Repeat the
 same process for each work order listed on the :guilabel:`Work Orders` tab.
 
 .. image:: two_step_manufacturing/done-button.png
-   :align: center
    :alt: The Done button for a work order on a manufacturing order.
 
-After completing all of the work orders, click :guilabel:`Produce All` at the top of the screen to
-mark the |MO| as :guilabel:`Done`, and register the manufactured product(s) into inventory.
+After completing all of the work orders, click :guilabel:`Produce` at the top of the screen to mark
+the |MO| as :guilabel:`Done`, and register the manufactured products into inventory.
 
 Shop Floor workflow
 -------------------
@@ -113,7 +109,6 @@ On the pop-up window, select the :guilabel:`Open Shop Floor` button at the top-l
 open the *Shop Floor* module.
 
 .. image:: two_step_manufacturing/shop-floor-button.png
-   :align: center
    :alt: The Open Shop Floor button for a work order on a manufacturing order.
 
 When accessed directly from a specific work order within an |MO|, *Shop Floor* defaults to the page
@@ -122,7 +117,6 @@ the work order that displays the |MO| number, the product and number of units to
 the steps required to complete the work order.
 
 .. image:: two_step_manufacturing/work-order-card.png
-   :align: center
    :alt: A work order card on a work center page in the Shop Floor module.
 
 A work order is processed by completing each step listed on its card. This can be done by clicking

--- a/content/applications/inventory_and_mrp/manufacturing/workflows/byproducts.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/workflows/byproducts.rst
@@ -26,7 +26,6 @@ so, navigate to :menuselection:`Manufacturing app --> Configuration --> Settings
 :guilabel:`Save` to apply the change.
 
 .. image:: byproducts/byproducts-setting.png
-   :align: center
    :alt: The By-Products setting on the Manufacturing app settings page.
 
 With the :guilabel:`By-Products` setting enabled, a :guilabel:`By-products` tab appears on product
@@ -48,7 +47,6 @@ produced during an *Assemble* operation, select that operation in the :guilabel:
 Operation` field.
 
 .. image:: byproducts/byproducts-tab.png
-   :align: center
    :alt: The By-Products tab on a BoM, configured with a "Scrap Wood" by-product.
 
 Manufacture by-product
@@ -62,9 +60,9 @@ In the :guilabel:`Bill of Material` field, select a |BoM| on which by-products h
 After doing so, the :guilabel:`Product` field auto-populates with the corresponding product. Click
 :guilabel:`Confirm` to confirm the |MO|.
 
-When manufacturing is completed, click the :guilabel:`Produce All` button at the top of the |MO|.
-After doing so, inventory counts update to reflect the quantity of by-product(s) produced, as well
-as the quantity of the product.
+When manufacturing is completed, click the :guilabel:`Produce` button at the top of the |MO|. After
+doing so, inventory counts update to reflect the quantity of by-products produced, as well as the
+quantity of the product.
 
 Click the :guilabel:`Product Moves` smart button at the top of the |MO| page to see the movements of
 components and products. Each by-product is listed on the resulting :guilabel:`Inventory Moves`
@@ -72,5 +70,4 @@ page, with the :guilabel:`From` column displaying the virtual production locatio
 :guilabel:`To` column displaying the location where the by-product is stored.
 
 .. image:: byproducts/product-moves.png
-   :align: center
    :alt: The Product Moves page for an MO with by-products.

--- a/content/applications/inventory_and_mrp/manufacturing/workflows/manufacture_lots_serials.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/workflows/manufacture_lots_serials.rst
@@ -32,8 +32,8 @@ selected, which only tracks the quantity on hand. Select :guilabel:`By Lots` to 
 using lot numbers, or :guilabel:`By Unique Serial Number` to track the product using serial numbers.
 
 .. seealso::
-   :doc:`Lots <../../inventory/product_management/product_tracking/lots>`
-   :doc:`Serial numbers <../../inventory/product_management/product_tracking/serial_numbers>`
+   - :doc:`Lots <../../inventory/product_management/product_tracking/lots>`
+   - :doc:`Serial numbers <../../inventory/product_management/product_tracking/serial_numbers>`
 
 Lot number manufacturing
 ========================
@@ -58,10 +58,10 @@ or manually enter a new lot number and click :guilabel:`Create "#"` in the drop-
 .. image:: manufacture_lots_serials/lot-sn-field.png
    :alt: The "Lot/Serial Number" field on an MO.
 
-Either of these methods assign the product(s) in the |MO| a lot number before production is
-finished. It is also possible to complete production and close the |MO| by clicking
-:guilabel:`Produce All`, without assigning a lot number. Doing so automatically generates and
-assigns a lot, using the next available number.
+Either of these methods assign the products in the |MO| a lot number before production is finished.
+It is also possible to complete production and close the |MO| by clicking :guilabel:`Produce`,
+without assigning a lot number. Doing so automatically generates and assigns a lot, using the next
+available number.
 
 Serial number manufacturing
 ===========================
@@ -81,8 +81,8 @@ The rest of the manufacturing process depends on how many units the |MO| contain
 Manufacture single unit
 -----------------------
 
-If a single unit of the product is being manufactured, clicking :guilabel:`Produce All` closes the
-|MO|, and automatically generates and assigns the next available serial number, which appears in the
+If a single unit of the product is being manufactured, clicking :guilabel:`Produce` closes the |MO|,
+and automatically generates and assigns the next available serial number, which appears in the
 :guilabel:`Lot/Serial Number` field.
 
 To assign a serial number without closing the |MO|, enter a number manually in the
@@ -110,7 +110,7 @@ Manufacture multiple units
       |MOs|, each containing one unit of the chair. The |MOs| are titled `WH/MO/00109-001` and
       `WH/MO/00109-002`.
 
-To assign serial numbers to each unit of an |MO|, click :guilabel:`Produce All` to open the
+To assign serial numbers to each unit of an |MO|, click :guilabel:`Produce` to open the
 :guilabel:`Batch Production` pop-up window.
 
 The :guilabel:`First Lot/SN` field of the pop-up window is auto-filled with the next available


### PR DESCRIPTION
**documentation task card**: https://www.odoo.com/odoo/project/3835/tasks/6334869

**key change**: update instances of `produce all` to `produce` per 19.4 release

**note**: this is a batch update for multiple articles with wording change only; _manufacturing backorders_ will be updated in this separate PR since the workflow is affected https://github.com/odoo/documentation/pull/19061