### PR TITLE
[FIX] sales: remove duplicate bullet points in pdf quote builder

### DIFF
--- a/content/applications/sales/sales/sales_quotations/pdf_quote_builder/dynamic_text.rst
+++ b/content/applications/sales/sales/sales_quotations/pdf_quote_builder/dynamic_text.rst
@@ -24,11 +24,6 @@ form field* in mind. Use the following tips to avoid overlapping text and other 
 - **Add line breaks**: Place dynamic form fields, like *Customer Name*, on their own lines.
   Alternatively, put them at the end of phrases to avoid text breaking. Long names can push static
   text out of alignment.
-- **Leave whitespace**: Ensure there is enough room for dynamic data to expand without overlapping
-  logos or borders.
-- **Add line breaks**: Place dynamic form fields, like *Customer Name*, on their own lines.
-  Alternatively, put them at the end of phrases to avoid text breaking. Long names can push static
-  text out of alignment. text appearance when adding or editing content.
 
 Odoo recommends editing PDF forms with Adobe software. Form fields in header and footer templates
 are required to retrieve dynamic values in Odoo.


### PR DESCRIPTION
## What this PR does and why it's needed
Removes a duplicated set of bullet points in the PDF quote builder's dynamic text guidance. A user flagged the duplication in [PR #18136](https://github.com/odoo/documentation/pull/18136), and this fix cleans it up.

## Changes

**Sales — PDF Quote Builder**
- Removed a duplicated "Leave whitespace" / "Add line breaks" bullet pair in the dynamic text formatting tips, including a stray trailing text fragment left over from the duplication

---
This `18.0` PR can be FWP up to `master`.
