### PR TITLE
Specify minimum label length for reconciliation

### DIFF
--- a/content/applications/finance/accounting/bank/reconciliation.rst
+++ b/content/applications/finance/accounting/bank/reconciliation.rst
@@ -120,6 +120,9 @@ If no partner is set on the transaction, the transaction's :guilabel:`Label` is 
 :guilabel:`Number`, :guilabel:`Customer Reference`, :guilabel:`Bill Reference`, and
 :guilabel:`Payment Reference` of existing invoices, bills, and payments.
 
+.. note::
+   Automatic reconciliation requires the :guilabel:`Label` to contain at least 6 characters.
+
 If a partner is set on the transaction, the transaction is instead matched with invoices, bills, and
 payments of the partner based on the :guilabel:`Amount`. The following rules are used in a
 sequential order to identify and apply a match:


### PR DESCRIPTION
I spent a lot of time trying to decipher why automatic reconciliation wasn't working when I used only numbers but it worked correctly when I used numbers and letters. Turns out that the issue wasn't using only numbers, it was that the numbers for the label where to short (1234). Looking at the code took a lot of digging but found out the restriction:

https://github.com/odoo/enterprise/blob/19.0/account_accountant/models/account_bank_statement.py#L709

I believe this is an important note for users to be aware of.