### PR TITLE
[DOC] developer/reference: expose odoo.http.Session class

### DIFF
--- a/content/developer/reference/backend/http.rst
+++ b/content/developer/reference/backend/http.rst
@@ -77,6 +77,30 @@ the start of the request.
     :members:
     :member-order: bysource
 
+Request
+-------
+
+The request object is automatically set on :data:`odoo.http.request` at
+the start of the request.
+
+.. autoclass:: odoo.http.Request
+    :members:
+    :member-order: bysource
+
+Session
+-------
+
+.. autoclass:: odoo.http.Session
+    :members:
+    :member-order: bysource
+
+.. autoclass:: odoo.http.JsonRPCDispatcher
+    :members:
+    :member-order: bysource
+.. autoclass:: odoo.http.HttpDispatcher
+    :members:
+    :member-order: bysource
+
 Response
 --------
 

--- a/content/developer/reference/backend/http.rst
+++ b/content/developer/reference/backend/http.rst
@@ -91,7 +91,7 @@ Session
 -------
 
 .. autoclass:: odoo.http.Session
-    :members:
+    :members: authenticate, finalize
     :member-order: bysource
 
 .. autoclass:: odoo.http.JsonRPCDispatcher


### PR DESCRIPTION
Prior to this commit, `odoo.http.Session` was absent from the HTTP framework reference, leaving methods such as `authenticate()` unexposed in the generated API documentation.

This commit introduces the `.. autoclass:: odoo.http.Session` directive to ensure the Session API is rendered.