### PR TITLE
mrp: clarify Apply on Variants matching logic

### DIFF
--- a/content/applications/inventory_and_mrp/manufacturing/advanced_configuration/product_variants.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/advanced_configuration/product_variants.rst
@@ -109,8 +109,26 @@ columns. Then, choose the desired values in the :guilabel:`Apply on Variants` co
    :align: center
    :alt: "Apply on Variants" option on the additional options menu.
 
-Each component can be assigned to multiple variants. Components with no variants specified are used
-in every variant of the product. The same principle applies when configuring operations and
+Each component can be assigned to multiple attribute values. When multiple values are selected,
+Odoo groups them by attribute. Values belonging to the same attribute are evaluated as **OR**
+conditions, while values belonging to different attributes are evaluated as **AND** conditions.
+
+.. example::
+   Consider a product with the following attributes and values:
+
+   - :guilabel:`Legs`: :guilabel:`Steel`, :guilabel:`Aluminium`, and
+     :guilabel:`Custom`
+   - :guilabel:`Color`: :guilabel:`White` and :guilabel:`Black`
+
+   Selecting :guilabel:`Legs: Steel`, :guilabel:`Legs: Aluminium`, and
+   :guilabel:`Color: White` applies the component to variants matching
+   ``(Legs = Steel OR Legs = Aluminium) AND Color = White``.
+
+   Selecting :guilabel:`Legs: Custom` and :guilabel:`Color: Black` applies the component only
+   to variants that have both the :guilabel:`Custom` legs and :guilabel:`Black` color values.
+
+Components with no values specified in the :guilabel:`Apply on Variants` field are used in every
+variant of the product. The same matching logic applies when configuring operations and
 by-products.
 
 When defining variant :abbr:`BoMs (bills of material)` by component assignment, the


### PR DESCRIPTION
The documentation explains that BoM lines can be assigned to multiple attribute values, but does not explain how those values are combined.

Clarify that values belonging to the same attribute are evaluated as OR conditions, while values belonging to different attributes are evaluated as AND conditions. Also clarify that leaving the field empty applies the line to every product variant.

This matches the BoM filtering logic implemented in `_skip_for_no_variant` (https://github.com/odoo/odoo/blob/19.0/addons/mrp/models/mrp_bom.py#L593-L630), which delegates instant and dynamic variant matching to `_match_all_variant_values` (from the product model).

I've added an example using the same attributes & colors as given in the supplied screenshots.