### PR TITLE
[FIX] developer/tutorials: remove remark for present fields in views

### DIFF
--- a/content/developer/tutorials/server_framework_101/11_sprinkles.rst
+++ b/content/developer/tutorials/server_framework_101/11_sprinkles.rst
@@ -293,9 +293,7 @@ gives the condition in which the property applies. For example:
         <field name="description" invisible="not is_partner"/>
     </form>
 
-This means that the ``description`` field is invisible when ``is_partner`` is ``False``. It is
-important to note that a field used in ``invisible`` **must** be present in the view. If it
-should not be displayed to the user, we can use the ``invisible`` attribute to hide it.
+This means that the ``description`` field is invisible when ``is_partner`` is ``False``.
 
 .. exercise:: Use ``invisible``.
 


### PR DESCRIPTION
After odoo/odoo#137031, the views no longer require the fields used in them to be present in the view, as they are automatically added to the view by the framework. This commit removes the outdated remark in the tutorial that suggested otherwise.