### PR TITLE
[IMP] timesheets: update timesheets assistant browser extensions

### DIFF
--- a/content/applications/services/timesheets/timesheet_assistant.rst
+++ b/content/applications/services/timesheets/timesheet_assistant.rst
@@ -212,9 +212,10 @@ To install the extension from Odoo, follow these steps:
    :guilabel:`Add to Firefox`, then :guilabel:`Add` for Firefox.
 
 .. note::
-   ActivityWatch browser extensions are only available for Google Chrome and Mozilla Firefox. The
-   `Firefox <https://addons.mozilla.org/en-US/firefox/addon/aw-watcher-web/>`_ and
-   `Chrome <https://chromewebstore.google.com/detail/activitywatch-web-watcher/nglaklhklhcoonedhgnpgddginnjdadi>`_
+   The Timesheets Assistant browser extension is only available for Google Chrome and Mozilla
+   Firefox. The
+   `Firefox <https://addons.mozilla.org/en-US/firefox/addon/timesheets-assistant/>`_ and
+   `Chrome <https://chromewebstore.google.com/detail/timesheets-assistant/bmgldglijgnaohjpjkieijkkjfacifdj>`_
    extensions can also be installed from their respective store pages.
 
  .. _timesheets/timesheet-assistant/assistant-rules:


### PR DESCRIPTION
Before this commit, the documentation mentions to install the Activity watch browser extension but a new browser extension has been published by Odoo for timesheets assistant which includes the activity watch extension and adds some additional features.

This commit changes the documentation in Timesheet assistant section to mention Timesheets assistant browser extension and alter the link to be able to access to the new extension.

task-6470304