### PR TITLE
Fix link to user service example in tutorial

### DIFF
--- a/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
+++ b/content/developer/tutorials/discover_js_framework/02_build_a_dashboard.rst
@@ -251,7 +251,7 @@ would prefer to do it only the first time, so we actually need to maintain some 
 .. seealso::
    - `Example: simple service <{GITHUB_PATH}/addons/web/static/src/core/network/http_service.js>`_
    - `Example: service with a dependency
-     <{GITHUB_PATH}/addons/web/static/src/core/user_service.js>`_
+     <{GITHUB_PATH}/addons/web/static/src/core/user.js>`_
 
 6. Display a pie chart
 ======================


### PR DESCRIPTION
The file name was changed but the tutorial link wasn't updated.