### PR TITLE
[FIX] reference/user_interface: typo in xpath replace position example

### DIFF
--- a/content/developer/reference/user_interface/view_records.rst
+++ b/content/developer/reference/user_interface/view_records.rst
@@ -304,9 +304,7 @@ specifies how the matched node should be modified.
       .. code-block:: xml
 
          <xpath expr="//field[@name='x_field']" position="replace">
-             <div class="wrapper">
-                 $0
-             </div>
+             <div class="wrapper">$0</div>
          </xpath>
 
 .. attribute:: attributes


### PR DESCRIPTION
The `xpath` node has a feature in the `replace` position which copies copies the node matched by the xpath expression. This feature looks for an element with text exactly equal to `$0`; newlines, whitespace characters, and other nodes will prevent the characters from being recognized.

Thus, the example code for this behavior is incorrect, as it includes several newlines and spaces. This commit fixes the example code.

task-6408040 [Link](https://www.odoo.com/odoo/my-tasks/6408040)