### PR TITLE
[IMP] MRP: MPS suggested replenishment calculation correction 18.0

### DIFF
--- a/content/applications/inventory_and_mrp/manufacturing/workflows/use_mps.rst
+++ b/content/applications/inventory_and_mrp/manufacturing/workflows/use_mps.rst
@@ -194,22 +194,38 @@ replenishment quantities for each product. Enter the following information:
   transferred to the next period. Toggle the :guilabel:`No Maximum` checkbox to enter a maximum
   value, or leave it un-toggled if no maximum should be specified.
 
-If no minimum or maximum replenishment limits are set, the |MPS| suggests the replenishment quantity
-needed to reach the :guilabel:`Safety Stock Target` while accounting for the starting stock and
-forecasted demand. In other words, the suggested quantity in the replenishment row is calculated by
-the following relation:
+By default, the |MPS| suggests the replenishment quantity needed to reach the :guilabel:`Safety
+Stock Target` while accounting for the starting stock and forecasted demand. In other words, the
+suggested quantity in the replenishment row is calculated by the following relation:
 
 .. math::
 
    \begin{align}
    \text{Replenishment} &= \text{Safety Stock Target} \\
    &- \text{Starting Stock} \\
-   &- \text{Forecasted Demand} \\
-   &- \text{Indirect Demand Forecast}
+   &+ \text{Forecasted Demand} \\
+   &+ \text{Indirect Demand Forecast}
    \end{align}
 
-If minimum or maximum limits are set, the suggested replenishment quantity is always bounded by
-these limits, regardless of the needed quantity to reach the :guilabel:`Safety Stock Target`.
+Additionally, the following rules are applied to the suggested `Replenishment` quantity above if
+minimum/maximum limits are set:
+
+#. If ``Replenishment > Maximum to Replenish``, it remains at the maximum.
+#. If ``0 < Replenishment < Minimum to Replenish``, the suggestion is the minimum quantity. If
+   ``Replenishment ≤ 0``, it defaults to `0`. However, if the suggestion already meets or exceeds
+   the minimum, it remains as-is.
+
+.. example::
+   A *Chair* product has a starting stock of `60` units for the current period and a forecasted
+   demand of `75` units. The following replenishment options are set:
+
+   - :guilabel:`Safety Stock Target`: `10` units
+   - :guilabel:`Minimum to Replenish`: `5` units
+   - :guilabel:`Maximum to Replenish`: `20` units
+
+   While the default suggested replenishment quantity (``10 - 60 + 75``) is `25` units of the
+   *Chair*, it exceeds the configured maximum of `20` units. Therefore the final suggested
+   replenishment quantity is `20`.
 
 Specify replenishment trigger
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
This PR corrects the documentation for calculating suggested replenishment quantities in the MPS given additional minimum/maximum limit configurations, as covered in a [previous PR](https://github.com/odoo/documentation/pull/19383#event-29505118099).

## Changelog
- Update to suggested replenishment calculation logic
- Added example

## Version Scope
This `18.0` should be FWP up to `19.0`.