### PR TITLE
[IMP] javascript_reference: add past date warning option for date fields

### DIFF
--- a/content/developer/reference/frontend/javascript_reference.rst
+++ b/content/developer/reference/frontend/javascript_reference.rst
@@ -726,11 +726,15 @@ Date (`date`)
 
             <field name="datefield" options="{'min_date': 'today', 'max_date': '2023-12-31'}" />
 
-    - `warn_future`: displays a warning if the value is in the future (based on today).
+    - `warning`: specifies when to display a warning (`"none"` by default).
+
+        The available warning modes are: `"none"`, `"future"`, and `"past"`.
+        Displays a warning if the value is in the future or in the past (based on
+        today), depending on the selected mode.
 
         .. code-block:: xml
 
-            <field name="datefield" options="{'warn_future': true}" />
+            <field name="datefield" options="{'warning': 'future'}" />
 
     - `numeric`: when set to true, it shows the date in the format set on the current language.
       (default: `false`).


### PR DESCRIPTION
Before this change, date and datetime fields only supported a warning for future dates. There was no option to warn users when a past date based on today, which is useful for fields such as deadlines or end dates.

After this change, a new warning option is introduced to support past date warnings in addition to the existing future date warning, giving users more flexibility when configuring date fields. Field-specific options in Studio are also reorganized

Community PR: https://github.com/odoo/odoo/pull/279010
Enterprise PR: https://github.com/odoo/enterprise/pull/125963

Task-6366295