### PR TITLE
[IMP] Inventory: physical inventory rules

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/warehouses_storage/inventory_management/count_products.rst
+++ b/content/applications/inventory_and_mrp/inventory/warehouses_storage/inventory_management/count_products.rst
@@ -14,61 +14,66 @@ warehouse.
 Physical Inventory page
 =======================
 
-To view the :guilabel:`Physical Inventory` page, navigate to :menuselection:`Inventory app -->
-Operations --> Physical Inventory`.
-
-The :guilabel:`Physical Inventory` page lists all products that are currently in stock.
+To view the *Physical Inventory* page, navigate to :menuselection:`Inventory app --> Operations -->
+Physical Inventory`.
 
 .. image:: count_products/physical-inventory-page.png
-   :alt: In stock products listed on the Physical Inventory page.
+   :alt: Products listed on the Physical Inventory page.
 
-.. note::
-   Only products with a quantity greater than zero are listed on the :guilabel:`Physical Inventory`
-   page. To view product lines with zero current quantity, go to :menuselection:`Inventory app -->
-   Reporting --> Stock`.
+On the *Physical Inventory* page, all products with stock history are listed, even if the quantity
+in stock is less than zero.
 
-For each product line, the following information is listed:
+.. tip::
+   Products that do not have a stock history do not appear on the *Physical Inventory* page.
 
-- :guilabel:`Product`: the product whose quantity is listed on the inventory adjustment line.
+Each product line contains the following information:
+
+- :guilabel:`Location`: The specific location in the warehouse where a product is stored. This
+  column is **only** visible if :doc:`Storage Locations <use_locations>` are enabled.
+- :guilabel:`Product`: The product whose quantity is listed on the inventory adjustment line.
 - :guilabel:`Lot/Serial Number`: the tracking identifier assigned to the specific product listed. It
   can contain letters, numbers, or a combination of both.
 
    .. note::
       If a specific product has a quantity of more than `1.00` in stock, and more than one serial
-      number, or lot number, assigned to it, each uniquely-identified product is displayed on its
-      own product line with its own lot/serial number, displayed under the :guilabel:`Lot/Serial
-      Number` column.
+      number or lot number assigned to it, each uniquely-identified product is displayed on its own
+      product line with its own lot/serial number, displayed under the :guilabel:`Lot/Serial Number`
+      column.
 
-- :guilabel:`Scheduled`: the date at which a count should be made. If not otherwise specified, this
-  date will default to the 31st of December of the current year.
-- :guilabel:`User`: the person assigned to the count in the database. This can either be the person
-  physically counting the inventory, or applying the count in the database.
-- :guilabel:`On Hand`: the quantity of the product currently recorded in the database.
-- :guilabel:`Counted`: the real quantity counted during an inventory count. This field is left blank
+- :guilabel:`Counted`: The real quantity counted during an inventory count. This field is left blank
   by default but can be changed, depending on if it matches the :guilabel:`On Hand` quantity or not.
-- :guilabel:`Difference`: the difference between the :guilabel:`On Hand` quantity and
-  :guilabel:`Counted` quantity, once an inventory adjustment is made. The difference is
-  automatically calculated after every inventory adjustment.
+- :guilabel:`Difference`: The difference between the :guilabel:`On Hand` quantity and
+  :guilabel:`Counted` quantity once an inventory adjustment is made. The difference is automatically
+  calculated after every inventory adjustment.
+- :guilabel:`Unit`: The :doc:`unit of measure <../../product_management/configure/uom>` in which the
+  product is measured. Unless otherwise specified (e.g., in :guilabel:`Pounds` or
+  :guilabel:`Ounces`), the default :abbr:`UoM (Unit of Measure)` is :guilabel:`Units`.
+- :guilabel:`Inventory Frequency`: The frequency in days for inventory counts. The default value of
+  this field is set to `0`.
+- :guilabel:`Product Category`: The category of the product list on the inventory adjustment line.
+- :guilabel:`Last Count Date`: The last time the quantity was updated.
+- :guilabel:`Scheduled`: The date at which a count should be made. If not otherwise specified, this
+  date defaults to December 31st of the current year.
+- :guilabel:`User`: The person assigned to the count in the database. This can either be the person
+  physically counting the inventory, or the person applying the count in the database.
+- :guilabel:`On Hand`: The quantity of the product currently recorded in the database.
+- :guilabel:`Company`: The company whose database these inventory adjustments are being made on. The
+  company is listed in the top corner of the database, next to the current user.
 
 .. tip::
    Some columns are hidden by default. To reveal these columns, click the :icon:`oi-settings-adjust`
