### PR TITLE
[FIX] inventory: UNSPSC link update 19.0

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
+++ b/content/applications/inventory_and_mrp/inventory/product_management/configure/uom.rst
@@ -187,8 +187,8 @@ of measure.
 
 To create a new unit, click the :guilabel:`New` button. Specify a unit name. If you want to convert
 between units, specify a quantity and a reference unit of measure to convert between. If applicable,
-enter a :guilabel:`UNSPSC Category`, which is a globally recognized `code managed by GS1
-<https://www.unspsc.org/>`_, that **must** be purchased in order to use.
+enter a :guilabel:`UNSPSC Category`, which is a globally recognized `code managed by UNDP
+<https://www.undp.org/unspsc>`_.
 
 .. example::
    You will be purchasing fabric in terms of yards or meters. Specify that one yard is equal to


### PR DESCRIPTION
## What this PR does and why it's needed
Fixes an incorrect UNSPSC reference link and description in the units of measure documentation, per feedback that the previous link and attribution were wrong. The UNSPSC code is managed by UNDP, not GS1, and is not a paid resource, so the text and link have been corrected accordingly.

## Changes

**Inventory — Units of measure**
- Corrected the `UNSPSC Category` description to attribute the code to UNDP instead of GS1, and updated the linked URL to `https://www.undp.org/unspsc`.
- Removed the inaccurate claim that the UNSPSC code **must** be purchased to use.

---
This `19.0` PR can be FWP up to `master`.