### PR TITLE
[FIX] fiscal_localizations: correct UAE typo in localization docs

### DIFF
--- a/content/applications/finance/fiscal_localizations/united_arab_emirates.rst
+++ b/content/applications/finance/fiscal_localizations/united_arab_emirates.rst
@@ -46,7 +46,7 @@ compliance with the Federal Tax Authority (FTA).
 The UAE localization package provides the following key features to ensure compliance with local
 fiscal and accounting regulations:
 
-- :ref:`Chart of accounts <localizations/uae/coa>`: a predefined structure aligned with UEA
+- :ref:`Chart of accounts <localizations/uae/coa>`: a predefined structure aligned with UAE
   accounting standards
 - :ref:`Taxes <localizations/uae/taxes>`: preconfigured tax groups and templates based on UAE VAT
   rules


### PR DESCRIPTION
The chart of accounts description read "UEA" instead of "UAE". This corrects the country abbreviation in the United Arab Emirates fiscal localization documentation.