### PR TITLE
[FIX] rental: product tracking

### DIFF
--- a/content/applications/sales/rental/configure_products/products.rst
+++ b/content/applications/sales/rental/configure_products/products.rst
@@ -43,7 +43,7 @@ clicking :guilabel:`Create`.
    :alt: The new product view in the Rental app.
 
 .. note::
-   For products that have *By Lots* or *By Unique Serial Number* enabled, refer to the
+   For products that have  *By Unique Serial Number* enabled, refer to the
    :ref:`rental/products/product-tracking` section.
 
 .. _rental/products/base-rental-period-price:
@@ -169,16 +169,19 @@ Configure product tracking
 
 .. important::
    To configure a physical rental product for product tracking, the **Inventory** app must be
-   installed, and *Lots & Serial Numbers* must be enabled.
+   installed, and :guilabel:`Lots & Serial Numbers` must be enabled.
+
+   For rental products, only :guilabel:`By Unique Serial Number` tracking can be used. Selecting
+   :guilabel:`By Lots` instead results in an error message, since that setting doesn't apply to
+   rentals.
 
 Go to the :menuselection:`Rental app --> Products --> Products`, then click :guilabel:`New`. In the
 new product window, the :guilabel:`Sales` checkbox is already selected by default. Select
 :guilabel:`Goods` as the :guilabel:`Product Type`. The :guilabel:`Tracking` field defaults to
 :guilabel:`By Quantity`.
 
-Click into the :guilabel:`Tracking` field and select either :guilabel:`By Lots` or :guilabel:`By
-Unique Serial Number`. Enter the number of products available to rent in the :guilabel:`Quantity On
-Hand` field.
+Click into the :guilabel:`Tracking` field and select :guilabel:`By Unique Serial Number`. Enter the
+number of products available to rent in the :guilabel:`Quantity On Hand` field.
 
 For the :guilabel:`Category` field, select :guilabel:`Goods` from the drop-down menu or create a new
 category by typing in the name and clicking :guilabel:`Create`. Configure :ref:`basic rental rate


### PR DESCRIPTION
## What this PR does and why it's needed

Clarifies the product tracking configuration steps for rental products, based on internal QA feedback that selecting :guilabel:`By Lots` on a rental product results in an error, since that tracking method isn't supported for rentals. The documentation now specifies that only :guilabel:`By Unique Serial Number` tracking should be used.

---
This `saas-19.3` PR  only.

Task link: https://www.odoo.com/odoo/project.task/6404546