### PR TITLE
[IMP] phone: remove schedule later, clarify actions

### DIFF
--- a/content/applications/productivity/phone.rst
+++ b/content/applications/productivity/phone.rst
@@ -10,11 +10,11 @@ Phone
    As of Odoo 19.0, the *VoIP* module has been renamed to *Odoo Phone*.
 
 The Odoo **Phone** app enables businesses to handle calls over the internet by integrating directly
-with Odoo apps like **CRM** and **Helpdesk**. The **Phone** app can link calls and messages to
-customer interactions, log communication history, and automate call routing based on predefined
-rules. Features like :ref:`call recording <productivity/phone/recording-transcription>` and
-analytics provide insights into call volume and response times, helping businesses streamline
-external communication and track team performance.
+with Odoo apps like **CRM** and **Helpdesk**. The **Phone** app can :doc:`link calls and messages to
+customer interactions <../essentials/activities>`, log communication history, and automate call
+routing based on predefined rules. Features like :ref:`call recording
+<productivity/phone/recording-transcription>` and analytics provide insights into call volume and
+response times, helping businesses streamline external communication and track team performance.
 
 .. cards::
    .. card:: Phone widget

--- a/content/applications/productivity/phone/phone_widget.rst
+++ b/content/applications/productivity/phone/phone_widget.rst
@@ -22,18 +22,15 @@ Click the :icon:`oi-voip` :guilabel:`(Hide Softphone)` icon again to close the w
 
 The **Phone** widget contains four tabs:
 
-- :icon:`oi-numpad` :guilabel:`Keypad`: Makes :ref:`outbound calls
-  <phone/phone_widget/outbound-call>`. Use the numeric keypad to dial a number, or type a name or
-  number to search for a contact. Click the :icon:`fa-globe` and/or :guilabel:`(country flag)` icon
-  to fill in a country code.
 - :icon:`fa-history` :guilabel:`Recent`: Lists recent :ref:`inbound calls
   <phone/phone_widget/inbound-call>` and :ref:`outbound calls <phone/phone_widget/outbound-call>` on
   the account, grouped by date. Click a call from the list to see the contact's phone number and
   company name, and click the :icon:`fa-list-ul` :guilabel:`(Open full history)` icon to view the
   full call history in the **Phone** app.
-- :icon:`fa-address-book-o` :guilabel:`Contacts`: Lists :doc:`contacts <../../essentials/contacts>`
-  that have a saved phone number. Click the :icon:`fa-phone` :guilabel:`(Call)` icon next to a
-  contact to call them, or click the contact's name to view their company name and phone number.
+- :icon:`oi-numpad` :guilabel:`Keypad`: Makes :ref:`outbound calls
+  <phone/phone_widget/outbound-call>`. Use the numeric keypad to dial a number, or type a name or
+  number to search for a contact. Click the :icon:`fa-globe` and/or :guilabel:`(country flag)` icon
+  to fill in a country code.
 - :icon:`fa-clock-o` :guilabel:`Activities`: Lists call :doc:`activities
   <../../essentials/activities>` assigned to the user, grouped by due date.
 
@@ -171,8 +168,10 @@ view the following drop-down action menus:
 - :icon:`fa-ellipsis-v` :guilabel:`Go to`: Send an email or SMS, and open records related to the
   contact. Depending on the type of contact, this can include call details, contacts, leads,
   tickets, tasks, sales, and subscriptions.
-- :icon:`fa-history` :guilabel:`Log (Recents tab only)`: Log the call as an activity in a related
-  record.
+- :icon:`fa-history` :guilabel:`History (Recents tab, Keypad tab)`: View the call history for the
+  selected contact.
+- :icon:`fa-clock-o` :guilabel:`Log (Recents tab only)`: Log the call as a completed activity in a
+  related record.
 - :icon:`fa-clock-o` :guilabel:`Activity (Activities tab only)`: Complete, edit, or cancel the
   activity.
 


### PR DESCRIPTION
Updates the Phone app documentation (content/applications/productivity/phone.rst and content/applications/productivity/phone/phone_widget.rst) to match recent UI changes to the phone widget: the Schedule Later action is gone, the Contacts tab was dropped, and the call-actions menu now separates History from Log.

- phone.rst: reworded the intro paragraph and linked "link calls and messages to customer interactions" to the activities doc via :doc:.
- phone_widget.rst:
  - Removed documentation of the Contacts tab (no longer one of the widget's tabs) and reordered the remaining tab list to Recent → Keypad → Activities.
  - Split the old Log drop-down action into two distinct entries:
      - History (Recents tab, Keypad tab): view the call history for the selected contact.
    - Log (Recents tab only): log the call as a completed activity on a related record (clarifies it logs a completed activity, not a scheduled one).

This saas-19.4 branch can be FWP to master.