### PR TITLE
[IMP] odoo_sh: revert backup period

### DIFF
--- a/content/administration/odoo_sh/getting_started/branches.rst
+++ b/content/administration/odoo_sh/getting_started/branches.rst
@@ -490,7 +490,7 @@ platform considers this safe enough. As an extra precaution, you can make a manu
 modifiyng production sources.
 
 The purpose of manual backups is to create a specific snapshot of production or staging databases
-(not available for development). These remain available for seven days. However, there is a limit of
+(not available for development). These remain available for three days. However, there is a limit of
 five daily manual backups.
 
 .. list-table::
@@ -502,10 +502,10 @@ five daily manual backups.
      - Manual backup
    * - Production
      - Yes (up to 3 months)
-     - Yes (7 days)
+     - Yes (3 days)
    * - Staging
      - No
-     - Yes (7 days)
+     - Yes (3 days)
    * - Development
      - No
      - No


### PR DESCRIPTION
Manual backups are available for 3 days, even though the Odoo.sh UI mentions 7 days.

task-6467820