### PR TITLE
[FIX] reference/user_interface: typo in xpath replace position example

### DIFF
--- a/content/developer/reference/user_interface/view_records.rst
+++ b/content/developer/reference/user_interface/view_records.rst
@@ -304,9 +304,7 @@ specifies how the matched node should be modified.
       .. code-block:: xml
 
          <xpath expr="//field[@name='x_field']" position="replace">
-             <div class="wrapper">
-                 $0
-             </div>
+             <div class="wrapper">$0</div>
          </xpath>
 
 .. attribute:: attributes


### PR DESCRIPTION
The `xpath` node has a feature in the `replace` position which copies the node matched by the xpath expression. This feature looks for an element with text exactly equal to `$0`; newlines, whitespace characters, and other nodes will prevent the characters from being recognized.

This behavior is defined in the following odoo Community file. Note that `text()='$0'` looks for an exact match, while `contains(text(),'$0')` would instead match on any text containing those characters.

```py
for loc in spec.xpath(".//*[text()='$0']"):
    loc.text = ''
    copied_node = copy.deepcopy(node)
    # TODO: Remove 'inherit_branding' logic if possible;
    # currently needed to track node removal for branding
    # distribution. Avoid marking root nodes to prevent
    # sibling branding issues.
    if inherit_branding:
        copied_node.set('data-oe-no-branding', '1')
    loc.append(copied_node)
```
https://github.com/odoo/odoo/blob/17.0/odoo/tools/template_inheritance.py#L151-L160

Thus, the example code for this behavior is incorrect, as it includes several newlines and spaces.

task-6408040 [Link](https://www.odoo.com/odoo/my-tasks/6408040)