### PR TITLE
[REF] AI: Separate MCP tools reference section

### DIFF
--- a/content/applications/productivity/ai/mcp_server.rst
+++ b/content/applications/productivity/ai/mcp_server.rst
@@ -1,3 +1,5 @@
+:show-content:
+
 =============
 AI MCP server
 =============
@@ -35,9 +37,8 @@ The following sequence outlines the |MCP| workflow in Odoo:
 
 #. The user :ref:`configures the client <ai/mcp/configuration>` with server details and an
    authentication key. Once connected, the client automatically makes an initial request to the
-   server for any available :ref:`AI tools <ai/mcp/available-tools>` (or *Server Actions*) exposed
-   to it in the database. If successful, the client caches the tools for the remainder of the
-   session.
+   server for any available :doc:`AI tools <mcp_server/mcp_tools>` (or *Server Actions*) exposed to
+   it in the database. If successful, the client caches the tools for the remainder of the session.
 #. The user prompts the client in plain language. A list of :ref:`example prompts
    <ai/mcp/use-cases>` is provided in this documentation.
 #. The client requests that the server invoke the correct tools.
@@ -285,8 +286,8 @@ automatically invoked without user approval.
    only advises the client that the tool is safe to invoke without explicit user approval.
 
 .. seealso::
-   See the :ref:`available tools <ai/mcp/available-tools>` section for a full list of available
-   tools in the database.
+   See the :doc:`available tools <mcp_server/mcp_tools>` page for a full list of available tools in
+   the database.
 
 .. _ai/mcp/use-cases:
 
@@ -343,168 +344,11 @@ Custom styling
    * - AI image generation
      - "Generate an image of a mountain at dusk and put it in the hero section."
 
-.. _ai/mcp/available-tools:
-
-Available tools
-===============
-
-The following AI tools are supported by the Odoo |MCP| server. Each tool is listed below with its
-name, description, and suggested *Readonly* status.
-
-Setup/context retrieval
------------------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Description
-     - Readonly
-   * - `AI Tool: MCP Retrieve initial context`
-     - Returns context about the currently authenticated user's database, including the user,
-       timezone, active company, and available companies.
-     - True
-
-.. note::
-   `AI Tool: MCP Retrieve initial context` runs automatically at the beginning of a user's session
-   and is **only** invoked by the client.
-
-Data querying
--------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Description
-     - Readonly
-   * - `AI Tool: Get Models`
-     - Lists every Odoo model the current user can access, including their technical names and
-       descriptions.
-     - True
-   * - `AI Tool: Get Fields`
-     - Lists the searchable and usable fields on a given model, including type and relations.
-     - True
-   * - `AI Tool: Get Menus`
-     - Lists every menu the current user can access, with its linked action, model, and available
-       view types.
-     - True
-   * - `AI Tool: Get Menu Details`
-     - Returns detailed information for specific menu IDs, such as action, domain, default filters
-       and groupings, and searchable fields.
-     - True
-   * - `AI Tool: Search`
-     - Searches records on a model using a domain and returns the requested fields.
-     - True
-   * - `AI Tool: Read group`
-     - Groups records by one or more fields and computes aggregates (sums, counts, averages, etc.)
-       over them.
-     - True
-   * - `AI Tool: Update Records`
-     - Updates one or more existing records matching a domain with new field values.
-     - False
-   * - `AI Tool: Create Records`
-     - Creates new records on a model with specified fields, optionally linking a preview menu to
-       show the result.
-     - False
-
-Navigation
-----------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Description
-     - Readonly
-   * - `AI Tool: Open Menu List`
-     - Redirects the UI to a menu's List view, optionally filtered and grouped.
-     - True
-   * - `AI Tool: Open Menu Kanban`
-     - Redirects the UI to a menu's Kanban view, optionally filtered and grouped.
-     - True
-   * - `AI Tool: Open Menu Graph`
-     - Redirects the UI to a menu's Graph view with a chosen measure, chart mode, grouping, and
-       sorting options.
-     - True
-   * - `AI Tool: Open Menu Pivot`
-     - Redirects the UI to a menu's Pivot view with row and column groupings and measures.
-     - True
-   * - `AI Tool: Run view action`
-     - Opens client or report actions (e.g., Discuss, printed reports) tied to a menu.
-     - True
-   * - `AI Tool: Compute Report Measures`
-     - Returns the measures available for aggregation on a given model or action. This tool is meant
-       to be called before opening a pivot or graph view.
-     - True
-   * - `AI Tool: Prepare Record Previews`
-     - Prepares metadata so that specific records render as rich preview cards in the Odoo Chat.
-     - True
-   * - `AI Tool: Adjust Search`
-     - Adjusts the search filters, groupings, active measures, or view type of the current view.
-     - True
-   * - `AI Tool: Compute Date`
-     - Computes an exact date or datetime from a relative expression (e.g., "start of last week").
-     - True
-
-Website styling
----------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Description
-     - Readonly
-   * - `AI Tool: Get Snippets`
-     - Fetches the HTML markup for named website-builder snippets so they can be edited and inserted
-       into a page.
-     - True
-   * - `AI Tool: Read Custom CSS`
-     - Reads the current contents of the website's custom SCSS rules.
-     - True
-   * - `AI Tool: Write Custom CSS`
-     - Overwrites the website's custom SCSS rules with new styling.
-     - False
-   * - `AI Tool: Apply HTML to Page`
-     - Applies HTML edits (e.g., replace, insert) to a specific website page.
-     - False
-
-Media generation
-----------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Description
-     - Readonly
-   * - `AI Tool: Generate an Image`
-     - Generates a new image from a text prompt. This tool is **only** invoked on explicit user
-       request.
-     - False
-   * - `AI Tool: Search Images`
-     - Searches *Unsplash* for stock photos matching a query.
-     - True
-   * - `AI Tool: Get user image URLs`
-     - Converts uploaded chat attachment IDs into permanent Odoo image URLs for use in content.
-     - True
-
-Additional tools
-----------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Description
-     - Readonly
-   * - `AI Tool: Web Search`
-     - Delegates a factual question or research task to a web search agent.
-     - True
-   * - `AI Tool: Load Skills`
-     - Loads detailed instructions and tools for specific registered AI skills by ID.
-     - True
-
 .. seealso::
    - :doc:`server-actions`
+   - :doc:`mcp_server/mcp_tools`
+
+.. toctree::
+   :titlesonly:
+
+   mcp_server/mcp_tools

--- a/content/applications/productivity/ai/mcp_server/mcp_tools.rst
+++ b/content/applications/productivity/ai/mcp_server/mcp_tools.rst
@@ -1,0 +1,164 @@
+===================
+Available MCP tools
+===================
+
+The following AI tools are supported by the :doc:`Odoo MCP server <../mcp_server>`. Each tool is
+listed below with its name, description, and suggested *Readonly* status.
+
+Setup/context retrieval
+=======================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Description
+     - Readonly
+   * - `AI Tool: MCP Retrieve initial context`
+     - Returns context about the currently authenticated user's database, including the user,
+       timezone, active company, and available companies.
+     - True
+
+.. note::
+   `AI Tool: MCP Retrieve initial context` runs automatically at the beginning of a user's session
+   and is **only** invoked by the client.
+
+Data querying
+=============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Description
+     - Readonly
+   * - `AI Tool: Get Models`
+     - Lists every Odoo model the current user can access, including their technical names and
+       descriptions.
+     - True
+   * - `AI Tool: Get Fields`
+     - Lists the searchable and usable fields on a given model, including type and relations.
+     - True
+   * - `AI Tool: Get Menus`
+     - Lists every menu the current user can access, with its linked action, model, and available
+       view types.
+     - True
+   * - `AI Tool: Get Menu Details`
+     - Returns detailed information for specific menu IDs, such as action, domain, default filters
+       and groupings, and searchable fields.
+     - True
+   * - `AI Tool: Search`
+     - Searches records on a model using a domain and returns the requested fields.
+     - True
+   * - `AI Tool: Read group`
+     - Groups records by one or more fields and computes aggregates (sums, counts, averages, etc.)
+       over them.
+     - True
+   * - `AI Tool: Update Records`
+     - Updates one or more existing records matching a domain with new field values.
+     - False
+   * - `AI Tool: Create Records`
+     - Creates new records on a model with specified fields, optionally linking a preview menu to
+       show the result.
+     - False
+
+Navigation
+==========
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Description
+     - Readonly
+   * - `AI Tool: Open Menu List`
+     - Redirects the UI to a menu's List view, optionally filtered and grouped.
+     - True
+   * - `AI Tool: Open Menu Kanban`
+     - Redirects the UI to a menu's Kanban view, optionally filtered and grouped.
+     - True
+   * - `AI Tool: Open Menu Graph`
+     - Redirects the UI to a menu's Graph view with a chosen measure, chart mode, grouping, and
+       sorting options.
+     - True
+   * - `AI Tool: Open Menu Pivot`
+     - Redirects the UI to a menu's Pivot view with row and column groupings and measures.
+     - True
+   * - `AI Tool: Run view action`
+     - Opens client or report actions (e.g., Discuss, printed reports) tied to a menu.
+     - True
+   * - `AI Tool: Compute Report Measures`
+     - Returns the measures available for aggregation on a given model or action. This tool is meant
+       to be called before opening a pivot or graph view.
+     - True
+   * - `AI Tool: Prepare Record Previews`
+     - Prepares metadata so that specific records render as rich preview cards in the Odoo Chat.
+     - True
+   * - `AI Tool: Adjust Search`
+     - Adjusts the search filters, groupings, active measures, or view type of the current view.
+     - True
+   * - `AI Tool: Compute Date`
+     - Computes an exact date or datetime from a relative expression (e.g., "start of last week").
+     - True
+
+Website styling
+===============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Description
+     - Readonly
+   * - `AI Tool: Get Snippets`
+     - Fetches the HTML markup for named website-builder snippets so they can be edited and inserted
+       into a page.
+     - True
+   * - `AI Tool: Read Custom CSS`
+     - Reads the current contents of the website's custom SCSS rules.
+     - True
+   * - `AI Tool: Write Custom CSS`
+     - Overwrites the website's custom SCSS rules with new styling.
+     - False
+   * - `AI Tool: Apply HTML to Page`
+     - Applies HTML edits (e.g., replace, insert) to a specific website page.
+     - False
+
+Media generation
+================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Description
+     - Readonly
+   * - `AI Tool: Generate an Image`
+     - Generates a new image from a text prompt. This tool is **only** invoked on explicit user
+       request.
+     - False
+   * - `AI Tool: Search Images`
+     - Searches *Unsplash* for stock photos matching a query.
+     - True
+   * - `AI Tool: Get user image URLs`
+     - Converts uploaded chat attachment IDs into permanent Odoo image URLs for use in content.
+     - True
+
+Additional tools
+================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tool
+     - Description
+     - Readonly
+   * - `AI Tool: Web Search`
+     - Delegates a factual question or research task to a web search agent.
+     - True
+   * - `AI Tool: Load Skills`
+     - Loads detailed instructions and tools for specific registered AI skills by ID.
+     - True
+
+.. seealso::
+   - :doc:`../mcp_server`


### PR DESCRIPTION
## Description
This PR separates the "Available tools" reference section from the AI MCP server documentation page (`mcp_server.rst`) into its own page. The main `mcp_server.rst` page now links to this page instead.

**NO content has been added or modified**. The change is structural only, creating a new RST file in the `mcp_server` folder for the moved content, along with appropriate edits to reference links.

## Changes
- Pulled the "Available tools" section in `mcp_server.rst` into a new page, `mcp_server/mcp_tools.rst`.
- Updated links/references to the tools list in `mcp_server.rst`

## Version Scope
This `saas-19.4` PR can be FWP up to `master`.
