### PR TITLE
[IMP] domain_names: CAA record

### DIFF
--- a/content/applications/websites/website/configuration/domain_names.rst
+++ b/content/applications/websites/website/configuration/domain_names.rst
@@ -362,7 +362,8 @@ protocol.
 
 Odoo generates a separate SSL certificate for each domain :ref:`mapped to a database
 <domain-name/db-map>` using `Let's Encrypt's certificate authority and ACME protocol
-<https://letsencrypt.org/how-it-works/>`_.
+<https://letsencrypt.org/how-it-works/>`_. Any CAA records configured for the domain must `allow
+Let's Encrypt <https://letsencrypt.org/docs/caa/>`_, otherwise certificate generation may fail.
 
 .. note::
    - Certificate generation may take up to 24 hours.


### PR DESCRIPTION
Occasionally customers use a CAA record to restrict which certificate authorities are allowed to provide certificates for their domain. If Let's Encrypt is not included in that, it will cause the certificate generation by Odoo Online or SH to fail.

Since this is an advanced topic, I opted to put a note about it in the section that gives more details about the SSL implementation. I expect that putting it in the main "Configure an existing domain name" section would cause confusion for most customers.