### PR TITLE
[IMP] accounting/l10n_cl: adding market certification guide

### DIFF
--- a/content/applications/finance/fiscal_localizations/chile.rst
+++ b/content/applications/finance/fiscal_localizations/chile.rst
@@ -63,6 +63,8 @@ localization.
    All features are only available if the company already completed the `SII Sistema de Facturación
    de Mercado <https://www.sii.cl/factura_electronica/factura_mercado/proceso_certificacion.htm>`_
    certification process.
+   For more details and contact information for local partners who can support the certification, refer
+   to the following `guide <https://www.odoo.com/knowledge/article/71240>`_.
 
 Company information
 ===================


### PR DESCRIPTION
Market certification is **REQUIRED** for companies to use the `l10n_cl_edi` module features.

We are adding an external guide with more details and the contact information of three local partners of Odoo that can support this certification process (Odoo is not able to do it, as only Chilean companies can).