### PR TITLE
[IMP] inventory: operations valuation article clarification

### DIFF
--- a/content/applications/inventory_and_mrp/inventory/inventory_valuation/operations_valuation.rst
+++ b/content/applications/inventory_and_mrp/inventory/inventory_valuation/operations_valuation.rst
@@ -5,9 +5,9 @@
 .. |FIFO| replace:: :abbr:`FIFO (First In First Out)`
 .. |AVCO| replace:: :abbr:`AVCO (Average Costing)`
 
-=========================================
-How inventory operations affect valuation
-=========================================
+=====================================================
+Valuation of stock movements and inventory operations
+=====================================================
 
 The **Inventory** app maintains a real-time valuation of stock based on the physical movement of
 goods. Every time an operation moves goods in or out of the company's stock, the value that came in
@@ -179,8 +179,20 @@ Each product has two key reporting figures calculated using the value from *stoc
 
 - :guilabel:`Total Value`: The total value of goods on hand. Sums the :guilabel:`Remaining Value` of
   inbound moves that still have a :guilabel:`Remaining Quantity`.
-- :guilabel:`Unit Cost`: The unit cost of a product. Calculated based on the :ref:`costing method
-  <inventory/cheat_sheet/accounting-methods>` set for the product group.
+- :guilabel:`Unit Cost`: The unit cost of a product, specific to each stock movement. Calculated
+  based on the :ref:`costing method <costing-methods>` set for the product group.
+
+.. important::
+
+   The :guilabel:`Unit Cost` on a stock movement is distinct from the *Cost* field in the *product
+   form*. The *Cost* field displays the average price of the product, even if the product group is
+   configured to use the |FIFO| costing method. As a result, the *Cost* field on the product form is
+   affected by outbound stock movements when using the |FIFO| costing method.
+
+   The value in the *Cost* field is used as the unit price for
+   :ref:`inventory/operations_valuation/inventory-adjustments`, even when using the |FIFO| costing
+   method.
+
 
 .. _inventory/operations_valuation/stock-movement-operations:
 
@@ -304,14 +316,18 @@ Inventory adjustments
 ---------------------
 
 Discrepancies between the recorded quantity and counted quantity can be reconciled through inventory
-adjustments. The difference is applied as a move to or from a virtual *Inventory Loss* location,
-which is outside stock, so the adjustment changes inventory value as well as quantity. Adjustments
-increase or decrease value based on the current unit cost of the product:
+adjustments. The difference is applied as a move to or from a virtual *Inventory adjustment*
+location, which is outside stock, so the adjustment changes inventory value as well as quantity.
+Adjustments increase or decrease value based on the difference between the counted quantity and the
+expected quantity:
 
 - A counted quantity **higher** than expected produces an *inbound* move and *increases* inventory
   value.
 - A counted quantity **lower** than expected produces an *outbound* move and *decreases* inventory
   value.
+
+Inventory adjustments use the product's current averaged cost as the :ref:`unit cost
+<inventory/operations_valuation/stock-movement-reported-values>` for the stock movement.
 
 .. seealso::
    :doc:`../warehouses_storage/inventory_management/count_products`


### PR DESCRIPTION
## What this PR does and why it's needed
Clarifies the "How inventory operations affect valuation" article by retitling it to better reflect its scope and by explaining the distinction between the `Unit Cost` shown on a stock movement and the `Cost` field on the product form, which can otherwise be mistaken for the same value.

## Changes

**Inventory Valuation**
- Renamed the page title from "How inventory operations affect valuation" to "Valuation of stock movements and inventory operations" for clarity.
- Clarified that `Unit Cost` is specific to each stock movement, and fixed its costing-method reference link.
- Added an important note explaining that the `Cost` field on the product form shows the average price of the product — even under the FIFO costing method — and is affected by outbound stock movements in that case; it is informational only and not used for valuation.

## Additional changes during review

These changes were made in a follow-up commit (implementing Felicia's review suggestion) and later squashed into the final commit, all within `content/applications/inventory_and_mrp/inventory/inventory_valuation/operations_valuation.rst`:

1. **`:guilabel:` → italics for "Cost" field** (lines 187-190)
   Changed `:guilabel:`Cost`` to plain italic *Cost* throughout the callout, since it refers to the product form field conceptually rather than as clickable UI.

2. **New clarification on Cost field's role in adjustments** (lines 192-194)
   Replaced the old closing line ("The Cost field is not used for valuation, and is only informational") with a more accurate statement:
   > "The value in the *Cost* field is used as the unit price for :ref:`inventory/operations_valuation/inventory-adjustments`, even when using the FIFO costing method."

3. **Renamed virtual location** (line ~319)
   *Inventory Loss* location -> *Inventory adjustment* location, matching Odoo's actual naming.

4. **Reworded valuation trigger for adjustments** (lines 318-322)
   Changed from "based on the current unit cost of the product" to "based on the difference between the counted quantity and the expected quantity" - a more precise description of what drives the value change.

5. **New paragraph added** (lines 328-330)
   > "Inventory adjustments use the product's current averaged cost as the :ref:`unit cost <inventory/operations_valuation/stock-movement-reported-values>` for the stock movement."

Net effect: 24 insertions, 8 deletions. The core addition clarifies that inventory adjustments always use the product's averaged cost as the unit price - even under FIFO - correcting the earlier (less precise) statement that the Cost field was purely informational.


---
This `19.0` PR can be FWP up to `master`.