-   :guilabel:`(adjust)` icon to the far right of the form's top row, and reveal any desired column
+   :guilabel:`(adjust)` icon to the top corner of the form's top row, and reveal any desired column
    by selecting the checkbox next to that option.
 
 The following additional columns are available, depending on the settings in the database:
 
-- :guilabel:`Location`: the specific location in the warehouse where a product is stored. This
-  column is **only** visible if :doc:`Storage Locations <use_locations>` are enabled.
-- :guilabel:`Product Category`: the category of the product list on the inventory adjustment line.
-- :guilabel:`Last Count Date`: the last time the quantity was updated.
-- :guilabel:`Expiration Date`: the date on which the goods with this serial number are due to
+- :guilabel:`Accounting Date`: The date on which the adjustments are accounted for in the Odoo
+  **Accounting** app.
+- :guilabel:`Expiration Date`: The date on which the goods with this serial number are due to
   expire. This column is only available if :doc:`Expiration Dates
-  <../../product_management/product_tracking/expiration_dates>` is enabled in the *Inventory*
-  settings.
-- :guilabel:`Package`: the package containing the quantity listed.
-- :guilabel:`Unit`: the :doc:`unit of measure <../../product_management/configure/uom>` in which the
-  product is measured. Unless otherwise specified (e.g., in :guilabel:`Pounds` or
-  :guilabel:`Ounces`), the default :abbr:`UoM (Unit of Measure)` is :guilabel:`Units`.
+  <../../product_management/product_tracking/expiration_dates>` is enabled in the **Inventory**
+  app's settings.
+- :guilabel:`Package`: The package containing the quantity listed.
 
 .. _inventory/create-adjustment:
 
@@ -79,13 +84,13 @@ To update an existing physical inventory entry, click into the corresponding fie
 :guilabel:`Counted` column for the product that must be adjusted. Adjust the count, then click
 :guilabel:`Apply All`.
 
-To create a new inventory adjustment from the :menuselection:`Physical Inventory` page, click
-:guilabel:`New`. Doing so creates a new, blank inventory adjustment line at the bottom of the page.
+To create a new inventory adjustment from the *Physical Inventory* page, click :guilabel:`New`.
+Doing so creates a new, blank inventory adjustment line at the bottom of the page.
 
 .. tip::
-   |Ia| can also be created from the :guilabel:`Forecasted Report` on an individual product record.
-   To open the report, navigate to a product record and click the :guilabel:`Forecasted` smart
-   button. Then, at the top of the page, click :guilabel:`Update Quantity`, then :guilabel:`New`.
+   |Ia| can also be created from the *Forecasted Report* on an individual product record. To open
+   the report, navigate to a product record and click the :guilabel:`Forecasted` smart button. Then,
+   at the top of the page, click :guilabel:`Update Quantity`, then :guilabel:`New`.
 
    .. image:: count_products/forecast-report.png
       :alt: The Update Quantity button on a Forecast report in the Inventory app.
@@ -133,9 +138,9 @@ Apply adjusted count
 Apply a single adjustment
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some companies do not require adjustment reasons to be recorded. In this circumstance, you can apply
-adjustments to a single line at a time by clicking the :guilabel:`Apply` button on the line at the
-far right of the page.
+Some companies do not require adjustment reasons to be recorded. In this circumstance, apply
+adjustments to a single line at a time by clicking the :icon:`fa-save` :guilabel:`Apply` button on
+the line at the far side of the page.
 
 Apply multiple adjustments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -143,12 +148,12 @@ Apply multiple adjustments
 To apply multiple adjustments at once, or to ensure that reasons for adjustments are recorded, use
 one of the following methods to apply multiple adjustments at once:
 
-- Click the :guilabel:`Apply All` button on the top left corner of the page.
-- Select the checkbox on the far left of the line. Doing so reveals new button options at the top of
-  the page, one of which is an :guilabel:`Apply` button.
+- Click the :guilabel:`Apply All` button on the top corner of the page.
+- Select the checkbox on the far side of the line. Doing so reveals new button options at the top of
+  the page, one of which is an :icon:`fa-save` :guilabel:`Apply` button.
 
 .. note::
-   It may be necessary to click the :guilabel:`Save` button at the top left of the screen before
+   It may be necessary to click the :guilabel:`Save` button at the top corner of the screen before
    applying the changes.
 
 Clicking these buttons opens a *Physical Inventory* pop-up window.
@@ -175,16 +180,16 @@ Relocate products
 =================
 
 |Ia| can also be used to relocate products to different storage locations, or to different packages.
-To relocate a product, click on the checkbox at the far left of the line for the desired product. At
+To relocate a product, click on the checkbox at the far side of the line for the desired product. At
 the top of the page, click the :icon:`fa-cog` :guilabel:`Actions` button, then select
 :guilabel:`Relocate`. Doing so opens a pop-up.
 
 On the resulting pop-up, enter the following information:
 
-- :guilabel:`To Location`: the new location for the products.
-- :guilabel:`To Package`: the new package for the products. This field only appears if you have
-  :guilabel:`Packages` enabled in the *Inventory* settings.
-- :guilabel:`Reason for relocation`: the reason for the move.
+- :guilabel:`To Location`: The new location for the products.
+- :guilabel:`To Package`: The new package for the products. This field only appears if you have
+  :guilabel:`Packages` enabled in the **Inventory** settings.
+- :guilabel:`Reason for relocation`: The reason for the move.
 
 Click :guilabel:`Confirm` to confirm the move.
 
@@ -201,7 +206,7 @@ Set to zero
 ===========
 
 |Ia| can also be used to clear inventory counts by setting the quantity to zero. To do this, select
-the checkbox at the far left of the line for the desired product. At the top of the page, click the
+the checkbox at the far side of the line for the desired product. At the top of the page, click the
 :icon:`fa-gear` :guilabel:`Actions` button to open a drop-down menu. Click :guilabel:`Set to 0`.
 Once this is complete, :ref:`apply <inventory/apply-adjustment>` the adjusted count.
 
@@ -219,7 +224,7 @@ Counting products is a recurring activity in a warehouse. Once a count is comple
 
 On each product line, identify whether the value in the :guilabel:`On Hand` column recorded in the
 database matches the newly-counted value. If the recorded value and the counted value match, enter
-the 'On Hand' quantity in the :guilabel:`Counted` column.
+the *On Hand* quantity in the :guilabel:`Counted` column.
 
 Doing so sets the value of the :guilabel:`Difference` column to `0.00`. Subsequently, once applied,
 an inventory move with `0.00` :guilabel:`Done` is recorded in the product's inventory adjustment
@@ -261,7 +266,7 @@ quantity on hand`, which sets the selected products' :guilabel:`Counted` quantit
 
 .. note::
    If other inventory adjustments were created during the count process, click :guilabel:`Save` in
