### PR TITLE
[FIX] rental: product tracking

### DIFF
--- a/content/applications/sales/rental/configure_products/products.rst
+++ b/content/applications/sales/rental/configure_products/products.rst
@@ -117,14 +117,17 @@ Configure a physical rental product for product tracking
 
 .. important::
    To configure a physical rental product for product tracking, the **Inventory** app must be
-   installed, and :doc:`Lots & Serial Numbers must be enabled
-   <../../../inventory_and_mrp/inventory/product_management/product_tracking>`.
+   installed, and :guilabel:`Lots & Serial Numbers` must be enabled.
+
+   For rental products, only :guilabel:`By Unique Serial Number` tracking can be used. Selecting
+   :guilabel:`By Lots` instead results in an error message, since that setting doesn't apply to
+   rentals.
 
 Go to the :menuselection:`Rental app --> Products`, then click :guilabel:`New`. In the new product
 window, the :guilabel:`Rental` checkbox is already ticked by default.
 
 Select the :guilabel:`Product Type` as :guilabel:`Goods`. Tick the :guilabel:`Track Inventory`
-checkbox and select either :guilabel:`By Lots` or :guilabel:`By Unique Serial Number` from the
+checkbox and select :guilabel:`By Unique Serial Number` from the
 drop-down menu.
 
 For the :guilabel:`Category` field, select :guilabel:`Goods` from the drop-down menu or create a new


### PR DESCRIPTION
## What this PR does and why it's needed

Clarifies the product tracking configuration steps for rental products, based on internal QA feedback that selecting :guilabel:`By Lots` on a rental product results in an error, since that tracking method isn't supported for rentals. The documentation now specifies that only :guilabel:`By Unique Serial Number` tracking should be used.

---
This `19.0` PR **should not be FWP**.

Task link: https://www.odoo.com/odoo/project.task/6404546