### PR TITLE
[IMP] upgrade supported version: update the color of Odoo SaaS 19.1

### DIFF
--- a/content/administration/standard_extended_support.rst
+++ b/content/administration/standard_extended_support.rst
@@ -51,7 +51,7 @@ The table below shows the support status of every version. Major releases are hi
      - March 2026
      -
    * - Odoo SaaS 19.1
-     - |green|
+     - |red|
      - N/A
      - N/A
      - January 2026


### PR DESCRIPTION
This PR updates the color of the line 'Odoo SaaS 19.1' from green to red. This version is no longer supported, and rolling upgrade releases are in progress. Changing the color to match reality also helps to dispel any doubts our customers may have and potentially prevent tickets such as [opw-6349179](https://www.odoo.com/my/tasks/6349179)