-   the top-left corner to save the current entry. Make sure this is done before opening the
+   the top corner to save the current entry. Make sure this is done before opening the
    :icon:`fa-cog` :guilabel:`Actions` menu to set the count.
 
 .. important::
@@ -277,14 +282,14 @@ Revert an inventory adjustment
 To revert the changes made in an inventory adjustment, navigate to :menuselection:`Inventory -->
 Reporting --> Moves History`.
 
-Select the checkbox at the far left of the line for the desired product. At the top of the page,
+Select the checkbox at the far side of the line for the desired product. At the top of the page,
 click the :icon:`fa-gear` :guilabel:`Actions` button to open a drop-down menu, and click
 :guilabel:`Revert Inventory Adjustment`.
 
 .. note::
-   After an inventory adjustment is reverted, the line is not removed from the :guilabel:`Moves
-   History` report. Instead, an additional line is added, this time with the word `[reverted]` added
-   to the :guilabel:`Reference` column.
+   After an inventory adjustment is reverted, the line is not removed from the *Moves History*
+   report. Instead, an additional line is added, this time with the word `[reverted]` added to the
+   :guilabel:`Reference` column.
 
    .. image:: count_products/reverted-adjustment.png
       :alt: The reference fields on the Moves History report in the Inventory app.
@@ -297,8 +302,8 @@ current year. However, for some companies, it is crucial that they have an accur
 at all times. In such cases, the default scheduled date can be modified.
 
 To modify the default scheduled date, go to :menuselection:`Inventory app --> Configuration -->
-Settings`. Then, in the :guilabel:`Operations` section, locate the :guilabel:`Annual Inventory Day
-and Month` setting, which includes a drop-down menu that is set to `31 December` by default.
+Settings`. Then, in the *Operations* section, locate the :guilabel:`Annual Inventory Day and Month`
+setting, which includes a drop-down menu that is set to `31 December` by default.
 
 .. image:: count_products/annual-inventory.png
    :alt: Adjust the next inventory count date with the Annual Inventory Day and Month setting.
@@ -319,7 +324,7 @@ Plan big inventory counts
 To plan big inventory counts, such as a full count of everything currently in stock, first navigate
 to :menuselection:`Inventory app --> Operations --> Physical Inventory`.
 
-Then, select the desired products to be counted by ticking the checkbox on the far left of each
+Then, select the desired products to be counted by selecting the checkbox on the far side of each
 product line.
 
 .. tip::
@@ -328,12 +333,12 @@ product line.
    lines.
 
 Once all desired products have been selected, click the :guilabel:`Request a Count` button at the
-top of the page. Doing so opens the :guilabel:`Inventory Request` pop-up window, where the following
+top of the page. Doing so opens the *Inventory Request* pop-up window, where the following
 information can be filled:
 
-- :guilabel:`Assign to`: the user responsible for the count.
-- :guilabel:`Scheduled at`: the planned date of the count.
-- :guilabel:`Show Expected Quantity`: whether the assigned user can see the expected quantity.
+- :guilabel:`Assign to`: The user responsible for the count.
+- :guilabel:`Scheduled at`: The planned date of the count.
+- :guilabel:`Show Expected Quantity`: Whether the assigned user can see the expected quantity.
 
 .. image:: count_products/count-popup.png
    :alt: Request a count pop-up on the Physical Inventory page.
@@ -365,14 +370,14 @@ the user who applied the count is listed in the :guilabel:`Done By`.
 Inventory audit
 ---------------
 
-An inventory audit can be accessed from the :guilabel:`Physical Inventory` page. This audit includes
-an inventory record both before and after a count is completed, to track what changed.
+An inventory audit can be accessed from the *Physical Inventory* page. This audit includes an
+inventory record both before and after a count is completed, to track what changed.
 
-On the :guilabel:`Physical Inventory` page, select the checkbox at the top-left of the page to
-select all of the lines. Then click the :guilabel:`Request a Count` button. On the pop-up, click
+On the *Physical Inventory* page, select the checkbox at the top corner of the page to select all of
+the lines. Then click the :guilabel:`Request a Count` button. On the pop-up, click
 :guilabel:`Confirm`.
 
-After returning to the :guilabel:`Physical Inventory` page, select all of the lines again. Click
+After returning to the *Physical Inventory* page, select all of the lines again. Click
 :menuselection:`Print --> Count Sheet`. The :guilabel:`Count Sheet` exports in PDF form.
 
 .. seealso::


### PR DESCRIPTION
## What this PR does and why it's needed
Updates the *Physical Inventory* page documentation in response to customer feedback, aligning the described behavior and column references with the actual page (which columns are displayed, how they're organized, and which products are listed).

Task: https://www.odoo.com/odoo/my-tasks/6129720

## Changes

**Physical Inventory page**
- Corrected the description of which products appear on the page: all products with stock history are now listed, including those with a quantity below zero, replacing the previous claim that only products with a quantity greater than zero are shown.
- Replaced the note about finding zero-quantity products in the *Stock* report with a tip clarifying that products without stock history don't appear on the page at all.
- Documented columns that appear and the order in which they appear.
- Small edits around list capitalization, avoiding "right" or "left" when pointing out where UI elements are (RTL users will not have that experience), and adding icons to a couple of UI elements.

---
This `19.0` PR can be FWP up to `master`.