### PR TITLE
[FIX] phone: correct number of navigation tabs

### DIFF
--- a/content/applications/productivity/phone/phone_widget.rst
+++ b/content/applications/productivity/phone/phone_widget.rst
@@ -20,7 +20,7 @@ a contact's phone number to initiate a call.
 
 Click the :icon:`oi-voip` :guilabel:`(Hide Softphone)` icon again to close the widget.
 
-The **Phone** widget contains four tabs:
+The **Phone** widget contains three tabs:
 
 - :icon:`fa-history` :guilabel:`Recent`: Lists recent :ref:`inbound calls
   <phone/phone_widget/inbound-call>` and :ref:`outbound calls <phone/phone_widget/outbound-call>` on


### PR DESCRIPTION
quick fix to decrement # of tabs in the softphone widget from 4 → 3

follow-up to https://github.com/odoo/documentation/pull/19482, which removed _contacts_ tab details since it was removed from the product