### PR TITLE
[ADD] Subscriptions: Created subscription loyalty page

### DIFF
--- a/content/applications/sales/sales/products_prices/loyalty_discount.rst
+++ b/content/applications/sales/sales/products_prices/loyalty_discount.rst
@@ -12,6 +12,8 @@ to create discount and loyalty programs that customers can use for online and in
 These programs offer more varied, public, and time-sensitive pricing options than :doc:`pricelists
 </applications/sales/sales/products_prices/prices/pricing>`.
 
+.. _sales/loyalty_discount/configure-settings:
+
 Configure the settings
 ======================
 

--- a/content/applications/sales/subscriptions.rst
+++ b/content/applications/sales/subscriptions.rst
@@ -305,3 +305,4 @@ tab, under the :guilabel:`SALES` section.
    subscriptions/reports
    subscriptions/automatic_payments
    subscriptions/subscriptions_deliveries
+   subscriptions/subscriptions_loyalty

--- a/content/applications/sales/subscriptions/subscriptions_loyalty.rst
+++ b/content/applications/sales/subscriptions/subscriptions_loyalty.rst
@@ -1,0 +1,76 @@
+.. meta::
+   :description: This page explains how loyalty and discount programs apply to subscription products
+                 through the Recurring option for conditional rules and rewards, and which program
+                 types support Recurring for rules, rewards, or both.
+
+==================================
+Subscriptions and loyalty programs
+==================================
+
+In addition to standard pricelists and per-order discounts, the Odoo **Subscriptions** app is
+compatible with dedicated loyalty and discount programs. Once :ref:`loyalty and discount programs
+have been enabled <sales/loyalty_discount/configure-settings>`, subscription-specific programs may
+be created.
+
+Configure loyalty programs for subscriptions
+============================================
+
+The process for creating a subscription-specific program is similar to :ref:`the normal process
+<sales/loyalty_discount/configure-programs>`, but there are a few considerations to keep in mind.
+With the **Subscriptions** app installed, both :guilabel:`conditional rules` and :guilabel:`rewards`
+may be marked as :guilabel:`Recurring`.
+
+However, not every program can be saved and utilized when both checkboxes are checked. Attempting to
+enable the :guilabel:`Recurring` checkbox for *conditional rules* when the program doesn't support
+it results in a *Validation Error* pop-up when saving the program.
+
+Programs that support recurring rules and rewards
+-------------------------------------------------
+
+Loyalty cards
+~~~~~~~~~~~~~
+
+The :guilabel:`Recurring` checkbox may be enabled for both rules and rewards. Enabling the checkbox
+for rules ensures that customers may earn loyalty points during each renewal period, so long as they
+meet the requirements. Enabling the checkbox for rewards ensures that earned loyalty points are
+automatically exchanged for applied rewards during each period.
+
+Next order coupons
+~~~~~~~~~~~~~~~~~~
+
+The :guilabel:`Recurring` checkbox may be enabled for both rules and rewards. Enabling the checkbox
+for rules ensures that customers may earn coupons good for their next order during each renewal
+period, so long as they meet the requirements. Enabling the checkbox for rewards ensures that earned
+coupons are automatically exchanged for applied rewards during each period.
+
+Programs that only support recurring rules
+------------------------------------------
+
+Coupons
+~~~~~~~
+
+The :guilabel:`Recurring` checkbox may be enabled for rewards only. Doing so ensures that earned
+coupons are automatically applied during each renewal period.
+
+Promotions
+~~~~~~~~~~
+
+The :guilabel:`Recurring` checkbox may be enabled for rewards only. Doing so ensures that earned
+promotional rewards are automatically applied during each renewal period.
+
+Discount code
+~~~~~~~~~~~~~
+
+The :guilabel:`Recurring` checkbox may be enabled for rewards only. Doing so ensures that earned
+discount codes are automatically applied during each renewal period.
+
+Buy X, Get Y
+~~~~~~~~~~~~
+
+The :guilabel:`Recurring` checkbox may be enabled for rewards only. Doing so ensures that earned
+rewards are automatically applied during each renewal period.
+
+.. seealso::
+   - :doc:`../sales/products_prices/prices/pricing`
+   - :doc:`../sales/products_prices/prices/discounts`
+   - :doc:`../sales/products_prices/loyalty_discount`


### PR DESCRIPTION
## What this PR does and why it's needed
Adds a new documentation page covering how loyalty and discount programs work with the **Subscriptions** app, and links it to the existing loyalty/discount configuration page. This gives users a dedicated reference for setting up subscription-specific loyalty programs (coupons, loyalty cards, promotions, etc.) instead of leaving that use case undocumented on the general loyalty/discount page.

## Changes

**Subscriptions**
- Added a new page, `subscriptions_loyalty.rst`, introducing how loyalty and discount programs apply to subscription products, including guidance on marking conditional rules and rewards as recurring.

**Sales — Products & Prices**
- Added a `:ref:` anchor (`sales/loyalty_discount/configure-settings`) to the "Configure the settings" section of `loyalty_discount.rst` so the new Subscriptions page can link directly to it.

---
This `saas-19.3` PR can be FWP up to `master`.