### PR TITLE
[FIX] Inventory: UOM UNSPSC link update

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
@@ -49,7 +49,7 @@ unit, such as `Box of 6`, then in the :guilabel:`Type` field, select the appropr
 such as :guilabel:`Bigger than the reference Unit of Measure`.
 
 If applicable, enter a :guilabel:`UNSPSC Category`, which is a globally recognized `code managed by
-GS1 <https://www.unspsc.org/>`_, that **must** be purchased in order to use.
+UNDP <https://www.undp.org/unspsc>`_.
 
 In the :guilabel:`Ratio` field, enter how many individual units are in the new |UOM|, such as
 `100.00000` when using the example of the `centimeter` (since a centimeter is 100 times *smaller*


### PR DESCRIPTION
## What this PR does and why it's needed
Fixes an incorrect UNSPSC reference on the Units of Measure (UoM) page, per reviewer feedback. The code was incorrectly attributed to GS1 with a purchase requirement; it is corrected to note UNSPSC is managed by UNDP, with an updated link and the removal of the inaccurate purchase claim.

## Changes

**Inventory — Units of Measure**
- Corrected the UNSPSC Category description on the UoM configuration page: replaced the incorrect "managed by GS1" attribution and `unspsc.org` link with "managed by UNDP" and a link to `undp.org/unspsc`.
- Removed the inaccurate claim that the UNSPSC code **must** be purchased in order to use.

---
This `18.0` PR **should not be FWP**.