### PR TITLE
[IMP] github_link: fix github link for upgrade testing

### DIFF
--- a/extensions/github_link/__init__.py
+++ b/extensions/github_link/__init__.py
@@ -66,7 +66,7 @@ def setup(app):
             return None
 
         # FIXME: make finding project root project-independent
-        if module.startswith('odoo.upgrade.util'):
+        if module.startswith(('odoo.upgrade.util', 'odoo.upgrade.testing')):
             from odoo.upgrade import util
             project = 'upgrade-util'
             project_root = os.path.join(os.path.dirname(util.__file__), '../..')


### PR DESCRIPTION
by default it taking `odoo` as project which leading to generating wrong `github_link`
like this ``github.com/odoo/odoo/upgrade-util/src/testing``. So, fixed it according to this 
https://github.com/odoo/documentation/blame/bda2dc276c797bb4a4d7d0320789d5c5b6008e64/content/developer/reference/upgrades/upgrade_utils.rst#L41

After fix coming like this.

`https://github.com/odoo/upgrade-util/blob/master/src/testing.py#L599`