### PR TITLE
[FIX] Sales: Added missing app to discount list

### DIFF
--- a/content/applications/sales/point_of_sale/extra/pricing.rst
+++ b/content/applications/sales/point_of_sale/extra/pricing.rst
@@ -55,7 +55,7 @@ settings <pos/use/settings>`, scroll down to the :guilabel:`Pricing` section, an
 
 Once the feature has been activated, go to :menuselection:`Point of Sale --> Products -->
 Discount & Loyalty` and :ref:`configure the desired discount and loyalty programs
-<sales/products/loyalty-programs>`. These programs are triggered when an order meets the defined
+<sales/loyalty_discount/configure-programs>`. These programs are triggered when an order meets the defined
 requirements. Depending on the :ref:`program type <sales/pricing_management/program-types>`, rewards
 are either applied automatically or manually by the cashier.
 

--- a/content/applications/sales/sales/products_prices/loyalty_discount.rst
+++ b/content/applications/sales/sales/products_prices/loyalty_discount.rst
@@ -2,9 +2,14 @@
 Discount and loyalty programs
 =============================
 
-The Odoo **Sales**, **eCommerce**, and **Point of Sale** applications allow users to create discount
-and loyalty programs that customers can use for online and in-store shopping. These programs offer
-more varied, public, and time-sensitive pricing options than :doc:`pricelists
+.. meta::
+   :description: Configure discount and loyalty programs in Odoo Sales, Subscriptions, eCommerce,
+                 and Point of Sale, including program types, conditional rules, and rewards, to
+                 offer customers varied and time-sensitive pricing beyond standard pricelists.
+
+The Odoo **Sales**, **Subscriptions**, **eCommerce**, and **Point of Sale** applications allow users
+to create discount and loyalty programs that customers can use for online and in-store shopping.
+These programs offer more varied, public, and time-sensitive pricing options than :doc:`pricelists
 </applications/sales/sales/products_prices/prices/pricing>`.
 
 Configure the settings
@@ -15,7 +20,7 @@ To begin using discount and loyalty programs, navigate to :menuselection:`Sales 
 Gift Card` setting by checking the box next to the feature. Finally, click :guilabel:`Save` to save
 the changes.
 
-.. _sales/products/loyalty-programs:
+.. _sales/loyalty_discount/configure-programs:
 
 Configure discount and loyalty programs
 =======================================
@@ -116,9 +121,8 @@ Conditional rules
 Next, configure the :guilabel:`Conditional rules` that determine when the program applies to a
 customer's order.
 
-In the :guilabel:`Rules & Rewards` tab, click :guilabel:`Add` next to :guilabel:`Conditional rules`
-to add *conditions* to the program. This reveals a :guilabel:`Create Conditional rules` pop-up
-window.
+In the *Rules & Rewards* tab, click :guilabel:`Add` next to :guilabel:`Conditional rules` to add
+*conditions* to the program. This reveals a *Create Conditional rules* pop-up window.
 
 .. image:: loyalty_discount/price-conditional-rewards.png
    :alt: Rules & Rewards tab of the loyalty program form.
@@ -157,9 +161,8 @@ Click :guilabel:`Save & Close` to save the rule and close the pop-up window, or 
 Rewards
 -------
 
-In the :guilabel:`Rules & Rewards` tab of the program form, click :guilabel:`Add` next to
-:guilabel:`Rewards` to add *rewards* to the program. This reveals a :guilabel:`Create Rewards`
-pop-up window.
+In the *Rules & Rewards* tab of the program form, click :guilabel:`Add` next to :guilabel:`Rewards`
+to add *rewards* to the program. This reveals a :guilabel:`Create Rewards` pop-up window.
 
 .. note::
    The options for :guilabel:`Rewards` vary depending on the selected :ref:`Program Type

--- a/content/applications/websites/ecommerce/configuration/prices.rst
+++ b/content/applications/websites/ecommerce/configuration/prices.rst
@@ -236,7 +236,7 @@ To enable :doc:`discount programs </applications/sales/sales/products_prices/loy
 your e-commerce, go to :menuselection:`Website --> Configuration --> Settings`, scroll down to the
 :guilabel:`eCommerce` section, and enable the :guilabel:`Discounts, Loyalty & Gift Card` feature.
 
-:ref:`Configure <sales/products/loyalty-programs>` the discount program, make sure the
+:ref:`Configure <sales/loyalty_discount/configure-programs>` the discount program, make sure the
 :guilabel:`Website` option is enabled, and add the relevant :ref:`Pricelist
 <ecommerce/prices/pricelists>` and :guilabel:`Website` on the program form, if needed.
 


### PR DESCRIPTION
## What this PR does and why it's needed
This PR fixes the discount and loyalty programs documentation to include the **Subscriptions** app, which was missing from the list of applications that support these programs. It also updates the custom anchor for the "Configure discount and loyalty programs" section to a more consistent naming convention and adds a meta description for SEO.

## Changes

**Discount and loyalty programs**
- Added **Subscriptions** to the list of apps (Sales, eCommerce, Point of Sale) that support discount and loyalty programs.
- Added a `.. meta::` description summarizing the page's content, now mentioning Subscriptions as well.
- Renamed the custom anchor from `sales/products/loyalty-programs` to `sales/loyalty_discount/configure-programs` to match the file name, and updated all cross-references to it in `point_of_sale/extra/pricing.rst` and `ecommerce/configuration/prices.rst`.
- Changed a couple of `:guilabel:` references to *Rules & Rewards* tab to italics for consistency with surrounding text.

---
This `saas-19.3` PR can be FWP up to `master`.