### PR TITLE
[REM] odoo_sh: outdated import behavior

### DIFF
--- a/content/administration/odoo_sh/getting_started/create.rst
+++ b/content/administration/odoo_sh/getting_started/create.rst
@@ -160,20 +160,6 @@ default Odoo.sh server is used.
    Port **25** is and will remain closed. If connecting to an external SMTP server, use port **465**
    or **587**.
 
-Check scheduled actions
------------------------
-
-Scheduled actions are **disabled by default** after importing your database. This prevents your
-newly imported database from performing potentially disruptive operations such as:
-
-- sending queued emails,
-- triggering mass mailings, or
-- syncing with third-party services (e.g., calendars, cloud storage).
-
-If you intend to use this imported database in production, **re-enable** only the scheduled actions
-you need by enabling :ref:`developer mode <developer-mode>` and going to :menuselection:`Settings
---> Technical --> Automation: Scheduled Actions`.
-
 Register the subscription
 -------------------------
 


### PR DESCRIPTION
If you import a backup into an Odoo SH production branch, it does not disable scheduled actions like the documentation says, so this section is obsolete. It appears to have been unaltered since the original SH documentation was created in 2018: https://github.com/odoo/documentation/pull/267 .

If a customer imports a neutralized test backup into a production branch and wishes to use it as a production database, they do need to re-enable scheduled actions as well as manually change many other things. This process is complex and to be avoided, and better handled by support if there's no other way, so seems out of scope for this documentation.