### PR TITLE
[IMP] payment_providers/payu: remove webhook configuration

### DIFF
--- a/content/applications/finance/payment_providers/payu.rst
+++ b/content/applications/finance/payment_providers/payu.rst
@@ -23,22 +23,5 @@ Create a PayU account with Odoo
    information has been submitted, you are then redirected to Odoo, and the payment provider is
    :guilabel:`Enabled`.
 
-.. _payment_providers/payu/webhook-input:
-
-Webhook configuration
-=====================
-
-#. Log into the `PayU Dashboard <https://onboarding.payu.in/app/account/>`_.
-#. Click :guilabel:`Developer` in the left menu, then, select :guilabel:`Webhooks`.
-#. Click :guilabel:`Create Webhook`.
-#. Select :guilabel:`Payments` as the type.
-#. Select :guilabel:`Successful` as the event.
-#. | Enter your Odoo database URL followed by `/payment/payu/webhook` in the :guilabel:`Webhook URL`
-     field.
-   | For example: https://example.odoo.com/payment/payu/webhook.
-#. Click :guilabel:`Create` to create the webhook.
-#. Repeat the same steps to create another webhook, but select :guilabel:`Failed` as the event
-   instead of :guilabel:`Successful`.
-
 .. seealso::
    :doc:`../payment_providers`


### PR DESCRIPTION
When the PayU payment provider was merged, merchants had to configure the webhook manually. However, this issue has now been fixed, so manual webhook configuration is no longer required. Since we already send the `webhook_url` in the request payload, PayU automatically configures the webhook using that URL.