### PR TITLE
[FIX] Inventory: UNSPSC link update

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
@@ -49,7 +49,7 @@ unit, such as `Box of 6`, then in the :guilabel:`Type` field, select the appropr
 such as :guilabel:`Bigger than the reference Unit of Measure`.
 
 If applicable, enter a :guilabel:`UNSPSC Category`, which is a globally recognized `code managed by
-GS1 <https://www.unspsc.org/>`_, that **must** be purchased in order to use.
+UNDP <https://www.undp.org/unspsc>`_.
 
 In the :guilabel:`Ratio` field, enter how many individual units are in the new |UOM|, such as
 `100.00000` when using the example of the `centimeter` (since a centimeter is 100 times *smaller*


### PR DESCRIPTION
## What this PR does and why it's needed
This PR corrects an out-of-date link, based on feedback. The UNSPSC code is managed by UNDP, not GS1, and does not require a paid purchase to use — both of which the previous text incorrectly stated.

## Changes

**Inventory — units of measure**
- Corrected the `UNSPSC Category` description on the UoM form: replaced the broken/incorrect GS1 attribution and link with the correct UNDP source (`https://www.undp.org/unspsc`), and removed the inaccurate claim that the code **must** be purchased to use.

---
This `17.0` PR **should not be FWP**.